### PR TITLE
feat(site): surface a11y, performance, operational capabilities + SEO/a11y polish

### DIFF
--- a/app/favicon.svg
+++ b/app/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#16213e"/>
+  <path d="M22 18h20a8 8 0 0 1 0 16H30a8 8 0 0 0 0 16h20" stroke="#00d4aa" stroke-width="6" stroke-linecap="round" fill="none"/>
+</svg>

--- a/app/features.css
+++ b/app/features.css
@@ -35,6 +35,38 @@ nav a {
 nav a:hover {
     background: rgba(0, 212, 170, 0.2);
 }
+nav a[aria-current="page"] {
+    background: rgba(0, 212, 170, 0.15);
+    color: #00d4aa;
+}
+.skip-link {
+    position: absolute;
+    left: -9999px;
+    top: 0;
+    background: #00d4aa;
+    color: #16213e;
+    padding: 0.6rem 1rem;
+    font-weight: bold;
+    text-decoration: none;
+    border-radius: 0 0 4px 0;
+    z-index: 100;
+}
+.skip-link:focus {
+    left: 0;
+    outline: 2px solid #16213e;
+    outline-offset: 2px;
+}
+footer {
+    margin-top: 4rem;
+    padding: 1.5rem 2rem;
+    border-top: 1px solid rgba(0, 212, 170, 0.25);
+    text-align: center;
+    font-size: 0.9rem;
+    opacity: 0.8;
+}
+footer a {
+    color: #00d4aa;
+}
 main {
     max-width: 960px;
     margin: 0 auto;

--- a/app/features.html
+++ b/app/features.html
@@ -3,19 +3,30 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Categories of automated quality checks in SlopStopper: security, hygiene, reliability (E2E, smoke, accessibility, Core Web Vitals), operational and deployment.">
+    <meta name="theme-color" content="#16213e">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="SlopStopper — Features">
+    <meta property="og:description" content="Practices and automated feedback loops that keep a repo healthy at high velocity.">
+    <meta property="og:site_name" content="SlopStopper">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="SlopStopper — Features">
+    <meta name="twitter:description" content="Practices and automated feedback loops that keep a repo healthy at high velocity.">
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <title>Features</title>
     <link rel="stylesheet" href="features.css">
 </head>
 <body>
+    <a href="#main" class="skip-link">Skip to main content</a>
     <header>
         <a href="index.html" class="site-title">SlopStopper</a>
-        <nav>
+        <nav aria-label="Main">
             <a href="index.html" id="nav-home">Home</a>
-            <a href="features.html" id="nav-features">Features</a>
+            <a href="features.html" id="nav-features" aria-current="page">Features</a>
             <a href="tools.html" id="nav-tools">Tools</a>
         </nav>
     </header>
-    <main>
+    <main id="main">
         <div class="hero">
             <h1>Practices &amp; Feedback</h1>
             <p>The categories of automated checks that keep your repo healthy</p>
@@ -44,6 +55,16 @@
                 <ul>
                     <li><strong>E2E Tests</strong> — Playwright tests verify all pages and user flows work on every pull request</li>
                     <li><strong>Smoke Tests</strong> — Lightweight smoke tests run against staging and production after every deploy</li>
+                    <li><strong>Accessibility</strong> — axe-core audits every page against WCAG 2.1 AA on PRs, after deploys, and on a daily schedule</li>
+                    <li><strong>Core Web Vitals</strong> — Lighthouse CI measures LCP, INP and CLS on every PR and nightly against production</li>
+                </ul>
+            </div>
+            <div class="card">
+                <h2>🤖 Operational</h2>
+                <ul>
+                    <li><strong>Auto PR Labelling</strong> — Pull requests are labelled automatically from the paths changed</li>
+                    <li><strong>Doc Auto-Updater</strong> — A weekly agentic workflow opens PRs to keep documentation in sync with the code</li>
+                    <li><strong>Failure Alerts</strong> — Failed workflow runs on main raise (or update) a tracking issue automatically</li>
                 </ul>
             </div>
             <div class="card">
@@ -82,7 +103,7 @@
                     <div class="loop-arrow">→</div>
                     <div class="loop-step">🧹 Hygiene<span class="step-sub">Complexity · Docs</span></div>
                     <div class="loop-arrow">→</div>
-                    <div class="loop-step">✅ Reliability<span class="step-sub">E2E · Smoke Tests</span></div>
+                    <div class="loop-step">✅ Reliability<span class="step-sub">E2E · Smoke · A11y · CWV</span></div>
                     <div class="loop-arrow">→</div>
                     <div class="loop-step">🚀 Deploy<span class="step-sub">Preview URL</span></div>
                     <div class="loop-arrow">→</div>
@@ -92,5 +113,8 @@
             </div>
         </section>
     </main>
+    <footer>
+        <p>SlopStopper is open source — <a href="https://github.com/hungovercoders/slopstopper" rel="noopener noreferrer">view the repository on GitHub</a>.</p>
+    </footer>
 </body>
 </html>

--- a/app/index.css
+++ b/app/index.css
@@ -35,6 +35,38 @@ nav a {
 nav a:hover {
     background: rgba(0, 212, 170, 0.2);
 }
+nav a[aria-current="page"] {
+    background: rgba(0, 212, 170, 0.15);
+    color: #00d4aa;
+}
+.skip-link {
+    position: absolute;
+    left: -9999px;
+    top: 0;
+    background: #00d4aa;
+    color: #16213e;
+    padding: 0.6rem 1rem;
+    font-weight: bold;
+    text-decoration: none;
+    border-radius: 0 0 4px 0;
+    z-index: 100;
+}
+.skip-link:focus {
+    left: 0;
+    outline: 2px solid #16213e;
+    outline-offset: 2px;
+}
+footer {
+    margin-top: 4rem;
+    padding: 1.5rem 2rem;
+    border-top: 1px solid rgba(0, 212, 170, 0.25);
+    text-align: center;
+    font-size: 0.9rem;
+    opacity: 0.8;
+}
+footer a {
+    color: #00d4aa;
+}
 main {
     max-width: 960px;
     margin: 0 auto;

--- a/app/index.html
+++ b/app/index.html
@@ -3,19 +3,30 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="SlopStopper — a reference template for adding deterministic, automated quality feedback (security, hygiene, reliability, accessibility, performance) to any repo.">
+    <meta name="theme-color" content="#16213e">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="SlopStopper">
+    <meta property="og:description" content="Deterministic feedback for AI-driven development — keep your repo healthy at high velocity.">
+    <meta property="og:site_name" content="SlopStopper">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="SlopStopper">
+    <meta name="twitter:description" content="Deterministic feedback for AI-driven development — keep your repo healthy at high velocity.">
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <title>SlopStopper</title>
     <link rel="stylesheet" href="index.css">
 </head>
 <body>
+    <a href="#main" class="skip-link">Skip to main content</a>
     <header>
         <a href="index.html" class="site-title">SlopStopper</a>
-        <nav>
-            <a href="index.html" id="nav-home">Home</a>
+        <nav aria-label="Main">
+            <a href="index.html" id="nav-home" aria-current="page">Home</a>
             <a href="features.html" id="nav-features">Features</a>
             <a href="tools.html" id="nav-tools">Tools</a>
         </nav>
     </header>
-    <main>
+    <main id="main">
         <div class="hero">
             <h1>SlopStopper</h1>
             <p>Deterministic feedback for AI-driven development — keep your repo healthy at high velocity</p>
@@ -36,7 +47,12 @@
             </div>
             <div class="card">
                 <h2>✅ Reliability</h2>
-                <p>End-to-end and smoke tests verify every deploy works correctly in staging and production environments.</p>
+                <p>End-to-end, smoke, accessibility and Core Web Vitals checks verify every deploy works correctly for every user.</p>
+                <a href="features.html" class="card-link">View practices →</a>
+            </div>
+            <div class="card">
+                <h2>🤖 Operational</h2>
+                <p>Auto-labelled PRs, an agentic doc updater and automatic failure alerts keep day-to-day workflow on autopilot.</p>
                 <a href="features.html" class="card-link">View practices →</a>
             </div>
             <div class="card">
@@ -46,5 +62,8 @@
             </div>
         </div>
     </main>
+    <footer>
+        <p>SlopStopper is open source — <a href="https://github.com/hungovercoders/slopstopper" rel="noopener noreferrer">view the repository on GitHub</a>.</p>
+    </footer>
 </body>
 </html>

--- a/app/tools.css
+++ b/app/tools.css
@@ -35,6 +35,38 @@ nav a {
 nav a:hover {
     background: rgba(0, 212, 170, 0.2);
 }
+nav a[aria-current="page"] {
+    background: rgba(0, 212, 170, 0.15);
+    color: #00d4aa;
+}
+.skip-link {
+    position: absolute;
+    left: -9999px;
+    top: 0;
+    background: #00d4aa;
+    color: #16213e;
+    padding: 0.6rem 1rem;
+    font-weight: bold;
+    text-decoration: none;
+    border-radius: 0 0 4px 0;
+    z-index: 100;
+}
+.skip-link:focus {
+    left: 0;
+    outline: 2px solid #16213e;
+    outline-offset: 2px;
+}
+footer {
+    margin-top: 4rem;
+    padding: 1.5rem 2rem;
+    border-top: 1px solid rgba(0, 212, 170, 0.25);
+    text-align: center;
+    font-size: 0.9rem;
+    opacity: 0.8;
+}
+footer a {
+    color: #00d4aa;
+}
 main {
     max-width: 960px;
     margin: 0 auto;

--- a/app/tools.html
+++ b/app/tools.html
@@ -3,19 +3,30 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="The technology stack powering SlopStopper: GitHub Actions, Task, Playwright, TypeScript, Semgrep, ZAP, Trivy, Gitleaks, axe-core, Lighthouse CI and more.">
+    <meta name="theme-color" content="#16213e">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="SlopStopper — Tools">
+    <meta property="og:description" content="The technology stack powering SlopStopper's automated feedback.">
+    <meta property="og:site_name" content="SlopStopper">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="SlopStopper — Tools">
+    <meta name="twitter:description" content="The technology stack powering SlopStopper's automated feedback.">
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <title>Tools</title>
     <link rel="stylesheet" href="tools.css">
 </head>
 <body>
+    <a href="#main" class="skip-link">Skip to main content</a>
     <header>
         <a href="index.html" class="site-title">SlopStopper</a>
-        <nav>
+        <nav aria-label="Main">
             <a href="index.html" id="nav-home">Home</a>
             <a href="features.html" id="nav-features">Features</a>
-            <a href="tools.html" id="nav-tools">Tools</a>
+            <a href="tools.html" id="nav-tools" aria-current="page">Tools</a>
         </nav>
     </header>
-    <main>
+    <main id="main">
         <div class="hero">
             <h1>Tools</h1>
             <p>The technology stack powering SlopStopper's automated feedback</p>
@@ -23,7 +34,11 @@
         <div class="card-grid">
             <div class="card">
                 <h2>⚙️ GitHub Actions</h2>
-                <p>All checks run as GitHub Actions workflows triggered on every pull request and push to main — security, hygiene, reliability and deployment in one pipeline.</p>
+                <p>All checks run as GitHub Actions workflows triggered on every pull request and push to main — security, hygiene, reliability, accessibility, performance and deployment in one pipeline.</p>
+            </div>
+            <div class="card">
+                <h2>📋 Task</h2>
+                <p>A Taskfile.yml defines the single source of truth for build, test, lint and scan commands so developers, AI agents and CI all run the same thing.</p>
             </div>
             <div class="card">
                 <h2>🎭 Playwright</h2>
@@ -34,18 +49,49 @@
                 <p>All application and test code is written in TypeScript for static type safety, reducing a whole class of bugs before code is even run.</p>
             </div>
             <div class="card">
-                <h2>🟢 Netlify</h2>
-                <p>Continuous deployment to Netlify with preview URLs on every PR and automated production releases on merge to main.</p>
-            </div>
-            <div class="card">
                 <h2>🐍 Python</h2>
                 <p>Reporting scripts that generate structured JSON reports for security, complexity, documentation and dependency checks used across CI workflows.</p>
             </div>
             <div class="card">
-                <h2>🔍 Semgrep &amp; ZAP</h2>
-                <p>Semgrep provides fast SAST scanning and OWASP ZAP provides DAST scanning against running deployments, together covering static and dynamic security concerns.</p>
+                <h2>🟢 Netlify</h2>
+                <p>Continuous deployment to Netlify with preview URLs on every PR and automated production releases on merge to main.</p>
+            </div>
+            <div class="card">
+                <h2>🔍 Semgrep</h2>
+                <p>Fast static application security testing (SAST). Scans source code for vulnerability patterns and OWASP-style issues before code is merged.</p>
+            </div>
+            <div class="card">
+                <h2>🕷️ OWASP ZAP</h2>
+                <p>Dynamic application security testing (DAST). Probes a running deployment for common web vulnerabilities such as XSS, injection and insecure headers.</p>
+            </div>
+            <div class="card">
+                <h2>🛡️ Trivy</h2>
+                <p>Scans project dependencies for known CVEs on every pull request and push, with severity-based gating to prevent vulnerable packages from reaching production.</p>
+            </div>
+            <div class="card">
+                <h2>🔑 Gitleaks</h2>
+                <p>Inspects every commit for accidentally committed credentials, tokens and other secrets, blocking pull requests when high-confidence matches are found.</p>
+            </div>
+            <div class="card">
+                <h2>🐛 Bandit &amp; Lizard</h2>
+                <p>Bandit performs Python-focused security analysis and Lizard enforces cyclomatic complexity limits so code stays auditable and maintainable.</p>
+            </div>
+            <div class="card">
+                <h2>♿ axe-core</h2>
+                <p>Industry-standard accessibility engine, run via Playwright on every page to flag WCAG 2.1 AA violations on PRs, after deploys and on a daily schedule.</p>
+            </div>
+            <div class="card">
+                <h2>⚡ Lighthouse CI</h2>
+                <p>Measures Core Web Vitals (LCP, INP, CLS) plus performance, accessibility and best-practice scores on every PR and nightly against production.</p>
+            </div>
+            <div class="card">
+                <h2>📝 markdownlint</h2>
+                <p>Lints all documentation as part of the hygiene checks, keeping markdown style, headings and link structure consistent across the repo.</p>
             </div>
         </div>
     </main>
+    <footer>
+        <p>SlopStopper is open source — <a href="https://github.com/hungovercoders/slopstopper" rel="noopener noreferrer">view the repository on GitHub</a>.</p>
+    </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Refresh homepage, features and tools pages so the site reflects capabilities already live in CI: accessibility audits (axe-core), Core Web Vitals (Lighthouse CI), auto-label PRs, agentic doc updater, workflow-failure alerts. Split Semgrep/ZAP and add Trivy, Gitleaks, Bandit, Lizard, Task and markdownlint to the Tools page (6 → 14).
- Add SEO + social metadata (description, OpenGraph, Twitter card, theme-color) and a same-origin SVG favicon to every page.
- A11y polish: skip-to-content link, `<nav aria-label="Main">` landmark, `aria-current="page"` on the active link with subtle styling, `<main id="main">` target, and a footer linking to the GitHub repo.

Netlify config intentionally untouched.

## Test plan
- [x] `npm run build` clean
- [x] Playwright smoke tests pass (7/7) against local server
- [x] axe-core accessibility audit at strictest `minor` threshold — 0 violations on `/`, `/features.html`, `/tools.html`
- [x] Visual check of all 3 pages at 1280px — layout intact, active-nav highlight visible, footer present
- [ ] Preview deploy spot-check (Netlify will produce one on this PR)
- [ ] Core Web Vitals workflow result on PR