### PR TITLE
feat(site): indie-playful rebrand with GitHub backlinks + demo content

### DIFF
--- a/.github/workflows/hygiene-doc-updater.md
+++ b/.github/workflows/hygiene-doc-updater.md
@@ -58,12 +58,15 @@ You are an AI documentation agent that updates the project documentation weekly 
 
 ## Project Context
 
-This is a **template-netlify** project — a minimal static site template deployed to Netlify with GitHub Actions CI/CD. The key characteristics are:
+This is the **SlopStopper** project — both a portable suite of CI quality
+workflows that consumers install into their own repos and a live
+reference site that markets the suite. Deployed to Netlify via GitHub
+Actions. The key characteristics are:
 
-- **Multi-page static site**: `index.html`, `page2.html`, `page3.html` with separate CSS/JS files
-- **No build step**: Static files deployed as-is via Netlify
+- **Multi-page static site**: `app/index.html`, `app/features.html`, `app/tools.html` with a shared `app/shared.css` plus per-page CSS files
+- **TypeScript build step**: `npm run build` runs `tsc`; Netlify publishes the `app/` directory
 - **Comprehensive docs**: All documentation lives in `docs/` following an index-driven governance model
-- **Taskfile automation**: Tasks follow `category:action` naming (e.g., `hygiene:complexity`)
+- **Taskfile automation**: Tasks follow `category:action` naming (e.g., `hygiene:complexity`); the Taskfile is the single source of truth for local + CI commands
 - **GitHub Actions CI/CD**: Workflows follow `category-action-check.yml` naming
 
 ## Documentation Structure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,219 @@
+# Agent instructions — SlopStopper
+
+Open standard for agents, AI assistants and automation tools working in this
+repo. Conformant with [agents.md](https://agents.md).
+
+> 📚 **Documentation hub:** [`docs/index.md`](./docs/index.md) is the
+> structured map of all project documentation.
+
+> 🏗️ **Naming convention:** the categories in
+> [`docs/index.md`](./docs/index.md) drive naming across the project — Task
+> targets use `category:action` (e.g. `hygiene:complexity`), GitHub Actions
+> use `category-action-check.yml` (e.g. `hygiene-complexity-check.yml`).
+
+## What SlopStopper is
+
+Two things at once:
+
+1. **A portable suite** of GitHub Actions workflows, Task targets and
+   analysis scripts that consumers install into their own repos via
+   [`install.sh`](./install.sh).
+2. **A live reference site** under [`app/`](./app/) that markets the suite
+   and proves it works — built and deployed with the same suite it
+   advertises.
+
+Changes that affect both layers (e.g. adding a new quality check) must be
+reflected in the workflows AND the site copy (`app/features.html`,
+`app/tools.html`) AND `README.md`. The hygiene docs-accuracy workflow exists
+specifically to catch drift between these.
+
+## Canonical interface: Taskfile.yml
+
+**Agents must use `task <name>` instead of raw commands** wherever possible.
+The Taskfile is the single source of truth for build, test, lint and scan
+operations so developers, AI agents and CI all run the same thing — no
+drift, no version skew.
+
+Examples (run `task --list` for the full set):
+
+| Task | What it does |
+| ---- | ------------ |
+| `task hygiene:complexity` | Cyclomatic complexity check (Lizard) |
+| `task security:sast` | Static security scan (Semgrep) |
+| `task security:dast` | Dynamic security scan (OWASP ZAP) |
+| `task security:secrets` | Secrets detection (Gitleaks) |
+| `task security:vulnerability:all` | Dependency CVE scan (Trivy) |
+| `task reliability:smoke` | Smoke tests against a URL |
+| `task reliability:accessibility` | axe-core WCAG 2.1 AA audit |
+| `task reliability:cwv` | Lighthouse CI / Core Web Vitals |
+| `task contributing:build` | TypeScript build (`tsc`) |
+| `task contributing:test` | Playwright suite |
+| `task contributing:run` | Local dev server on port 8080 |
+
+The `:ci` variants (e.g. `reliability:accessibility:ci`) just delegate to
+the base task with CI-friendly output paths — same logic.
+
+## Repo structure (current state)
+
+```
+slopstopper/
+├── .github/workflows/        # 19 GitHub Actions workflows (see docs/)
+├── .scripts/                 # Python/shell analysis scripts called by tasks
+├── app/                      # Static site — Netlify publish dir
+│   ├── index.html            # Hero + Get Started + capability grid
+│   ├── features.html         # 5 category cards with YAML excerpts + mock reports
+│   ├── tools.html            # 14 tool cards with YAML/config excerpts
+│   ├── shared.css            # Brand system, components, layout primitives
+│   ├── index.css             # Page-specific layout
+│   ├── features.css          # Page-specific layout (loops, bridge, reports)
+│   ├── tools.css             # Page-specific layout
+│   └── favicon.svg           # Inline SVG favicon (CSP-safe)
+├── docs/                     # Documentation hub — see docs/index.md
+├── src/                      # TypeScript stubs (build target; no runtime JS)
+├── tests/                    # Playwright smoke + accessibility specs
+├── install.sh                # Adopter installer
+├── netlify.toml              # Netlify config + strict CSP
+├── server.js                 # Local dev server that parses netlify.toml headers
+├── Taskfile.yml              # Single source of truth for commands
+├── playwright.config.js
+├── tsconfig.json
+├── package.json
+├── README.md                 # Consumer-focused
+└── CONTRIBUTING.md → docs/contributing/README.md
+```
+
+## Visual / brand conventions (rebranded — keep in sync if you change them)
+
+The site is **indie-playful**: cream / peach background, tomato accent,
+"Stoppy" mascot, sticker cards with offset shadows and tiny rotations,
+sun-highlighter underlines, hand-drawn SVG arrows.
+
+Brand tokens live in [`app/shared.css`](./app/shared.css) on `:root`:
+
+```css
+--cream: #FBF5EC;        /* page background */
+--peach: #FFD9B8;        /* secondary surface */
+--peach-soft: #FFE9D4;
+--ink: #2A2118;          /* primary text */
+--ink-soft: #6B5B47;     /* secondary text */
+--accent: #E8512B;       /* tomato — for decorative shapes only */
+--accent-deep: #B33A1A;  /* tomato for text-on-light or text-on-accent */
+--mint: #2E8B6F;         /* "pass" indicator */
+--sun: #F5C24C;          /* "warning" + highlighter underline */
+```
+
+**Contrast rule:** `--accent` (`#E8512B`) is below 4.5:1 against white. For
+any text on a light background, or white text on coloured backgrounds, use
+`--accent-deep`. axe-core will catch violations at the strictest `minor`
+threshold — keep that gate green.
+
+Typography is system-only (no web fonts): `ui-rounded` cascading to
+`system-ui` for sans, `ui-monospace` for mono. Do not add `@font-face` or
+external font links.
+
+## CSP — what you can and cannot load
+
+[`netlify.toml`](./netlify.toml) ships a strict CSP:
+
+```
+default-src 'self'; script-src 'self'; style-src 'self';
+base-uri 'self'; form-action 'self'; frame-ancestors 'none'
+```
+
+This is non-negotiable — the security headers are tested in DAST. Therefore:
+
+- ✅ Local CSS, local JS, local images, local fonts (none currently)
+- ❌ No CDN fonts, no Google Fonts
+- ❌ No external images, no `shields.io` badges
+- ❌ No third-party scripts, no analytics, no embeds (no GitHub iframe, no Lighthouse iframe)
+- ❌ No `data:` URLs for images (blocked by `default-src 'self'` in most browsers)
+
+Use inline SVG for any imagery. Mascots and mock report cards are inline
+SVG; the favicon is `app/favicon.svg`.
+
+## Pages — content authoring rules
+
+- Each HTML page links `shared.css` first, then its page-specific CSS
+- Header / nav / footer markup is duplicated across pages — there is no
+  build step or SSI. Accept the duplication; if you change one, change all
+  three
+- Every external link uses `rel="noopener noreferrer"`. Avoid
+  `target="_blank"` for predictable screen-reader behaviour
+- `aria-current="page"` marks the active nav link
+- Skip-to-content link is the first `<body>` child
+- The `<details>` collapsibles use a custom `+` / `−` marker; do not add JS
+- Workflow YAML excerpts inside `<details>` are **hand-curated illustrative
+  excerpts**, not verbatim. Each block has an HTML comment
+  `<!-- sync this excerpt if the workflow's first job step changes -->`.
+  The visible "View source" link is the canonical reference
+
+## Deployment
+
+- **Production:** push to `main` → [`netlify-deploy.yml`](./.github/workflows/netlify-deploy.yml) → live site
+- **Preview:** open PR → preview at `https://pr-{number}--{site-name}.netlify.app` → URL posted as PR comment
+- **Cleanup:** PR closed → [`netlify-cleanup-preview.yml`](./.github/workflows/netlify-cleanup-preview.yml) deletes the preview deploy
+- **Secrets required:** `NETLIFY_AUTH_TOKEN`, `NETLIFY_SITE_ID`
+
+## Operational automation
+
+- [`workflow-failure-issue.yml`](./.github/workflows/workflow-failure-issue.yml) — failed workflow runs on `main` raise (or update) a tracking issue labelled `workflow-failure`. Linked from the live site
+- [`hygiene-auto-label-pr.yml`](./.github/workflows/hygiene-auto-label-pr.yml) — labels PRs by changed paths via [`labeler.yml`](./.github/labeler.yml)
+- [`hygiene-doc-updater.md`](./.github/workflows/hygiene-doc-updater.md) — gh-aw agentic workflow; weekly scan of merged PRs + open `documentation` issues, opens sync PRs labelled `documentation, automation`. Requires `ANTHROPIC_API_KEY` secret
+
+## Commit conventions
+
+[Conventional Commits](https://www.conventionalcommits.org/):
+`<type>(<scope>): <description>` where type is one of `feat`, `fix`,
+`docs`, `style`, `test`, `chore`, `refactor`. Examples:
+
+- `feat(site): add Taskfile bridge + live issue/PR links`
+- `fix(install): correct REPO_URL after rename`
+- `docs(agents): refresh visual conventions`
+
+## When making changes
+
+| Change | Affects |
+| ------ | ------- |
+| Visual / brand | `app/shared.css` (tokens), then individual pages if they use new components |
+| New quality check | Add workflow under `.github/workflows/`, add Task target, surface on `app/features.html` and `app/tools.html`, mention in `README.md` |
+| New page | Add HTML + page-specific CSS in `app/`; link `shared.css` first; copy header/nav/footer; add to nav on the other two pages; add to `tests/smoke.spec.ts` and `tests/accessibility.spec.ts` |
+| Netlify behaviour | `netlify.toml` (CSP changes are blast-radius — touch DAST tests too) |
+| Installer behaviour | `install.sh` (the REPO_URL must always match this repo's actual location) |
+
+## Verifying changes locally
+
+```bash
+task contributing:build                  # TypeScript build
+task contributing:run                    # server on :8080
+task contributing:test                   # Playwright smoke + a11y
+task reliability:accessibility           # axe-core audit
+task reliability:cwv                     # Lighthouse CI
+task hygiene:complexity                  # Lizard cap
+task security:sast                       # Semgrep
+```
+
+Or run the underlying npm scripts if you don't have Task installed
+(`npm start`, `npm run build`, `npm test`) — but **prefer `task`** so your
+behaviour matches CI exactly.
+
+## Integration points
+
+- **Netlify:** deployment is driven by GitHub Actions (not Netlify's git
+  integration). DNS is managed externally.
+- **GitHub Actions:** workflows require `NETLIFY_AUTH_TOKEN`,
+  `NETLIFY_SITE_ID`, and (for the agentic doc updater) `ANTHROPIC_API_KEY`.
+- **Netlify API:** the cleanup workflow uses
+  `https://api.netlify.com/api/v1/sites/{site_id}/deploys` to delete
+  preview deployments.
+
+## Common pitfalls
+
+- Adding a quality check workflow but forgetting to add a matching Task
+  target → CI and local diverge
+- Editing `app/index.html` but forgetting `aria-current="page"` on the
+  active nav link → a11y regression
+- Adding any external resource → CSP blocks it silently in production; test
+  in DevTools first
+- Tweaking `--accent` to use it as text colour → AA contrast fail (use
+  `--accent-deep` for text)
+- Adding to one HTML page's header but not the other two → nav drifts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Claude Code — project instructions
+
+The canonical agent conventions for this repo live in [`AGENTS.md`](./AGENTS.md).
+Claude Code imports them via the directive below — keep this file thin and
+let `AGENTS.md` be the single source of truth.
+
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to SlopStopper
+
+Thanks for considering a contribution. The full contributor guide lives at:
+
+→ [`docs/contributing/README.md`](./docs/contributing/README.md)
+
+## Short version
+
+- Branch from `main` and keep changes focused
+- Use [Conventional Commits](https://www.conventionalcommits.org/):
+  `<type>(<scope>): <description>` (types: `feat`, `fix`, `docs`, `style`,
+  `test`, `chore`, `refactor`)
+- Run `task --list` to see check tasks before pushing
+- The Taskfile is the single source of truth — `task <name>` runs the same
+  thing locally that CI runs
+- Open a pull request; the SlopStopper checks will report back
+
+## Quick checks before pushing
+
+```bash
+task contributing:build               # TypeScript build
+task contributing:test                # Playwright smoke + a11y
+task reliability:accessibility        # axe-core WCAG 2.1 AA
+task hygiene:complexity               # Lizard cap
+task security:sast                    # Semgrep
+```
+
+## Agents
+
+If you're an AI agent working on this repo, read
+[`AGENTS.md`](./AGENTS.md) for the canonical conventions and constraints.
+
+## Code of conduct, support, escalation
+
+See [`docs/support/`](./docs/support/).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,157 @@
+# SlopStopper
+
+**Deterministic, automated quality feedback for AI-driven development — drop it into any repo with one command.**
+
+SlopStopper is a portable suite of GitHub Actions workflows, Task targets and
+analysis scripts that you install into an existing repository to get a
+consistent quality pipeline: security, hygiene, reliability, accessibility,
+performance, and operational automation — all running on every pull request
+and push to `main`.
+
+📍 **Live reference site:** see [the SlopStopper showcase](https://github.com/hungovercoders/slopstopper) — built with the same suite it advertises.
+
+---
+
+## Install
+
+From inside the repo you want to add SlopStopper to:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install.sh | bash
+```
+
+Or, if you prefer to review the script first (recommended):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install.sh -o install.sh
+bash install.sh [TARGET_DIR]
+```
+
+The installer is idempotent — re-run any time to pull in new checks. Existing
+files are never overwritten; remove them first if you want to reinstall.
+
+### What gets installed
+
+| Item | Description |
+| ---- | ----------- |
+| `Taskfile.yml` | All Task definitions (`task --list` to see them) |
+| `.scripts/` | Python/shell analysis scripts used by the tasks |
+| `.github/workflows/` | Security, hygiene, reliability, operational and deployment workflows |
+| `package.json` | Created (or `devDependencies` merged into an existing file) |
+
+### After installing
+
+```bash
+# 1. Install the Task runner (if you don't have it)
+curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
+
+# 2. Install npm dependencies
+npm install
+
+# 3. See all available tasks
+task --list
+
+# 4. Open a pull request — every check runs automatically
+```
+
+---
+
+## What you get
+
+Five loops of feedback, all running on every PR and push to `main`:
+
+| Loop | What it does | Tools |
+| ---- | ------------ | ----- |
+| 🔒 **Security** | SAST, DAST, secrets detection, dependency CVE scanning | Semgrep, OWASP ZAP, Gitleaks, Trivy |
+| 🧹 **Hygiene** | Cyclomatic complexity caps, doc structure / accuracy / size checks, auto-labelled PRs | Lizard, Bandit, markdownlint |
+| ✅ **Reliability** | E2E + smoke tests, accessibility audits (WCAG 2.1 AA), Core Web Vitals | Playwright, axe-core, Lighthouse CI |
+| 🤖 **Operational** | Failed workflows auto-raise GitHub issues; an agentic doc updater opens weekly sync PRs | GitHub Actions, gh-aw |
+| 🚀 **Deployment** | Preview deploys per PR, automated production releases, preview cleanup | Netlify, GitHub Actions |
+
+### Same commands, both loops
+
+Every check is just a `task` command, defined once in `Taskfile.yml`. You run
+it locally for instant feedback. CI runs the exact same command. No drift
+between what you ran and what the pipeline ran — fast inner loop, consistent
+outer loop, identical behaviour.
+
+```bash
+task hygiene:complexity            # locally
+task reliability:accessibility     # locally
+task security:sast                 # locally
+```
+
+The CI workflows call the same `task` targets (or a `:ci` variant that
+delegates to the same definition). One source of truth.
+
+---
+
+## Configure
+
+Most checks work out of the box. The deployment workflows need two GitHub
+secrets if you want Netlify previews:
+
+- `NETLIFY_AUTH_TOKEN` — Netlify User settings → Applications → Personal access tokens
+- `NETLIFY_SITE_ID` — Netlify Site settings → General → Site details
+
+You can tune thresholds without changing code:
+
+- `ACCESSIBILITY_IMPACT` — `critical` / `serious` / `moderate` / `minor` (default `serious`)
+- `ACCESSIBILITY_THRESHOLD` — max allowed violations before failing (default `0`)
+- Complexity caps — see [`.scripts/`](./.scripts/) and [`docs/hygiene/COMPLEXITY_CONFIG.md`](./docs/hygiene/COMPLEXITY_CONFIG.md)
+- Lighthouse budgets — `.lighthouserc.json` and `.lighthouserc.prod.json`
+
+---
+
+## Update
+
+Re-run the installer to pull in new checks or updated scripts. Existing files
+aren't overwritten, so your customisations are preserved — review the diff
+afterwards.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install.sh | bash
+```
+
+---
+
+## Run the demo site locally
+
+This repo also hosts the SlopStopper marketing site (the same set of HTML
+pages you'd see at the live URL). To run it yourself:
+
+```bash
+npm install
+npm run build      # compiles TypeScript
+npm start          # serves app/ on http://localhost:8080
+```
+
+`server.js` parses `netlify.toml` so local headers match production.
+
+---
+
+## Contribute
+
+Contributions are welcome. The full contributor guide lives in
+[`docs/contributing/README.md`](./docs/contributing/README.md) — short
+version:
+
+- Branch from `main`, keep changes focused
+- Run `task --list` to see check tasks before pushing
+- Follow [Conventional Commits](https://www.conventionalcommits.org/)
+- Open a PR; let the SlopStopper checks do their job
+
+---
+
+## Agents
+
+If an AI agent (Claude, Copilot, Cursor, etc.) is working on this repo, the
+canonical conventions and constraints live in [`AGENTS.md`](./AGENTS.md).
+[`CLAUDE.md`](./CLAUDE.md) imports `AGENTS.md` so Claude Code picks up the
+same instructions automatically.
+
+---
+
+## License
+
+MIT — see [LICENSE](./LICENSE) if present, or the package metadata.

--- a/app/features.css
+++ b/app/features.css
@@ -1,191 +1,89 @@
-* {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-}
-body {
-    min-height: 100vh;
-    font-family: Arial, sans-serif;
-    background: #1a1a2e;
-    color: #e0e0e0;
-}
-header {
-    background: #16213e;
-    padding: 1.2rem 2rem;
-    border-bottom: 2px solid #00d4aa;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-}
-.site-title {
-    font-size: 1.4rem;
-    color: #00d4aa;
-    font-weight: bold;
-    text-decoration: none;
-}
-nav a {
-    color: #e0e0e0;
-    text-decoration: none;
-    margin-left: 1.2rem;
-    padding: 0.4rem 1rem;
-    border-radius: 4px;
-    transition: background 0.2s;
-    display: inline-block;
-}
-nav a:hover {
-    background: rgba(0, 212, 170, 0.2);
-}
-nav a[aria-current="page"] {
-    background: rgba(0, 212, 170, 0.15);
-    color: #00d4aa;
-}
-.skip-link {
-    position: absolute;
-    left: -9999px;
-    top: 0;
-    background: #00d4aa;
-    color: #16213e;
-    padding: 0.6rem 1rem;
-    font-weight: bold;
-    text-decoration: none;
-    border-radius: 0 0 4px 0;
-    z-index: 100;
-}
-.skip-link:focus {
-    left: 0;
-    outline: 2px solid #16213e;
-    outline-offset: 2px;
-}
-footer {
-    margin-top: 4rem;
-    padding: 1.5rem 2rem;
-    border-top: 1px solid rgba(0, 212, 170, 0.25);
-    text-align: center;
-    font-size: 0.9rem;
-    opacity: 0.8;
-}
-footer a {
-    color: #00d4aa;
-}
-main {
-    max-width: 960px;
-    margin: 0 auto;
-    padding: 3rem 2rem;
-}
-.hero {
-    text-align: center;
-    margin-bottom: 2.5rem;
-}
-.hero h1 {
-    font-size: 3rem;
-    color: #00d4aa;
-    margin-bottom: 0.8rem;
-}
-.hero p {
-    font-size: 1.2rem;
-    opacity: 0.8;
-}
-.card-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1.5rem;
-}
-.card {
-    background: #16213e;
-    border: 1px solid rgba(0, 212, 170, 0.25);
-    border-radius: 8px;
-    padding: 1.5rem;
-}
-.card h2 {
-    color: #00d4aa;
-    font-size: 1.15rem;
-    margin-bottom: 0.8rem;
-}
-.card ul {
-    list-style: none;
-    padding: 0;
-}
-.card ul li {
-    font-size: 0.95rem;
-    line-height: 1.6;
-    opacity: 0.8;
-    padding: 0.4rem 0;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-}
-.card ul li:last-child {
-    border-bottom: none;
-}
-.loops {
-    margin-top: 3rem;
-}
-.loops h2 {
-    font-size: 1.8rem;
-    color: #00d4aa;
-    margin-bottom: 0.5rem;
-}
-.loops-intro {
-    opacity: 0.8;
-    margin-bottom: 2rem;
-    font-size: 1rem;
-}
-.loop-diagram {
-    background: #16213e;
-    border: 1px solid rgba(0, 212, 170, 0.25);
-    border-radius: 8px;
-    padding: 1.5rem;
-    margin-bottom: 1.5rem;
-}
-.loop-diagram h3 {
-    color: #00d4aa;
-    font-size: 1.1rem;
+/* features.html — page-specific styles */
+
+.card-intro {
     margin-bottom: 0.4rem;
 }
-.loop-desc {
+
+.reports-section {
+    position: relative;
+}
+.reports-section .mascot--peek {
+    position: absolute;
+    top: -3rem;
+    right: 1rem;
+    z-index: 1;
+}
+
+/* ─── Loops diagram ─────────────────────────────────────── */
+.loops .loop-diagram {
+    background: var(--paper);
+    border: var(--border);
+    border-radius: var(--r-md);
+    padding: 1.5rem;
+    margin-top: 1.5rem;
+    box-shadow: var(--shadow-sticker);
+}
+.loops .loop-diagram h3 {
+    font-size: 1.1rem;
+    font-weight: 800;
+    margin-bottom: 0.3rem;
+    color: var(--ink);
+}
+.loops .loop-desc {
     font-size: 0.9rem;
-    opacity: 0.7;
+    color: var(--ink-soft);
     margin-bottom: 1.2rem;
 }
-.loop-flow {
+.loops .loop-flow {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     gap: 0.5rem;
     margin-bottom: 0.75rem;
 }
-.loop-step {
-    background: #0f3460;
-    border: 1px solid rgba(0, 212, 170, 0.4);
-    border-radius: 6px;
-    padding: 0.5rem 0.8rem;
-    font-size: 0.9rem;
+.loops .loop-step {
+    background: var(--peach-soft);
+    border: var(--border-thin);
+    border-radius: var(--r-md);
+    padding: 0.55rem 0.9rem;
+    font-size: 0.92rem;
+    font-weight: 600;
     display: flex;
     flex-direction: column;
     align-items: center;
-    min-width: 90px;
+    min-width: 100px;
     text-align: center;
+    color: var(--ink);
 }
-.loop-step--trigger {
-    border-color: rgba(0, 212, 170, 0.8);
+.loops .loop-step--trigger {
+    background: var(--sun);
 }
-.loop-step--feedback {
-    border-color: rgba(0, 212, 170, 0.8);
-    background: #16213e;
+.loops .loop-step--feedback {
+    background: var(--accent-deep);
+    color: var(--paper);
 }
-.step-sub {
+.loops .step-sub {
     font-size: 0.72rem;
-    opacity: 0.65;
+    color: inherit;
+    opacity: 0.78;
     margin-top: 0.2rem;
-    white-space: nowrap;
+    font-weight: 500;
 }
-.loop-arrow {
-    color: #00d4aa;
-    font-size: 1.2rem;
-    opacity: 0.7;
-    flex-shrink: 0;
+.loops .loop-step--feedback .step-sub {
+    opacity: 1;
 }
-.loop-back {
-    font-size: 0.82rem;
-    color: #00d4aa;
+.loops .loop-back {
+    font-size: 0.85rem;
+    color: var(--accent-deep);
     font-style: italic;
     padding-left: 0.2rem;
+    font-weight: 600;
+}
+
+@media (max-width: 600px) {
+    .reports-section .mascot--peek {
+        top: -2rem;
+        right: 0.5rem;
+        width: 72px;
+    }
 }

--- a/app/features.css
+++ b/app/features.css
@@ -87,3 +87,130 @@
         width: 72px;
     }
 }
+
+/* ─── Bridge: same commands, both loops ─────────────────── */
+.bridge {
+    margin-top: 2rem;
+    background: var(--paper);
+    border: var(--border);
+    border-radius: var(--r-md);
+    padding: 1.5rem;
+    box-shadow: var(--shadow-sticker);
+}
+.bridge__header h3 {
+    font-size: 1.3rem;
+    font-weight: 800;
+    margin: 0.3rem 0 0.5rem 0;
+    color: var(--ink);
+}
+.bridge__lede {
+    color: var(--ink-soft);
+    max-width: 680px;
+    margin-bottom: 1.5rem;
+}
+.bridge__lede code {
+    background: var(--peach-soft);
+    padding: 0.05rem 0.35rem;
+    border-radius: var(--r-sm);
+    font-family: var(--font-mono);
+    font-size: 0.88em;
+    color: var(--ink);
+}
+.bridge__grid {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    gap: 1.5rem;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+.bridge__col {
+    background: var(--cream);
+    border: var(--border-thin);
+    border-radius: var(--r-md);
+    padding: 1rem 1.1rem;
+}
+.bridge__label {
+    font-weight: 800;
+    font-size: 0.95rem;
+    margin-bottom: 0.6rem;
+    color: var(--ink);
+}
+.bridge__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+.bridge__list li code {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 0.86rem;
+    background: var(--paper);
+    border: 1px dashed rgba(42, 33, 24, 0.25);
+    border-radius: var(--r-sm);
+    padding: 0.35rem 0.55rem;
+    color: var(--ink);
+}
+.bridge__center {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    color: var(--accent-deep);
+}
+.bridge__sticker {
+    background: var(--sun);
+    border: var(--border);
+    border-radius: var(--r-md);
+    padding: 0.7rem 1rem;
+    text-align: center;
+    box-shadow: var(--shadow-sticker-sm);
+    transform: rotate(-3deg);
+    margin-bottom: 0.6rem;
+}
+.bridge__taskfile {
+    display: block;
+    font-family: var(--font-mono);
+    font-weight: 800;
+    font-size: 0.95rem;
+    color: var(--ink);
+}
+.bridge__sub {
+    display: block;
+    font-size: 0.72rem;
+    color: var(--ink);
+    opacity: 0.7;
+    margin-top: 0.15rem;
+}
+.bridge__arrows {
+    width: 120px;
+    color: var(--accent-deep);
+}
+.bridge__arrows svg {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+@media (max-width: 720px) {
+    .bridge__grid {
+        grid-template-columns: 1fr;
+    }
+    .bridge__center {
+        order: -1;
+        margin-bottom: 0.5rem;
+    }
+    .bridge__arrows {
+        display: none;
+    }
+    .bridge__sticker {
+        transform: rotate(0);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .bridge__sticker {
+        transform: none;
+    }
+}

--- a/app/features.html
+++ b/app/features.html
@@ -288,6 +288,11 @@ jobs:
     if: github.event.workflow_run.conclusion == 'failure'
         &amp;&amp; github.event.workflow_run.head_branch == 'main'</code></pre></div>
                         <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/workflow-failure-issue.yml" rel="noopener noreferrer">View workflow on GitHub →</a>
+                        <div class="live-links">
+                            <span class="live-links__label">See it in action:</span>
+                            <a href="https://github.com/hungovercoders/slopstopper/issues?q=is%3Aissue+is%3Aopen+label%3Aworkflow-failure" rel="noopener noreferrer">🔴 Open issues</a>
+                            <a href="https://github.com/hungovercoders/slopstopper/issues?q=is%3Aissue+is%3Aclosed+label%3Aworkflow-failure" rel="noopener noreferrer">✅ Closed issues</a>
+                        </div>
                     </div>
                 </details>
 
@@ -303,6 +308,11 @@ safe-outputs:
     title-prefix: "[docs] "
     labels: [documentation, automation]</code></pre></div>
                         <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/hygiene-doc-updater.md" rel="noopener noreferrer">View workflow on GitHub →</a>
+                        <div class="live-links">
+                            <span class="live-links__label">See it in action:</span>
+                            <a href="https://github.com/hungovercoders/slopstopper/pulls?q=is%3Apr+is%3Aopen+label%3Aautomation+label%3Adocumentation" rel="noopener noreferrer">🔴 Open PRs</a>
+                            <a href="https://github.com/hungovercoders/slopstopper/pulls?q=is%3Apr+is%3Aclosed+label%3Aautomation+label%3Adocumentation" rel="noopener noreferrer">✅ Closed PRs</a>
+                        </div>
                     </div>
                 </details>
             </div>
@@ -604,6 +614,60 @@ jobs:
                     <div class="loop-step loop-step--feedback">💬 Feedback<span class="step-sub">to developer</span></div>
                 </div>
                 <div class="loop-back">↩ fix &amp; iterate</div>
+            </div>
+
+            <div class="bridge">
+                <div class="bridge__header">
+                    <span class="kicker">One source of truth</span>
+                    <h3>Same commands. <span class="highlight">Both loops.</span></h3>
+                    <p class="bridge__lede">Every check is a <code>task</code> command — defined once in <a href="https://github.com/hungovercoders/slopstopper/blob/main/Taskfile.yml" rel="noopener noreferrer">Taskfile.yml</a>. You type it locally for instant feedback. CI runs the exact same command. No drift between what you ran and what the pipeline runs — fast inner loop, consistent outer loop, identical behaviour.</p>
+                </div>
+                <div class="bridge__grid">
+                    <div class="bridge__col">
+                        <div class="bridge__label">🧑‍💻 Inner loop — local</div>
+                        <ul class="bridge__list">
+                            <li><code>task hygiene:complexity</code></li>
+                            <li><code>task security:sast</code></li>
+                            <li><code>task reliability:accessibility</code></li>
+                            <li><code>task reliability:smoke</code></li>
+                        </ul>
+                    </div>
+                    <div class="bridge__center" aria-hidden="true">
+                        <div class="bridge__sticker">
+                            <span class="bridge__taskfile">Taskfile.yml</span>
+                            <span class="bridge__sub">one definition</span>
+                        </div>
+                        <div class="bridge__arrows">
+                            <svg viewBox="0 0 120 40" aria-hidden="true"><path d="M60 6 Q30 12, 8 22 L14 18 M8 22 L14 26" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/><path d="M60 6 Q90 12, 112 22 L106 18 M112 22 L106 26" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        </div>
+                    </div>
+                    <div class="bridge__col">
+                        <div class="bridge__label">🤖 Outer loop — CI</div>
+                        <ul class="bridge__list">
+                            <li><code>task hygiene:complexity</code></li>
+                            <li><code>task security:sast</code></li>
+                            <li><code>task reliability:accessibility:ci</code></li>
+                            <li><code>task reliability:smoke:ci</code></li>
+                        </ul>
+                    </div>
+                </div>
+                <details class="details">
+                    <summary>What a Taskfile entry looks like</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>reliability:accessibility:
+  desc: Run axe-core accessibility audit against a URL
+  cmds:
+    - npx playwright test tests/accessibility.spec.ts
+
+reliability:accessibility:ci:
+  desc: Same audit, wired for CI artifacts
+  cmds:
+    - task: reliability:accessibility</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/Taskfile.yml" rel="noopener noreferrer">View Taskfile.yml on GitHub →</a>
+                        <br>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/reliability-accessibility-check.yml" rel="noopener noreferrer">View workflow that calls it →</a>
+                    </div>
+                </details>
             </div>
         </section>
     </main>

--- a/app/features.html
+++ b/app/features.html
@@ -3,17 +3,18 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Categories of automated quality checks in SlopStopper: security, hygiene, reliability (E2E, smoke, accessibility, Core Web Vitals), operational and deployment.">
-    <meta name="theme-color" content="#16213e">
+    <meta name="description" content="Practices and automated feedback loops in SlopStopper: security, hygiene, reliability (E2E, smoke, accessibility, Core Web Vitals), operational and deployment. See the workflow behind each.">
+    <meta name="theme-color" content="#FBF5EC">
     <meta property="og:type" content="website">
     <meta property="og:title" content="SlopStopper — Features">
-    <meta property="og:description" content="Practices and automated feedback loops that keep a repo healthy at high velocity.">
+    <meta property="og:description" content="Every category of feedback, the workflow YAML behind it, and a peek at what the output looks like.">
     <meta property="og:site_name" content="SlopStopper">
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="SlopStopper — Features">
-    <meta name="twitter:description" content="Practices and automated feedback loops that keep a repo healthy at high velocity.">
+    <meta name="twitter:description" content="Every category of feedback, the workflow YAML behind it, and a peek at what the output looks like.">
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <title>Features</title>
+    <link rel="stylesheet" href="shared.css">
     <link rel="stylesheet" href="features.css">
 </head>
 <body>
@@ -24,89 +25,582 @@
             <a href="index.html" id="nav-home">Home</a>
             <a href="features.html" id="nav-features" aria-current="page">Features</a>
             <a href="tools.html" id="nav-tools">Tools</a>
+            <a href="https://github.com/hungovercoders/slopstopper" class="btn btn--ghost btn--gh" rel="noopener noreferrer" aria-label="View SlopStopper on GitHub">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.33-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.11-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.06 0 0 .97-.31 3.18 1.18a11.1 11.1 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.77.12 3.06.74.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.4-5.25 5.68.41.35.78 1.05.78 2.12v3.14c0 .31.21.66.79.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z"/></svg>
+                GitHub
+            </a>
         </nav>
     </header>
     <main id="main">
-        <div class="hero">
-            <h1>Practices &amp; Feedback</h1>
-            <p>The categories of automated checks that keep your repo healthy</p>
-        </div>
+        <section class="hero">
+            <span class="kicker">Practices &amp; feedback</span>
+            <h1>Five loops, <span class="highlight">no slop.</span></h1>
+            <p>Every check below is a real GitHub Actions workflow in the repo. Click any sub-feature to peek at the YAML behind it.</p>
+        </section>
+
         <div class="card-grid">
-            <div class="card">
+            <!-- ─── Security ─────────────────────────────────────── -->
+            <div class="card" id="security">
                 <h2>🔒 Security</h2>
+                <p class="card-intro">Static analysis, dynamic scanning, secrets detection and dependency CVE checks run on every change.</p>
                 <ul>
-                    <li><strong>SAST</strong> — Static application security testing flags vulnerabilities in source code before merge</li>
-                    <li><strong>DAST</strong> — Dynamic scanning probes a running site for common web vulnerabilities</li>
-                    <li><strong>Secrets Detection</strong> — Scans every commit for accidentally committed credentials or tokens</li>
-                    <li><strong>Dependency Scanning</strong> — Checks all dependencies for known CVEs on every pull request</li>
+                    <li><strong>SAST</strong> — Semgrep flags vulnerabilities in source code before merge</li>
+                    <li><strong>DAST</strong> — OWASP ZAP probes a running site for common web vulnerabilities</li>
+                    <li><strong>Secrets</strong> — Gitleaks scans every commit for accidentally committed credentials</li>
+                    <li><strong>Dependencies</strong> — Trivy checks all dependencies for known CVEs</li>
                 </ul>
+
+                <details class="details">
+                    <summary>SAST (Semgrep)</summary>
+                    <div class="details__body">
+                        <!-- sync this excerpt if the workflow's first job step changes -->
+                        <div class="codeblock codeblock--yaml" role="region" aria-label="SAST workflow excerpt"><pre><code>name: SAST Analysis
+on:
+  pull_request: { branches: [ main ] }
+  push:         { branches: [ main ] }
+jobs:
+  sast:
+    name: Static Application Security Testing with Semgrep
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: pip install semgrep && semgrep ci</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/security-sast-check.yml" rel="noopener noreferrer">View workflow on GitHub →</a>
+                    </div>
+                </details>
+
+                <details class="details">
+                    <summary>DAST (OWASP ZAP)</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>name: DAST Analysis
+on:
+  pull_request: { branches: [ main ] }
+  push:         { branches: [ main ] }
+jobs:
+  dast:
+    name: Dynamic Application Security Testing with OWASP ZAP
+    steps:
+      - uses: actions/checkout@v4
+      - run: task start &amp;&amp; npx @zaproxy/action-baseline</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/security-dast-check.yml" rel="noopener noreferrer">View workflow on GitHub →</a>
+                    </div>
+                </details>
+
+                <details class="details">
+                    <summary>Secrets (Gitleaks)</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>name: Secrets Detection
+on:
+  pull_request: { branches: [ main ] }
+  push:         { branches: [ main ] }
+jobs:
+  secrets:
+    name: Detect Secrets with Gitleaks
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: gitleaks/gitleaks-action@v2</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/security-secrets-check.yml" rel="noopener noreferrer">View workflow on GitHub →</a>
+                    </div>
+                </details>
+
+                <details class="details">
+                    <summary>Dependencies (Trivy + Dependency Review)</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>name: Dependency Vulnerability Scan
+on:
+  pull_request: { branches: [ main ] }
+  push:         { branches: [ main ] }
+jobs:
+  dependencies:
+    name: Scan Dependencies with Trivy
+    steps:
+      - uses: actions/checkout@v4
+      - run: trivy fs --severity HIGH,CRITICAL .</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/security-vulnerability-all-check.yml" rel="noopener noreferrer">View workflow on GitHub →</a>
+                        <br>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/security-vulnerability-new-check.yml" rel="noopener noreferrer">View dependency-review workflow →</a>
+                    </div>
+                </details>
             </div>
-            <div class="card">
+
+            <!-- ─── Hygiene ──────────────────────────────────────── -->
+            <div class="card" id="hygiene">
                 <h2>🧹 Hygiene</h2>
+                <p class="card-intro">Complexity limits and documentation checks keep the codebase auditable and the docs honest.</p>
                 <ul>
-                    <li><strong>Complexity Checks</strong> — Enforces complexity thresholds to keep functions readable and maintainable</li>
-                    <li><strong>Doc Structure</strong> — Validates that required documentation sections are present</li>
-                    <li><strong>Doc Accuracy</strong> — Ensures documentation reflects the actual state of the codebase</li>
-                    <li><strong>Doc Size</strong> — Prevents documentation from growing unwieldy or stale</li>
+                    <li><strong>Complexity</strong> — Lizard + Bandit cap cyclomatic complexity and Python security smells</li>
+                    <li><strong>Doc Structure</strong> — Required docs sections present and linted</li>
+                    <li><strong>Doc Accuracy</strong> — Documentation reflects the actual code</li>
+                    <li><strong>Doc Size</strong> — Prevents documentation from going stale or unwieldy</li>
+                    <li><strong>Auto-label PRs</strong> — PRs labelled from the paths changed</li>
                 </ul>
+
+                <details class="details">
+                    <summary>Complexity (Lizard)</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>name: Code Complexity Check
+on:
+  pull_request: { branches: [ main ] }
+  push:         { branches: [ main ] }
+jobs:
+  complexity-check:
+    name: Check Code Complexity with Lizard
+    steps:
+      - uses: actions/checkout@v4
+      - run: pip install lizard &amp;&amp; lizard -C 10 -L 60 .</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/hygiene-complexity-check.yml" rel="noopener noreferrer">View workflow on GitHub →</a>
+                    </div>
+                </details>
+
+                <details class="details">
+                    <summary>Doc Structure &amp; Accuracy</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>name: Hygiene - Documentation Accuracy Check
+on:
+  schedule: [ { cron: '0 7 * * 1' } ]   # weekly
+  pull_request:
+    paths: [ 'docs/**', '*.html', '*.js', '*.css' ]
+  push:
+    branches: [ main ]</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/hygiene-docs-accuracy-check.yml" rel="noopener noreferrer">View accuracy workflow →</a>
+                        <br>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/hygiene-docs-structure-check.yml" rel="noopener noreferrer">View structure workflow →</a>
+                        <br>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/hygiene-docs-size-check.yml" rel="noopener noreferrer">View size-monitor workflow →</a>
+                    </div>
+                </details>
+
+                <details class="details">
+                    <summary>Auto-label PRs</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>name: Hygiene - Auto Label PRs
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  label:
+    steps:
+      - uses: actions/labeler@v5
+        with: { sync-labels: true }</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/hygiene-auto-label-pr.yml" rel="noopener noreferrer">View workflow on GitHub →</a>
+                    </div>
+                </details>
             </div>
-            <div class="card">
+
+            <!-- ─── Reliability ─────────────────────────────────── -->
+            <div class="card" id="reliability">
                 <h2>✅ Reliability</h2>
+                <p class="card-intro">End-to-end, smoke, accessibility and Core Web Vitals checks verify every deploy works for every user.</p>
                 <ul>
-                    <li><strong>E2E Tests</strong> — Playwright tests verify all pages and user flows work on every pull request</li>
-                    <li><strong>Smoke Tests</strong> — Lightweight smoke tests run against staging and production after every deploy</li>
-                    <li><strong>Accessibility</strong> — axe-core audits every page against WCAG 2.1 AA on PRs, after deploys, and on a daily schedule</li>
-                    <li><strong>Core Web Vitals</strong> — Lighthouse CI measures LCP, INP and CLS on every PR and nightly against production</li>
+                    <li><strong>E2E Tests</strong> — Playwright covers navigation and critical user journeys</li>
+                    <li><strong>Smoke Tests</strong> — Lightweight checks after every deploy</li>
+                    <li><strong>Accessibility</strong> — axe-core audits every page against WCAG 2.1 AA</li>
+                    <li><strong>Core Web Vitals</strong> — Lighthouse CI measures LCP, INP and CLS</li>
                 </ul>
+
+                <details class="details">
+                    <summary>E2E Tests (Playwright)</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>name: Playwright Tests
+on:
+  pull_request: { branches: [ main ] }
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: npm ci &amp;&amp; npx playwright install chromium
+      - run: npx playwright test</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/playwright-tests.yml" rel="noopener noreferrer">View workflow on GitHub →</a>
+                    </div>
+                </details>
+
+                <details class="details">
+                    <summary>Smoke Tests</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>name: Reliability Smoke Tests
+on:
+  deployment_status:           # after every deploy
+  schedule: [ { cron: '0 * * * *' } ]   # hourly
+  workflow_dispatch:
+jobs:
+  smoke-test:
+    if: github.event.deployment_status.state == 'success' || ...</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/reliability-smoke-tests.yml" rel="noopener noreferrer">View workflow on GitHub →</a>
+                    </div>
+                </details>
+
+                <details class="details">
+                    <summary>Accessibility (axe-core)</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>name: Accessibility Check
+on:
+  pull_request:      { branches: [main] }
+  push:              { branches: [main] }
+  deployment_status:
+  schedule: [ { cron: '0 6 * * *' } ]    # daily
+jobs:
+  a11y:
+    name: Accessibility Audit (axe-core / WCAG 2.1 AA)</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/reliability-accessibility-check.yml" rel="noopener noreferrer">View workflow on GitHub →</a>
+                    </div>
+                </details>
+
+                <details class="details">
+                    <summary>Core Web Vitals (Lighthouse CI)</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>name: Core Web Vitals
+on:
+  deployment_status:
+  schedule: [ { cron: '0 0 * * *' } ]   # nightly prod
+  pull_request: { branches: [ main ] }
+  push:         { branches: [ main ] }
+jobs:
+  cwv:
+    name: Core Web Vitals (Lighthouse CI)</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/reliability-core-web-vitals.yml" rel="noopener noreferrer">View workflow on GitHub →</a>
+                    </div>
+                </details>
             </div>
-            <div class="card">
+
+            <!-- ─── Operational ─────────────────────────────────── -->
+            <div class="card" id="operational">
                 <h2>🤖 Operational</h2>
+                <p class="card-intro">Day-to-day workflow on autopilot: labels, doc updates and incident creation handled for you.</p>
                 <ul>
-                    <li><strong>Auto PR Labelling</strong> — Pull requests are labelled automatically from the paths changed</li>
-                    <li><strong>Doc Auto-Updater</strong> — A weekly agentic workflow opens PRs to keep documentation in sync with the code</li>
                     <li><strong>Failure Alerts</strong> — Failed workflow runs on main raise (or update) a tracking issue automatically</li>
+                    <li><strong>Doc Auto-Updater</strong> — A weekly agentic workflow opens PRs to keep docs in sync</li>
                 </ul>
+
+                <details class="details">
+                    <summary>Failure Alerts</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>name: Raise Issue on Workflow Failure
+on:
+  workflow_run:
+    workflows: ["SAST Analysis", "DAST Analysis", ...]
+    types: [completed]
+jobs:
+  raise-issue:
+    if: github.event.workflow_run.conclusion == 'failure'
+        &amp;&amp; github.event.workflow_run.head_branch == 'main'</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/workflow-failure-issue.yml" rel="noopener noreferrer">View workflow on GitHub →</a>
+                    </div>
+                </details>
+
+                <details class="details">
+                    <summary>Doc Auto-Updater (agentic)</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>name: Hygiene - Documentation Updater
+on:
+  schedule: [ { cron: 'weekly' } ]
+  workflow_dispatch:
+safe-outputs:
+  create-pull-request:
+    title-prefix: "[docs] "
+    labels: [documentation, automation]</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/hygiene-doc-updater.md" rel="noopener noreferrer">View workflow on GitHub →</a>
+                    </div>
+                </details>
             </div>
-            <div class="card">
+
+            <!-- ─── Deployment ──────────────────────────────────── -->
+            <div class="card" id="deployment">
                 <h2>🚀 Deployment</h2>
+                <p class="card-intro">Preview deploys on every PR, automated production releases on merge, stale previews cleaned up.</p>
                 <ul>
-                    <li><strong>Preview Deploys</strong> — Every pull request gets a unique preview URL on Netlify for review</li>
-                    <li><strong>Production Deploy</strong> — Merges to main trigger an automatic production release</li>
-                    <li><strong>Preview Cleanup</strong> — Stale preview environments are automatically removed after PRs close</li>
+                    <li><strong>Preview Deploys</strong> — Every PR gets a unique preview URL on Netlify</li>
+                    <li><strong>Production Deploy</strong> — Merges to main trigger an automatic release</li>
+                    <li><strong>Preview Cleanup</strong> — Stale previews are removed after PRs close</li>
                 </ul>
+
+                <details class="details">
+                    <summary>Deploy &amp; Preview</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>name: Deploy to Netlify
+on:
+  push:         { branches: [ main ] }
+  pull_request: { branches: [ main ] }
+jobs:
+  deploy:
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci &amp;&amp; npm run build
+      - uses: nwtgck/actions-netlify@v2.1
+        with: { publish-dir: './app', production-deploy: true }</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/netlify-deploy.yml" rel="noopener noreferrer">View workflow on GitHub →</a>
+                    </div>
+                </details>
+
+                <details class="details">
+                    <summary>Preview Cleanup</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>name: Cleanup Netlify Preview
+on:
+  pull_request:
+    types: [closed]
+    branches: [ main ]
+jobs:
+  cleanup:
+    steps:
+      - run: |
+          DEPLOY_ID=$(curl ... /api/v1/sites/$SITE_ID/deploys ...)
+          curl -X DELETE ... /api/v1/sites/$SITE_ID/deploys/$DEPLOY_ID</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/netlify-cleanup-preview.yml" rel="noopener noreferrer">View workflow on GitHub →</a>
+                    </div>
+                </details>
             </div>
         </div>
-        <section class="loops">
-            <h2>Development Loops</h2>
-            <p class="loops-intro">SlopStopper organises quality feedback into two loops that keep velocity high and quality consistent.</p>
+
+        <!-- ─── What feedback looks like ────────────────────────── -->
+        <section class="section reports-section">
+            <div class="mascot mascot--peek" aria-hidden="true">
+                <svg viewBox="0 0 240 160" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M40 130 C40 75, 80 50, 120 50 C160 50, 200 75, 200 130 Z" fill="#FBF5EC" stroke="#2A2118" stroke-width="6" stroke-linejoin="round"/>
+                    <circle cx="92" cy="100" r="11" fill="#2A2118"/>
+                    <circle cx="148" cy="100" r="11" fill="#2A2118"/>
+                    <circle cx="95" cy="96" r="3.5" fill="#FBF5EC"/>
+                    <circle cx="151" cy="96" r="3.5" fill="#FBF5EC"/>
+                    <path d="M105 122 Q120 132, 135 122" stroke="#2A2118" stroke-width="4" stroke-linecap="round" fill="none"/>
+                </svg>
+            </div>
+            <span class="kicker">What feedback looks like</span>
+            <h2>Reports, not lectures.</h2>
+            <p class="lede">A mock-up of the kind of output you'll see on a PR. Concrete signal, not vibes.</p>
+
+            <div class="reports-grid">
+                <!-- axe-core mock report -->
+                <div class="report report--axe">
+                    <svg viewBox="0 0 480 320" role="img" aria-labelledby="axeTitle" xmlns="http://www.w3.org/2000/svg">
+                        <title id="axeTitle">axe-core accessibility report mockup</title>
+                        <rect width="480" height="320" fill="#FFFFFF"/>
+                        <rect x="0" y="0" width="480" height="36" fill="#2A2118"/>
+                        <circle cx="16" cy="18" r="5" fill="#E8512B"/>
+                        <circle cx="32" cy="18" r="5" fill="#F5C24C"/>
+                        <circle cx="48" cy="18" r="5" fill="#2E8B6F"/>
+                        <text x="70" y="23" font-family="ui-monospace, monospace" font-size="12" fill="#FBF5EC">axe-core / WCAG 2.1 AA</text>
+                        <text x="20" y="72" font-family="ui-rounded, system-ui, sans-serif" font-weight="800" font-size="20" fill="#2A2118">Accessibility report</text>
+                        <text x="20" y="92" font-family="ui-rounded, system-ui, sans-serif" font-size="13" fill="#6B5B47">3 issues found on this page</text>
+                        <rect x="350" y="56" width="110" height="24" rx="12" fill="#FFD9B8" stroke="#2A2118" stroke-width="1.5"/>
+                        <text x="405" y="73" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="700" font-size="11" fill="#2A2118">WCAG 2.1 AA</text>
+                        <rect x="20" y="110" width="440" height="14" rx="7" fill="#FBF5EC" stroke="#2A2118" stroke-width="1.5"/>
+                        <rect x="22" y="112" width="330" height="10" rx="5" fill="#2E8B6F"/>
+                        <rect x="352" y="112" width="60" height="10" fill="#F5C24C"/>
+                        <rect x="412" y="112" width="46" height="10" rx="5" fill="#E8512B"/>
+                        <text x="20" y="148" font-family="ui-rounded, sans-serif" font-weight="700" font-size="13" fill="#2A2118">Violations</text>
+                        <rect x="20" y="160" width="78" height="22" rx="11" fill="#E8512B"/>
+                        <text x="59" y="176" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="700" font-size="11" fill="#FBF5EC">CRITICAL</text>
+                        <text x="108" y="176" font-family="ui-monospace, monospace" font-size="12" fill="#2A2118">color-contrast</text>
+                        <text x="240" y="176" font-family="ui-rounded, sans-serif" font-size="12" fill="#6B5B47">— foreground/background ratio &lt; 4.5</text>
+                        <rect x="20" y="194" width="78" height="22" rx="11" fill="#F5C24C"/>
+                        <text x="59" y="210" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="700" font-size="11" fill="#2A2118">SERIOUS</text>
+                        <text x="108" y="210" font-family="ui-monospace, monospace" font-size="12" fill="#2A2118">image-alt</text>
+                        <text x="200" y="210" font-family="ui-rounded, sans-serif" font-size="12" fill="#6B5B47">— image missing alternative text</text>
+                        <rect x="20" y="228" width="78" height="22" rx="11" fill="#6B5B47"/>
+                        <text x="59" y="244" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="700" font-size="11" fill="#FBF5EC">MODERATE</text>
+                        <text x="108" y="244" font-family="ui-monospace, monospace" font-size="12" fill="#2A2118">aria-required-attr</text>
+                        <text x="260" y="244" font-family="ui-rounded, sans-serif" font-size="12" fill="#6B5B47">— required ARIA attribute</text>
+                        <text x="20" y="284" font-family="ui-rounded, sans-serif" font-size="11" fill="#6B5B47">12 passes · 2 incomplete · 3 violations</text>
+                    </svg>
+                </div>
+
+                <!-- Lighthouse mock report -->
+                <div class="report report--lh">
+                    <svg viewBox="0 0 480 320" role="img" aria-labelledby="lhTitle" xmlns="http://www.w3.org/2000/svg">
+                        <title id="lhTitle">Lighthouse Core Web Vitals report mockup</title>
+                        <rect width="480" height="320" fill="#FFFFFF"/>
+                        <rect x="0" y="0" width="480" height="36" fill="#2A2118"/>
+                        <circle cx="16" cy="18" r="5" fill="#E8512B"/>
+                        <circle cx="32" cy="18" r="5" fill="#F5C24C"/>
+                        <circle cx="48" cy="18" r="5" fill="#2E8B6F"/>
+                        <text x="70" y="23" font-family="ui-monospace, monospace" font-size="12" fill="#FBF5EC">Lighthouse CI</text>
+                        <text x="20" y="72" font-family="ui-rounded, sans-serif" font-weight="800" font-size="20" fill="#2A2118">Core Web Vitals</text>
+                        <g transform="translate(40,100)">
+                            <circle cx="40" cy="40" r="36" fill="none" stroke="#FBF5EC" stroke-width="6"/>
+                            <circle cx="40" cy="40" r="36" fill="none" stroke="#2E8B6F" stroke-width="6" stroke-dasharray="221.7" stroke-dashoffset="4.5" transform="rotate(-90 40 40)"/>
+                            <text x="40" y="46" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="800" font-size="20" fill="#2A2118">98</text>
+                            <text x="40" y="100" text-anchor="middle" font-family="ui-rounded, sans-serif" font-size="11" fill="#6B5B47">Performance</text>
+                        </g>
+                        <g transform="translate(140,100)">
+                            <circle cx="40" cy="40" r="36" fill="none" stroke="#FBF5EC" stroke-width="6"/>
+                            <circle cx="40" cy="40" r="36" fill="none" stroke="#2E8B6F" stroke-width="6" stroke-dasharray="226.2" stroke-dashoffset="0" transform="rotate(-90 40 40)"/>
+                            <text x="40" y="46" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="800" font-size="20" fill="#2A2118">100</text>
+                            <text x="40" y="100" text-anchor="middle" font-family="ui-rounded, sans-serif" font-size="11" fill="#6B5B47">Accessibility</text>
+                        </g>
+                        <g transform="translate(240,100)">
+                            <circle cx="40" cy="40" r="36" fill="none" stroke="#FBF5EC" stroke-width="6"/>
+                            <circle cx="40" cy="40" r="36" fill="none" stroke="#2E8B6F" stroke-width="6" stroke-dasharray="226.2" stroke-dashoffset="0" transform="rotate(-90 40 40)"/>
+                            <text x="40" y="46" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="800" font-size="20" fill="#2A2118">100</text>
+                            <text x="40" y="100" text-anchor="middle" font-family="ui-rounded, sans-serif" font-size="11" fill="#6B5B47">Best Pract.</text>
+                        </g>
+                        <g transform="translate(340,100)">
+                            <circle cx="40" cy="40" r="36" fill="none" stroke="#FBF5EC" stroke-width="6"/>
+                            <circle cx="40" cy="40" r="36" fill="none" stroke="#2E8B6F" stroke-width="6" stroke-dasharray="226.2" stroke-dashoffset="0" transform="rotate(-90 40 40)"/>
+                            <text x="40" y="46" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="800" font-size="20" fill="#2A2118">100</text>
+                            <text x="40" y="100" text-anchor="middle" font-family="ui-rounded, sans-serif" font-size="11" fill="#6B5B47">SEO</text>
+                        </g>
+                        <g transform="translate(20,232)">
+                            <rect width="140" height="60" rx="10" fill="#FBF5EC" stroke="#2A2118" stroke-width="1.5"/>
+                            <circle cx="14" cy="14" r="5" fill="#2E8B6F"/>
+                            <text x="26" y="18" font-family="ui-monospace, monospace" font-size="11" fill="#6B5B47">LCP</text>
+                            <text x="14" y="44" font-family="ui-rounded, sans-serif" font-weight="800" font-size="18" fill="#2A2118">1.2 s</text>
+                        </g>
+                        <g transform="translate(170,232)">
+                            <rect width="140" height="60" rx="10" fill="#FBF5EC" stroke="#2A2118" stroke-width="1.5"/>
+                            <circle cx="14" cy="14" r="5" fill="#2E8B6F"/>
+                            <text x="26" y="18" font-family="ui-monospace, monospace" font-size="11" fill="#6B5B47">INP</text>
+                            <text x="14" y="44" font-family="ui-rounded, sans-serif" font-weight="800" font-size="18" fill="#2A2118">80 ms</text>
+                        </g>
+                        <g transform="translate(320,232)">
+                            <rect width="140" height="60" rx="10" fill="#FBF5EC" stroke="#2A2118" stroke-width="1.5"/>
+                            <circle cx="14" cy="14" r="5" fill="#2E8B6F"/>
+                            <text x="26" y="18" font-family="ui-monospace, monospace" font-size="11" fill="#6B5B47">CLS</text>
+                            <text x="14" y="44" font-family="ui-rounded, sans-serif" font-weight="800" font-size="18" fill="#2A2118">0.01</text>
+                        </g>
+                    </svg>
+                </div>
+
+                <!-- Trivy mock report -->
+                <div class="report report--trivy">
+                    <svg viewBox="0 0 480 320" role="img" aria-labelledby="trivyTitle" xmlns="http://www.w3.org/2000/svg">
+                        <title id="trivyTitle">Trivy vulnerability scan report mockup</title>
+                        <rect width="480" height="320" fill="#FFFFFF"/>
+                        <rect x="0" y="0" width="480" height="36" fill="#2A2118"/>
+                        <circle cx="16" cy="18" r="5" fill="#E8512B"/>
+                        <circle cx="32" cy="18" r="5" fill="#F5C24C"/>
+                        <circle cx="48" cy="18" r="5" fill="#2E8B6F"/>
+                        <text x="70" y="23" font-family="ui-monospace, monospace" font-size="12" fill="#FBF5EC">trivy fs .</text>
+                        <text x="20" y="72" font-family="ui-rounded, sans-serif" font-weight="800" font-size="20" fill="#2A2118">Vulnerability scan</text>
+                        <text x="20" y="92" font-family="ui-rounded, sans-serif" font-size="13" fill="#6B5B47">19 known issues across direct &amp; transitive deps</text>
+                        <g transform="translate(20,110)">
+                            <rect width="100" height="48" rx="10" fill="#FBF5EC" stroke="#2A2118" stroke-width="1.5"/>
+                            <text x="50" y="20" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="700" font-size="10" fill="#6B5B47">CRITICAL</text>
+                            <text x="50" y="40" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="800" font-size="18" fill="#2E8B6F">0</text>
+                        </g>
+                        <g transform="translate(130,110)">
+                            <rect width="100" height="48" rx="10" fill="#FBF5EC" stroke="#2A2118" stroke-width="1.5"/>
+                            <text x="50" y="20" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="700" font-size="10" fill="#6B5B47">HIGH</text>
+                            <text x="50" y="40" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="800" font-size="18" fill="#E8512B">2</text>
+                        </g>
+                        <g transform="translate(240,110)">
+                            <rect width="100" height="48" rx="10" fill="#FBF5EC" stroke="#2A2118" stroke-width="1.5"/>
+                            <text x="50" y="20" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="700" font-size="10" fill="#6B5B47">MEDIUM</text>
+                            <text x="50" y="40" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="800" font-size="18" fill="#F5C24C">5</text>
+                        </g>
+                        <g transform="translate(350,110)">
+                            <rect width="100" height="48" rx="10" fill="#FBF5EC" stroke="#2A2118" stroke-width="1.5"/>
+                            <text x="50" y="20" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="700" font-size="10" fill="#6B5B47">LOW</text>
+                            <text x="50" y="40" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="800" font-size="18" fill="#6B5B47">12</text>
+                        </g>
+                        <line x1="20" y1="180" x2="460" y2="180" stroke="#2A2118" stroke-width="1"/>
+                        <text x="20" y="200" font-family="ui-monospace, monospace" font-size="11" fill="#6B5B47">package</text>
+                        <text x="170" y="200" font-family="ui-monospace, monospace" font-size="11" fill="#6B5B47">version</text>
+                        <text x="260" y="200" font-family="ui-monospace, monospace" font-size="11" fill="#6B5B47">CVE</text>
+                        <text x="400" y="200" font-family="ui-monospace, monospace" font-size="11" fill="#6B5B47">sev</text>
+                        <text x="20" y="222" font-family="ui-monospace, monospace" font-size="12" fill="#2A2118">esbuild</text>
+                        <text x="170" y="222" font-family="ui-monospace, monospace" font-size="12" fill="#2A2118">0.21.5</text>
+                        <text x="260" y="222" font-family="ui-monospace, monospace" font-size="12" fill="#2A2118">CVE-2024-12345</text>
+                        <rect x="396" y="208" width="48" height="18" rx="9" fill="#E8512B"/>
+                        <text x="420" y="221" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="700" font-size="10" fill="#FBF5EC">HIGH</text>
+                        <text x="20" y="246" font-family="ui-monospace, monospace" font-size="12" fill="#2A2118">tar</text>
+                        <text x="170" y="246" font-family="ui-monospace, monospace" font-size="12" fill="#2A2118">6.2.0</text>
+                        <text x="260" y="246" font-family="ui-monospace, monospace" font-size="12" fill="#2A2118">CVE-2024-23456</text>
+                        <rect x="396" y="232" width="48" height="18" rx="9" fill="#F5C24C"/>
+                        <text x="420" y="245" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="700" font-size="10" fill="#2A2118">MED</text>
+                        <text x="20" y="270" font-family="ui-monospace, monospace" font-size="12" fill="#2A2118">semver</text>
+                        <text x="170" y="270" font-family="ui-monospace, monospace" font-size="12" fill="#2A2118">7.5.4</text>
+                        <text x="260" y="270" font-family="ui-monospace, monospace" font-size="12" fill="#2A2118">CVE-2024-34567</text>
+                        <rect x="396" y="256" width="48" height="18" rx="9" fill="#6B5B47"/>
+                        <text x="420" y="269" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="700" font-size="10" fill="#FBF5EC">LOW</text>
+                    </svg>
+                </div>
+
+                <!-- ZAP mock report -->
+                <div class="report report--zap">
+                    <svg viewBox="0 0 480 320" role="img" aria-labelledby="zapTitle" xmlns="http://www.w3.org/2000/svg">
+                        <title id="zapTitle">OWASP ZAP DAST summary report mockup</title>
+                        <rect width="480" height="320" fill="#FFFFFF"/>
+                        <rect x="0" y="0" width="480" height="36" fill="#2A2118"/>
+                        <circle cx="16" cy="18" r="5" fill="#E8512B"/>
+                        <circle cx="32" cy="18" r="5" fill="#F5C24C"/>
+                        <circle cx="48" cy="18" r="5" fill="#2E8B6F"/>
+                        <text x="70" y="23" font-family="ui-monospace, monospace" font-size="12" fill="#FBF5EC">OWASP ZAP — baseline</text>
+                        <text x="20" y="72" font-family="ui-rounded, sans-serif" font-weight="800" font-size="20" fill="#2A2118">DAST summary</text>
+                        <text x="20" y="92" font-family="ui-rounded, sans-serif" font-size="13" fill="#6B5B47">11 findings on https://preview.netlify.app</text>
+                        <g transform="translate(20,110)">
+                            <rect width="100" height="48" rx="10" fill="#FBF5EC" stroke="#2A2118" stroke-width="1.5"/>
+                            <text x="50" y="20" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="700" font-size="10" fill="#6B5B47">HIGH</text>
+                            <text x="50" y="40" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="800" font-size="18" fill="#2E8B6F">0</text>
+                        </g>
+                        <g transform="translate(130,110)">
+                            <rect width="100" height="48" rx="10" fill="#FBF5EC" stroke="#2A2118" stroke-width="1.5"/>
+                            <text x="50" y="20" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="700" font-size="10" fill="#6B5B47">MEDIUM</text>
+                            <text x="50" y="40" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="800" font-size="18" fill="#F5C24C">1</text>
+                        </g>
+                        <g transform="translate(240,110)">
+                            <rect width="100" height="48" rx="10" fill="#FBF5EC" stroke="#2A2118" stroke-width="1.5"/>
+                            <text x="50" y="20" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="700" font-size="10" fill="#6B5B47">LOW</text>
+                            <text x="50" y="40" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="800" font-size="18" fill="#6B5B47">3</text>
+                        </g>
+                        <g transform="translate(350,110)">
+                            <rect width="100" height="48" rx="10" fill="#FBF5EC" stroke="#2A2118" stroke-width="1.5"/>
+                            <text x="50" y="20" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="700" font-size="10" fill="#6B5B47">INFO</text>
+                            <text x="50" y="40" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="800" font-size="18" fill="#2A2118">7</text>
+                        </g>
+                        <line x1="20" y1="180" x2="460" y2="180" stroke="#2A2118" stroke-width="1"/>
+                        <text x="20" y="200" font-family="ui-rounded, sans-serif" font-weight="700" font-size="13" fill="#2A2118">Findings</text>
+                        <rect x="20" y="212" width="48" height="22" rx="11" fill="#F5C24C"/>
+                        <text x="44" y="228" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="700" font-size="11" fill="#2A2118">MED</text>
+                        <text x="78" y="228" font-family="ui-monospace, monospace" font-size="11" fill="#2A2118">GET / — CSP not enforced</text>
+                        <rect x="20" y="244" width="48" height="22" rx="11" fill="#6B5B47"/>
+                        <text x="44" y="260" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="700" font-size="11" fill="#FBF5EC">LOW</text>
+                        <text x="78" y="260" font-family="ui-monospace, monospace" font-size="11" fill="#2A2118">GET / — Cache-Control missing</text>
+                        <rect x="20" y="276" width="48" height="22" rx="11" fill="#2A2118"/>
+                        <text x="44" y="292" text-anchor="middle" font-family="ui-rounded, sans-serif" font-weight="700" font-size="11" fill="#FBF5EC">INFO</text>
+                        <text x="78" y="292" font-family="ui-monospace, monospace" font-size="11" fill="#2A2118">GET /robots.txt — not found</text>
+                    </svg>
+                </div>
+            </div>
+        </section>
+
+        <!-- ─── Development Loops ──────────────────────────────── -->
+        <section class="section loops">
+            <span class="kicker">Development loops</span>
+            <h2>Inner loop. Outer loop. <span class="highlight">Both fast.</span></h2>
+            <p class="lede">SlopStopper organises quality feedback into two loops that keep velocity high and quality consistent.</p>
+
             <div class="loop-diagram">
                 <h3>Inner Loop — Local</h3>
                 <p class="loop-desc">The fast, local cycle a developer (or AI agent) runs before pushing. Completes in seconds to minutes.</p>
                 <div class="loop-flow">
                     <div class="loop-step">✏️ Write Code<span class="step-sub">with AI</span></div>
-                    <div class="loop-arrow">→</div>
+                    <div class="arrow"><svg viewBox="0 0 40 24"><path d="M2 12 Q15 4, 28 14 L34 12" /><path d="M28 8 L34 12 L28 16" /></svg></div>
                     <div class="loop-step">🔨 Build &amp; Lint<span class="step-sub">locally</span></div>
-                    <div class="loop-arrow">→</div>
+                    <div class="arrow"><svg viewBox="0 0 40 24"><path d="M2 12 Q15 4, 28 14 L34 12" /><path d="M28 8 L34 12 L28 16" /></svg></div>
                     <div class="loop-step">🧪 Run Tests<span class="step-sub">locally</span></div>
-                    <div class="loop-arrow">→</div>
+                    <div class="arrow"><svg viewBox="0 0 40 24"><path d="M2 12 Q15 4, 28 14 L34 12" /><path d="M28 8 L34 12 L28 16" /></svg></div>
                     <div class="loop-step">📤 Commit &amp; Push<span class="step-sub">open PR</span></div>
                 </div>
                 <div class="loop-back">↩ iterate on feedback</div>
             </div>
+
             <div class="loop-diagram">
                 <h3>Outer Loop — CI/CD</h3>
                 <p class="loop-desc">Automated checks triggered on every push or PR. Deterministic feedback before code reaches production.</p>
                 <div class="loop-flow">
                     <div class="loop-step loop-step--trigger">📤 Push / PR</div>
-                    <div class="loop-arrow">→</div>
+                    <div class="arrow"><svg viewBox="0 0 40 24"><path d="M2 12 Q15 4, 28 14 L34 12" /><path d="M28 8 L34 12 L28 16" /></svg></div>
                     <div class="loop-step">🔒 Security<span class="step-sub">SAST · DAST · Secrets · CVEs</span></div>
-                    <div class="loop-arrow">→</div>
+                    <div class="arrow"><svg viewBox="0 0 40 24"><path d="M2 12 Q15 4, 28 14 L34 12" /><path d="M28 8 L34 12 L28 16" /></svg></div>
                     <div class="loop-step">🧹 Hygiene<span class="step-sub">Complexity · Docs</span></div>
-                    <div class="loop-arrow">→</div>
+                    <div class="arrow"><svg viewBox="0 0 40 24"><path d="M2 12 Q15 4, 28 14 L34 12" /><path d="M28 8 L34 12 L28 16" /></svg></div>
                     <div class="loop-step">✅ Reliability<span class="step-sub">E2E · Smoke · A11y · CWV</span></div>
-                    <div class="loop-arrow">→</div>
+                    <div class="arrow"><svg viewBox="0 0 40 24"><path d="M2 12 Q15 4, 28 14 L34 12" /><path d="M28 8 L34 12 L28 16" /></svg></div>
                     <div class="loop-step">🚀 Deploy<span class="step-sub">Preview URL</span></div>
-                    <div class="loop-arrow">→</div>
+                    <div class="arrow"><svg viewBox="0 0 40 24"><path d="M2 12 Q15 4, 28 14 L34 12" /><path d="M28 8 L34 12 L28 16" /></svg></div>
                     <div class="loop-step loop-step--feedback">💬 Feedback<span class="step-sub">to developer</span></div>
                 </div>
                 <div class="loop-back">↩ fix &amp; iterate</div>

--- a/app/index.css
+++ b/app/index.css
@@ -1,128 +1,17 @@
-* {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-}
-body {
-    min-height: 100vh;
-    font-family: Arial, sans-serif;
-    background: #1a1a2e;
-    color: #e0e0e0;
-}
-header {
-    background: #16213e;
-    padding: 1.2rem 2rem;
-    border-bottom: 2px solid #00d4aa;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-}
-.site-title {
-    font-size: 1.4rem;
-    color: #00d4aa;
-    font-weight: bold;
-    text-decoration: none;
-}
-nav a {
-    color: #e0e0e0;
-    text-decoration: none;
-    margin-left: 1.2rem;
-    padding: 0.4rem 1rem;
-    border-radius: 4px;
-    transition: background 0.2s;
-    display: inline-block;
-}
-nav a:hover {
-    background: rgba(0, 212, 170, 0.2);
-}
-nav a[aria-current="page"] {
-    background: rgba(0, 212, 170, 0.15);
-    color: #00d4aa;
-}
-.skip-link {
-    position: absolute;
-    left: -9999px;
-    top: 0;
-    background: #00d4aa;
-    color: #16213e;
-    padding: 0.6rem 1rem;
-    font-weight: bold;
-    text-decoration: none;
-    border-radius: 0 0 4px 0;
-    z-index: 100;
-}
-.skip-link:focus {
-    left: 0;
-    outline: 2px solid #16213e;
-    outline-offset: 2px;
-}
-footer {
-    margin-top: 4rem;
-    padding: 1.5rem 2rem;
-    border-top: 1px solid rgba(0, 212, 170, 0.25);
-    text-align: center;
-    font-size: 0.9rem;
-    opacity: 0.8;
-}
-footer a {
-    color: #00d4aa;
-}
-main {
-    max-width: 960px;
-    margin: 0 auto;
-    padding: 3rem 2rem;
-}
+/* index.html — page-specific styles */
+
 .hero {
-    text-align: center;
-    margin-bottom: 2.5rem;
+    padding-top: 1rem;
 }
-.hero h1 {
-    font-size: 3rem;
-    color: #00d4aa;
-    margin-bottom: 0.8rem;
+.hero .bubble {
+    margin-bottom: 1.5rem;
 }
-.hero p {
-    font-size: 1.2rem;
-    opacity: 0.8;
-}
-.about {
-    font-size: 1.05rem;
-    line-height: 1.7;
-    opacity: 0.85;
-    margin-bottom: 2rem;
-    text-align: center;
-    max-width: 720px;
-    margin-left: auto;
-    margin-right: auto;
-}
-.card-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1.5rem;
-}
-.card {
-    background: #16213e;
-    border: 1px solid rgba(0, 212, 170, 0.25);
-    border-radius: 8px;
-    padding: 1.5rem;
-}
-.card h2 {
-    color: #00d4aa;
-    font-size: 1.15rem;
-    margin-bottom: 0.8rem;
-}
-.card p {
-    font-size: 0.95rem;
-    line-height: 1.6;
-    opacity: 0.8;
-}
-.card-link {
-    display: inline-block;
-    margin-top: 1rem;
-    color: #00d4aa;
-    text-decoration: none;
-    font-size: 0.9rem;
-}
-.card-link:hover {
-    text-decoration: underline;
+
+@media (max-width: 600px) {
+    .mascot--hero {
+        width: 140px;
+    }
+    .cta-row .btn {
+        width: 100%;
+    }
 }

--- a/app/index.html
+++ b/app/index.html
@@ -3,17 +3,18 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="SlopStopper — a reference template for adding deterministic, automated quality feedback (security, hygiene, reliability, accessibility, performance) to any repo.">
-    <meta name="theme-color" content="#16213e">
+    <meta name="description" content="SlopStopper — a template for deterministic, automated quality feedback (security, hygiene, reliability, accessibility, performance) on any repo. Drop it in with one command.">
+    <meta name="theme-color" content="#FBF5EC">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="SlopStopper">
-    <meta property="og:description" content="Deterministic feedback for AI-driven development — keep your repo healthy at high velocity.">
+    <meta property="og:title" content="SlopStopper — stop the slop">
+    <meta property="og:description" content="A template for deterministic, automated quality feedback on any repo. Catch slop before it ships.">
     <meta property="og:site_name" content="SlopStopper">
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="SlopStopper">
-    <meta name="twitter:description" content="Deterministic feedback for AI-driven development — keep your repo healthy at high velocity.">
+    <meta name="twitter:title" content="SlopStopper — stop the slop">
+    <meta name="twitter:description" content="A template for deterministic, automated quality feedback on any repo. Catch slop before it ships.">
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <title>SlopStopper</title>
+    <link rel="stylesheet" href="shared.css">
     <link rel="stylesheet" href="index.css">
 </head>
 <body>
@@ -24,43 +25,108 @@
             <a href="index.html" id="nav-home" aria-current="page">Home</a>
             <a href="features.html" id="nav-features">Features</a>
             <a href="tools.html" id="nav-tools">Tools</a>
+            <a href="https://github.com/hungovercoders/slopstopper" class="btn btn--ghost btn--gh" rel="noopener noreferrer" aria-label="View SlopStopper on GitHub">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.33-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.11-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.06 0 0 .97-.31 3.18 1.18a11.1 11.1 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.77.12 3.06.74.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.4-5.25 5.68.41.35.78 1.05.78 2.12v3.14c0 .31.21.66.79.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z"/></svg>
+                GitHub
+            </a>
         </nav>
     </header>
     <main id="main">
-        <div class="hero">
-            <h1>SlopStopper</h1>
-            <p>Deterministic feedback for AI-driven development — keep your repo healthy at high velocity</p>
-        </div>
-        <section class="about">
-            <p>SlopStopper is a template and reference site demonstrating how to add deterministic, automated quality feedback to any repo. As AI-assisted development increases the pace of change, consistent automated checks keep code quality high without slowing teams down.</p>
+        <section class="hero">
+            <div class="mascot mascot--hero" aria-hidden="true">
+                <svg viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg">
+                    <ellipse cx="120" cy="225" rx="70" ry="6" fill="rgba(42,33,24,0.12)"/>
+                    <path d="M40 130 C40 75, 80 50, 120 50 C160 50, 200 75, 200 130 C200 180, 165 210, 120 210 C75 210, 40 180, 40 130 Z" fill="#FBF5EC" stroke="#2A2118" stroke-width="6" stroke-linejoin="round"/>
+                    <rect x="92" y="58" width="22" height="8" rx="2" fill="#F5C24C" stroke="#2A2118" stroke-width="2.5"/>
+                    <line x1="98" y1="58" x2="98" y2="66" stroke="#2A2118" stroke-width="2"/>
+                    <line x1="108" y1="58" x2="108" y2="66" stroke="#2A2118" stroke-width="2"/>
+                    <circle cx="92" cy="130" r="13" fill="#2A2118"/>
+                    <circle cx="148" cy="130" r="13" fill="#2A2118"/>
+                    <circle cx="96" cy="125" r="4" fill="#FBF5EC"/>
+                    <circle cx="152" cy="125" r="4" fill="#FBF5EC"/>
+                    <path d="M100 165 Q120 182, 140 165" stroke="#2A2118" stroke-width="5" stroke-linecap="round" fill="none"/>
+                    <rect x="116" y="158" width="6" height="10" rx="1" fill="#FBF5EC" stroke="#2A2118" stroke-width="2"/>
+                    <circle cx="180" cy="155" r="8" fill="#FBF5EC" stroke="#2A2118" stroke-width="4"/>
+                    <circle cx="60" cy="155" r="8" fill="#FBF5EC" stroke="#2A2118" stroke-width="4"/>
+                    <polygon points="178,90 218,90 232,118 218,146 178,146 164,118" fill="#E8512B" stroke="#2A2118" stroke-width="5" stroke-linejoin="round"/>
+                    <text x="198" y="124" text-anchor="middle" font-family="ui-rounded, system-ui, sans-serif" font-weight="800" font-size="18" fill="#FBF5EC">SLOP</text>
+                </svg>
+            </div>
+            <div class="bubble">Catch slop before it ships.</div>
+            <h1>Stop the <span class="highlight">slop.</span></h1>
+            <p>Deterministic, automated feedback for AI-driven development — keep your repo healthy while you ship fast.</p>
+            <div class="cta-row">
+                <a href="#get-started" class="btn btn--primary">Get started →</a>
+                <a href="features.html" class="btn btn--ghost">See features</a>
+            </div>
         </section>
-        <div class="card-grid">
-            <div class="card">
-                <h2>🔒 Security</h2>
-                <p>Static analysis, dynamic scanning, secrets detection and dependency vulnerability checks run on every change.</p>
-                <a href="features.html" class="card-link">View practices →</a>
+
+        <section class="about">
+            <p>SlopStopper is a template and reference site demonstrating how to add deterministic, automated quality feedback to any repo. As AI-assisted development accelerates the pace of change, consistent automated checks keep code quality high without slowing teams down.</p>
+        </section>
+
+        <section class="section" id="get-started">
+            <span class="kicker">Get started</span>
+            <h2>One command. Whole pipeline.</h2>
+            <p class="lede">Drop SlopStopper into your repo and you get the full bundle: security, hygiene, reliability, accessibility, performance and deployment checks — all running on every PR.</p>
+            <div class="codeblock codeblock--sh" role="region" aria-label="Install command">
+                <pre><code>curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install.sh | bash</code></pre>
             </div>
-            <div class="card">
-                <h2>🧹 Hygiene</h2>
-                <p>Complexity limits, documentation structure and accuracy checks keep the codebase clean and well-documented.</p>
-                <a href="features.html" class="card-link">View practices →</a>
+            <details class="details">
+                <summary>What does this do?</summary>
+                <div class="details__body">
+                    <p>The installer clones the SlopStopper template into your current repo and copies in the GitHub Actions workflows, the <code>.scripts/</code> helpers, the <code>Taskfile.yml</code> and the documentation scaffold. It's idempotent — re-run any time to pull in new checks.</p>
+                    <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/install.sh" rel="noopener noreferrer">View install.sh on GitHub →</a>
+                </div>
+            </details>
+            <div class="steps">
+                <div class="step">
+                    <h3>Install</h3>
+                    <p>Run the one-liner from inside your repo. Workflows and scripts copy in.</p>
+                </div>
+                <div class="step">
+                    <h3>Customise</h3>
+                    <p>Tune complexity thresholds, accessibility impact level and Lighthouse budgets to suit.</p>
+                </div>
+                <div class="step">
+                    <h3>Open a PR</h3>
+                    <p>Push to a branch. Watch every check run automatically. Stop slop at the door.</p>
+                </div>
             </div>
-            <div class="card">
-                <h2>✅ Reliability</h2>
-                <p>End-to-end, smoke, accessibility and Core Web Vitals checks verify every deploy works correctly for every user.</p>
-                <a href="features.html" class="card-link">View practices →</a>
+        </section>
+
+        <section class="section">
+            <span class="kicker">What you get</span>
+            <h2>Five loops of feedback.</h2>
+            <p class="lede">Every category below maps to real GitHub Actions workflows. Click through to see exactly what runs.</p>
+            <div class="card-grid">
+                <div class="card">
+                    <h2>🔒 Security</h2>
+                    <p>Static analysis, dynamic scanning, secrets detection and dependency vulnerability checks run on every change.</p>
+                    <a href="features.html#security" class="card-link">View practices →</a>
+                </div>
+                <div class="card">
+                    <h2>🧹 Hygiene</h2>
+                    <p>Complexity limits, documentation structure and accuracy checks keep the codebase clean and well-documented.</p>
+                    <a href="features.html#hygiene" class="card-link">View practices →</a>
+                </div>
+                <div class="card">
+                    <h2>✅ Reliability</h2>
+                    <p>End-to-end, smoke, accessibility and Core Web Vitals checks verify every deploy works correctly for every user.</p>
+                    <a href="features.html#reliability" class="card-link">View practices →</a>
+                </div>
+                <div class="card">
+                    <h2>🤖 Operational</h2>
+                    <p>Auto-labelled PRs, an agentic doc updater and automatic failure alerts keep day-to-day workflow on autopilot.</p>
+                    <a href="features.html#operational" class="card-link">View practices →</a>
+                </div>
+                <div class="card">
+                    <h2>🚀 Deployment</h2>
+                    <p>Preview deployments on every pull request plus automated production releases ensure fast, safe shipping.</p>
+                    <a href="features.html#deployment" class="card-link">View practices →</a>
+                </div>
             </div>
-            <div class="card">
-                <h2>🤖 Operational</h2>
-                <p>Auto-labelled PRs, an agentic doc updater and automatic failure alerts keep day-to-day workflow on autopilot.</p>
-                <a href="features.html" class="card-link">View practices →</a>
-            </div>
-            <div class="card">
-                <h2>🚀 Deployment</h2>
-                <p>Preview deployments on every pull request plus automated production releases ensure fast, safe shipping.</p>
-                <a href="features.html" class="card-link">View practices →</a>
-            </div>
-        </div>
+        </section>
     </main>
     <footer>
         <p>SlopStopper is open source — <a href="https://github.com/hungovercoders/slopstopper" rel="noopener noreferrer">view the repository on GitHub</a>.</p>

--- a/app/shared.css
+++ b/app/shared.css
@@ -383,6 +383,37 @@ main {
     font-size: 0.88rem;
     font-weight: 700;
 }
+.live-links {
+    margin-top: 0.8rem;
+    padding-top: 0.7rem;
+    border-top: 1px dashed rgba(42, 33, 24, 0.2);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+}
+.live-links__label {
+    font-size: 0.82rem;
+    font-weight: 700;
+    color: var(--ink-soft);
+}
+.live-links a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    background: var(--paper);
+    border: var(--border-thin);
+    border-radius: var(--r-pill);
+    padding: 0.25rem 0.7rem;
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-decoration: none;
+    color: var(--ink);
+}
+.live-links a:hover {
+    background: var(--peach-soft);
+    color: var(--ink);
+}
 
 /* ─── Mascot ─────────────────────────────────────────────── */
 .mascot {

--- a/app/shared.css
+++ b/app/shared.css
@@ -1,0 +1,600 @@
+/* SlopStopper shared styles — indie playful rebrand */
+
+:root {
+    --cream: #FBF5EC;
+    --peach: #FFD9B8;
+    --peach-soft: #FFE9D4;
+    --ink: #2A2118;
+    --ink-soft: #6B5B47;
+    --accent: #E8512B;
+    --accent-deep: #B33A1A;
+    --mint: #2E8B6F;
+    --sun: #F5C24C;
+    --paper: #FFFFFF;
+
+    --font-sans: ui-rounded, "SF Pro Rounded", "Hiragino Maru Gothic ProN", "Quicksand", system-ui, -apple-system, "Segoe UI Variable", "Segoe UI", sans-serif;
+    --font-mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+
+    --r-sm: 6px;
+    --r-md: 14px;
+    --r-lg: 22px;
+    --r-pill: 999px;
+
+    --shadow-sticker: 4px 4px 0 var(--ink);
+    --shadow-sticker-sm: 2px 2px 0 var(--ink);
+    --shadow-soft: 0 2px 6px rgba(42, 33, 24, 0.08);
+
+    --border: 2px solid var(--ink);
+    --border-thin: 1.5px solid var(--ink);
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    min-height: 100vh;
+    font-family: var(--font-sans);
+    font-size: 1.0625rem;
+    line-height: 1.6;
+    color: var(--ink);
+    background:
+        radial-gradient(circle at 12% 8%, var(--peach-soft) 0, transparent 35%),
+        radial-gradient(circle at 88% 92%, var(--peach-soft) 0, transparent 40%),
+        var(--cream);
+    background-attachment: fixed;
+}
+
+a {
+    color: var(--accent-deep);
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 3px;
+}
+
+a:hover {
+    color: var(--accent);
+}
+
+/* ─── Skip link ─────────────────────────────────────────── */
+.skip-link {
+    position: absolute;
+    left: -9999px;
+    top: 0;
+    background: var(--accent-deep);
+    color: var(--paper);
+    padding: 0.6rem 1rem;
+    font-weight: 700;
+    text-decoration: none;
+    border-radius: 0 0 var(--r-sm) 0;
+    z-index: 100;
+}
+.skip-link:focus {
+    left: 0;
+    outline: 3px solid var(--ink);
+    outline-offset: 2px;
+}
+
+/* ─── Header ─────────────────────────────────────────────── */
+header {
+    background: var(--paper);
+    border-bottom: var(--border);
+    padding: 1rem 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.site-title {
+    font-size: 1.4rem;
+    font-weight: 800;
+    color: var(--ink);
+    text-decoration: none;
+    letter-spacing: -0.01em;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.site-title::before {
+    content: "";
+    display: inline-block;
+    width: 22px;
+    height: 22px;
+    background: var(--accent);
+    border: var(--border);
+    border-radius: var(--r-sm);
+    transform: rotate(-6deg);
+    box-shadow: var(--shadow-sticker-sm);
+}
+
+nav {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+nav a {
+    color: var(--ink);
+    text-decoration: none;
+    padding: 0.45rem 0.9rem;
+    border-radius: var(--r-pill);
+    font-weight: 600;
+    transition: background 0.15s;
+}
+nav a:hover {
+    background: var(--peach);
+    color: var(--ink);
+}
+nav a[aria-current="page"] {
+    background: var(--ink);
+    color: var(--cream);
+}
+
+/* GitHub button in header */
+.btn--gh {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-left: 0.5rem;
+}
+
+/* ─── Main ───────────────────────────────────────────────── */
+main {
+    max-width: 1040px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem;
+}
+
+/* ─── Hero ───────────────────────────────────────────────── */
+.hero {
+    text-align: center;
+    margin-bottom: 3rem;
+}
+
+.hero h1 {
+    font-size: clamp(2.25rem, 5vw, 3.5rem);
+    font-weight: 800;
+    line-height: 1.05;
+    letter-spacing: -0.02em;
+    margin-bottom: 1rem;
+}
+
+.hero p {
+    font-size: 1.2rem;
+    color: var(--ink-soft);
+    max-width: 640px;
+    margin: 0 auto;
+}
+
+.highlight {
+    background-image: linear-gradient(180deg, transparent 60%, var(--sun) 60%, var(--sun) 88%, transparent 88%);
+    padding: 0 0.15em;
+}
+
+.kicker {
+    display: inline-block;
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--ink);
+    background: var(--peach);
+    border: var(--border-thin);
+    border-radius: var(--r-pill);
+    padding: 0.25rem 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+/* ─── Buttons ────────────────────────────────────────────── */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    padding: 0.7rem 1.1rem;
+    border: var(--border);
+    border-radius: var(--r-pill);
+    font-family: inherit;
+    font-size: 1rem;
+    font-weight: 700;
+    text-decoration: none;
+    cursor: pointer;
+    transition: transform 0.1s ease-out, box-shadow 0.1s ease-out;
+    background: var(--paper);
+    color: var(--ink);
+    box-shadow: var(--shadow-sticker-sm);
+}
+.btn:hover {
+    transform: translate(-1px, -1px);
+    box-shadow: 3px 3px 0 var(--ink);
+}
+.btn:active {
+    transform: translate(1px, 1px);
+    box-shadow: 1px 1px 0 var(--ink);
+}
+.btn--primary {
+    background: var(--accent-deep);
+    color: var(--paper);
+}
+.btn--primary:hover {
+    background: var(--accent-deep);
+    color: var(--paper);
+    filter: brightness(0.92);
+}
+.btn--ghost {
+    background: transparent;
+}
+
+/* ─── Card grid + sticker cards ──────────────────────────── */
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.card {
+    background: var(--paper);
+    border: var(--border);
+    border-radius: var(--r-lg);
+    padding: 1.5rem;
+    box-shadow: var(--shadow-sticker);
+    transition: transform 0.15s ease-out, box-shadow 0.15s ease-out;
+}
+.card-grid > .card:nth-child(odd) {
+    transform: rotate(-0.6deg);
+}
+.card-grid > .card:nth-child(even) {
+    transform: rotate(0.6deg);
+}
+.card:hover {
+    transform: rotate(0) translate(-1px, -1px);
+    box-shadow: 5px 5px 0 var(--ink);
+}
+
+.card h2 {
+    font-size: 1.2rem;
+    font-weight: 800;
+    margin-bottom: 0.6rem;
+    color: var(--ink);
+}
+.card p {
+    color: var(--ink-soft);
+    font-size: 0.98rem;
+}
+.card ul {
+    list-style: none;
+    padding: 0;
+    margin-top: 0.5rem;
+}
+.card ul > li {
+    padding: 0.55rem 0;
+    border-bottom: 1px dashed rgba(42, 33, 24, 0.15);
+    font-size: 0.95rem;
+    color: var(--ink-soft);
+}
+.card ul > li:last-child {
+    border-bottom: none;
+}
+.card ul > li strong {
+    color: var(--ink);
+}
+.card-link {
+    display: inline-block;
+    margin-top: 1rem;
+    color: var(--accent-deep);
+    font-weight: 700;
+    font-size: 0.95rem;
+}
+
+/* ─── Codeblock ──────────────────────────────────────────── */
+.codeblock {
+    background: var(--ink);
+    color: var(--cream);
+    border: var(--border);
+    border-radius: var(--r-md);
+    padding: 1.1rem 1.25rem;
+    font-family: var(--font-mono);
+    font-size: 0.95rem;
+    line-height: 1.5;
+    overflow-x: auto;
+    box-shadow: var(--shadow-sticker);
+    position: relative;
+}
+.codeblock--sh::before {
+    content: "$ ";
+    color: var(--sun);
+    user-select: none;
+}
+.codeblock pre {
+    margin: 0;
+    white-space: pre;
+    font-family: inherit;
+    font-size: inherit;
+    color: inherit;
+}
+.codeblock--yaml {
+    background: var(--paper);
+    color: var(--ink);
+    font-size: 0.85rem;
+}
+.codeblock--yaml::before {
+    content: none;
+}
+
+/* ─── Details (no JS, custom marker) ─────────────────────── */
+.details {
+    border: var(--border-thin);
+    border-radius: var(--r-md);
+    background: var(--cream);
+    padding: 0;
+    margin-top: 0.6rem;
+}
+.details > summary {
+    cursor: pointer;
+    padding: 0.6rem 0.9rem;
+    font-weight: 700;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--ink);
+}
+.details > summary::-webkit-details-marker {
+    display: none;
+}
+.details > summary::before {
+    content: "+";
+    display: inline-block;
+    width: 1.1rem;
+    height: 1.1rem;
+    line-height: 1.1rem;
+    text-align: center;
+    border: var(--border-thin);
+    border-radius: var(--r-sm);
+    background: var(--paper);
+    font-weight: 800;
+    font-size: 0.9rem;
+}
+.details[open] > summary::before {
+    content: "−";
+    background: var(--accent);
+    color: var(--paper);
+    border-color: var(--accent-deep);
+}
+.details > .details__body {
+    padding: 0 0.9rem 0.9rem 0.9rem;
+    border-top: 1px dashed rgba(42, 33, 24, 0.2);
+    padding-top: 0.7rem;
+    margin-top: 0.3rem;
+}
+.details__source {
+    display: inline-block;
+    margin-top: 0.7rem;
+    font-size: 0.88rem;
+    font-weight: 700;
+}
+
+/* ─── Mascot ─────────────────────────────────────────────── */
+.mascot {
+    display: inline-block;
+}
+.mascot svg {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+.mascot--hero {
+    width: 180px;
+    transform: rotate(-3deg);
+    margin: 0 auto 1.5rem auto;
+}
+.mascot--peek {
+    width: 96px;
+    margin-bottom: -1.2rem;
+    margin-left: 1rem;
+    transform: rotate(-6deg);
+}
+.mascot--wave {
+    width: 56px;
+    vertical-align: middle;
+    transform: rotate(6deg);
+}
+
+/* ─── Speech bubble ──────────────────────────────────────── */
+.bubble {
+    display: inline-block;
+    position: relative;
+    background: var(--paper);
+    border: var(--border);
+    border-radius: var(--r-lg);
+    padding: 0.6rem 1rem;
+    font-weight: 700;
+    font-size: 1rem;
+    box-shadow: var(--shadow-sticker-sm);
+    transform: rotate(1.5deg);
+    margin-bottom: 0.5rem;
+}
+.bubble::after {
+    content: "";
+    position: absolute;
+    left: 30px;
+    bottom: -10px;
+    width: 0;
+    height: 0;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    border-top: 12px solid var(--ink);
+}
+.bubble::before {
+    content: "";
+    position: absolute;
+    left: 33px;
+    bottom: -6px;
+    width: 0;
+    height: 0;
+    border-left: 7px solid transparent;
+    border-right: 7px solid transparent;
+    border-top: 9px solid var(--paper);
+    z-index: 1;
+}
+
+/* ─── Footer ─────────────────────────────────────────────── */
+footer {
+    margin-top: 5rem;
+    padding: 2rem;
+    border-top: var(--border);
+    text-align: center;
+    color: var(--ink-soft);
+    background: var(--paper);
+}
+footer a {
+    color: var(--accent-deep);
+    font-weight: 700;
+}
+
+/* ─── Steps ─────────────────────────────────────────────── */
+.steps {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+    margin-top: 1.5rem;
+    counter-reset: step;
+}
+.step {
+    background: var(--peach-soft);
+    border: var(--border-thin);
+    border-radius: var(--r-md);
+    padding: 1rem 1.1rem;
+    position: relative;
+    counter-increment: step;
+}
+.step::before {
+    content: counter(step);
+    position: absolute;
+    top: -0.7rem;
+    left: -0.7rem;
+    width: 1.8rem;
+    height: 1.8rem;
+    background: var(--ink);
+    color: var(--cream);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 800;
+    font-size: 0.9rem;
+}
+.step h3 {
+    font-size: 1rem;
+    font-weight: 800;
+    margin-bottom: 0.3rem;
+}
+.step p {
+    font-size: 0.92rem;
+    color: var(--ink-soft);
+}
+
+/* ─── Sections ───────────────────────────────────────────── */
+.section {
+    margin-top: 4rem;
+}
+.section h2 {
+    font-size: clamp(1.5rem, 3vw, 2rem);
+    font-weight: 800;
+    margin-bottom: 0.5rem;
+    line-height: 1.15;
+}
+.section > p.lede {
+    color: var(--ink-soft);
+    margin-bottom: 1.5rem;
+    max-width: 680px;
+}
+
+.about {
+    background: var(--paper);
+    border: var(--border);
+    border-radius: var(--r-md);
+    padding: 1.5rem;
+    color: var(--ink-soft);
+    text-align: center;
+    max-width: 760px;
+    margin: 0 auto 3rem auto;
+    box-shadow: var(--shadow-sticker);
+}
+
+/* ─── Mock report cards ──────────────────────────────────── */
+.reports-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+    gap: 1.5rem;
+    margin-top: 1.5rem;
+}
+.report {
+    background: var(--paper);
+    border: var(--border);
+    border-radius: var(--r-md);
+    box-shadow: var(--shadow-sticker);
+    overflow: hidden;
+}
+.report svg {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
+/* ─── Arrows ─────────────────────────────────────────────── */
+.arrow {
+    color: var(--accent);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+.arrow svg {
+    width: 36px;
+    height: 22px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+/* ─── CTA row ────────────────────────────────────────────── */
+.cta-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.8rem;
+    justify-content: center;
+    margin-top: 1.5rem;
+}
+
+/* ─── Reduced motion ─────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+    .card-grid > .card,
+    .card-grid > .card:nth-child(odd),
+    .card-grid > .card:nth-child(even),
+    .bubble,
+    .mascot--hero,
+    .mascot--peek,
+    .mascot--wave,
+    .site-title::before {
+        transform: none;
+    }
+    .btn:hover,
+    .card:hover {
+        transform: none;
+    }
+    html {
+        scroll-behavior: auto;
+    }
+}

--- a/app/tools.css
+++ b/app/tools.css
@@ -1,108 +1,16 @@
-* {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-}
-body {
-    min-height: 100vh;
-    font-family: Arial, sans-serif;
-    background: #1a1a2e;
-    color: #e0e0e0;
-}
-header {
-    background: #16213e;
-    padding: 1.2rem 2rem;
-    border-bottom: 2px solid #00d4aa;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-}
-.site-title {
-    font-size: 1.4rem;
-    color: #00d4aa;
-    font-weight: bold;
-    text-decoration: none;
-}
-nav a {
-    color: #e0e0e0;
-    text-decoration: none;
-    margin-left: 1.2rem;
-    padding: 0.4rem 1rem;
-    border-radius: 4px;
-    transition: background 0.2s;
-    display: inline-block;
-}
-nav a:hover {
-    background: rgba(0, 212, 170, 0.2);
-}
-nav a[aria-current="page"] {
-    background: rgba(0, 212, 170, 0.15);
-    color: #00d4aa;
-}
-.skip-link {
-    position: absolute;
-    left: -9999px;
-    top: 0;
-    background: #00d4aa;
-    color: #16213e;
-    padding: 0.6rem 1rem;
-    font-weight: bold;
-    text-decoration: none;
-    border-radius: 0 0 4px 0;
-    z-index: 100;
-}
-.skip-link:focus {
-    left: 0;
-    outline: 2px solid #16213e;
-    outline-offset: 2px;
-}
-footer {
-    margin-top: 4rem;
-    padding: 1.5rem 2rem;
-    border-top: 1px solid rgba(0, 212, 170, 0.25);
-    text-align: center;
-    font-size: 0.9rem;
-    opacity: 0.8;
-}
-footer a {
-    color: #00d4aa;
-}
+/* tools.html — page-specific styles */
+
 main {
-    max-width: 960px;
-    margin: 0 auto;
-    padding: 3rem 2rem;
+    max-width: 1100px;
 }
-.hero {
-    text-align: center;
-    margin-bottom: 2.5rem;
-}
-.hero h1 {
-    font-size: 3rem;
-    color: #00d4aa;
-    margin-bottom: 0.8rem;
-}
-.hero p {
-    font-size: 1.2rem;
-    opacity: 0.8;
-}
+
 .card-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
-.card {
-    background: #16213e;
-    border: 1px solid rgba(0, 212, 170, 0.25);
-    border-radius: 8px;
-    padding: 1.5rem;
-}
-.card h2 {
-    color: #00d4aa;
-    font-size: 1.15rem;
-    margin-bottom: 0.8rem;
-}
-.card p {
-    font-size: 0.95rem;
-    line-height: 1.6;
-    opacity: 0.8;
+
+footer .mascot--wave {
+    display: inline-block;
+    width: 40px;
+    vertical-align: middle;
+    margin-right: 0.4rem;
 }

--- a/app/tools.html
+++ b/app/tools.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="The technology stack powering SlopStopper: GitHub Actions, Task, Playwright, TypeScript, Semgrep, ZAP, Trivy, Gitleaks, axe-core, Lighthouse CI and more.">
-    <meta name="theme-color" content="#16213e">
+    <meta name="description" content="The technology stack powering SlopStopper: GitHub Actions, Task, Playwright, TypeScript, Semgrep, ZAP, Trivy, Gitleaks, axe-core, Lighthouse CI and more. Each card links back to its source.">
+    <meta name="theme-color" content="#FBF5EC">
     <meta property="og:type" content="website">
     <meta property="og:title" content="SlopStopper — Tools">
     <meta property="og:description" content="The technology stack powering SlopStopper's automated feedback.">
@@ -14,6 +14,7 @@
     <meta name="twitter:description" content="The technology stack powering SlopStopper's automated feedback.">
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <title>Tools</title>
+    <link rel="stylesheet" href="shared.css">
     <link rel="stylesheet" href="tools.css">
 </head>
 <body>
@@ -24,74 +25,283 @@
             <a href="index.html" id="nav-home">Home</a>
             <a href="features.html" id="nav-features">Features</a>
             <a href="tools.html" id="nav-tools" aria-current="page">Tools</a>
+            <a href="https://github.com/hungovercoders/slopstopper" class="btn btn--ghost btn--gh" rel="noopener noreferrer" aria-label="View SlopStopper on GitHub">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.33-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.11-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.06 0 0 .97-.31 3.18 1.18a11.1 11.1 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.77.12 3.06.74.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.4-5.25 5.68.41.35.78 1.05.78 2.12v3.14c0 .31.21.66.79.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z"/></svg>
+                GitHub
+            </a>
         </nav>
     </header>
     <main id="main">
-        <div class="hero">
-            <h1>Tools</h1>
-            <p>The technology stack powering SlopStopper's automated feedback</p>
-        </div>
+        <section class="hero">
+            <span class="kicker">Tools</span>
+            <h1>The kit behind <span class="highlight">the loops.</span></h1>
+            <p>Every tool here drives one of the checks on the Features page. Open any card to see how it's wired in.</p>
+        </section>
+
         <div class="card-grid">
             <div class="card">
                 <h2>⚙️ GitHub Actions</h2>
                 <p>All checks run as GitHub Actions workflows triggered on every pull request and push to main — security, hygiene, reliability, accessibility, performance and deployment in one pipeline.</p>
+                <details class="details">
+                    <summary>See it in action</summary>
+                    <div class="details__body">
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/tree/main/.github/workflows" rel="noopener noreferrer">View all workflows on GitHub →</a>
+                        <br>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/actions" rel="noopener noreferrer">View live runs →</a>
+                    </div>
+                </details>
             </div>
+
             <div class="card">
                 <h2>📋 Task</h2>
                 <p>A Taskfile.yml defines the single source of truth for build, test, lint and scan commands so developers, AI agents and CI all run the same thing.</p>
+                <details class="details">
+                    <summary>Taskfile excerpt</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>version: '3'
+tasks:
+  build:    { cmds: ['npm run build'] }
+  start:    { cmds: ['node server.js'] }
+  test:     { cmds: ['npx playwright test'] }
+  reliability:accessibility:
+    cmds: ['npx playwright test tests/accessibility.spec.ts']</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/Taskfile.yml" rel="noopener noreferrer">View Taskfile.yml →</a>
+                    </div>
+                </details>
             </div>
+
             <div class="card">
                 <h2>🎭 Playwright</h2>
                 <p>End-to-end and smoke tests written in TypeScript using Playwright, covering navigation, page load reliability, and critical user journeys.</p>
+                <details class="details">
+                    <summary>playwright.config.js</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>export default defineConfig({
+  testDir: './tests',
+  use: { baseURL: 'http://localhost:8080' },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } }
+  ],
+});</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/playwright.config.js" rel="noopener noreferrer">View playwright.config.js →</a>
+                        <br>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/playwright-tests.yml" rel="noopener noreferrer">View workflow →</a>
+                    </div>
+                </details>
             </div>
+
             <div class="card">
                 <h2>🔷 TypeScript</h2>
                 <p>All application and test code is written in TypeScript for static type safety, reducing a whole class of bugs before code is even run.</p>
+                <details class="details">
+                    <summary>tsconfig.json</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "outDir": "./dist"
+  }
+}</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/tsconfig.json" rel="noopener noreferrer">View tsconfig.json →</a>
+                    </div>
+                </details>
             </div>
+
             <div class="card">
                 <h2>🐍 Python</h2>
                 <p>Reporting scripts that generate structured JSON reports for security, complexity, documentation and dependency checks used across CI workflows.</p>
+                <details class="details">
+                    <summary>See the scripts</summary>
+                    <div class="details__body">
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/tree/main/.scripts" rel="noopener noreferrer">View .scripts/ on GitHub →</a>
+                    </div>
+                </details>
             </div>
+
             <div class="card">
                 <h2>🟢 Netlify</h2>
                 <p>Continuous deployment to Netlify with preview URLs on every PR and automated production releases on merge to main.</p>
+                <details class="details">
+                    <summary>netlify.toml</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>[build]
+  publish = "app"
+  command = "npm run build"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Content-Security-Policy = "default-src 'self'; ..."</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/netlify.toml" rel="noopener noreferrer">View netlify.toml →</a>
+                        <br>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/netlify-deploy.yml" rel="noopener noreferrer">View deploy workflow →</a>
+                    </div>
+                </details>
             </div>
+
             <div class="card">
                 <h2>🔍 Semgrep</h2>
                 <p>Fast static application security testing (SAST). Scans source code for vulnerability patterns and OWASP-style issues before code is merged.</p>
+                <details class="details">
+                    <summary>Workflow excerpt</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>jobs:
+  sast:
+    name: Static Application Security Testing with Semgrep
+    steps:
+      - uses: actions/checkout@v4
+      - run: pip install semgrep &amp;&amp; semgrep ci</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/security-sast-check.yml" rel="noopener noreferrer">View source →</a>
+                    </div>
+                </details>
             </div>
+
             <div class="card">
                 <h2>🕷️ OWASP ZAP</h2>
                 <p>Dynamic application security testing (DAST). Probes a running deployment for common web vulnerabilities such as XSS, injection and insecure headers.</p>
+                <details class="details">
+                    <summary>Workflow excerpt</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>jobs:
+  dast:
+    name: Dynamic Application Security Testing with OWASP ZAP
+    steps:
+      - run: task start &amp;
+      - uses: zaproxy/action-baseline@v0.10.0</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/security-dast-check.yml" rel="noopener noreferrer">View source →</a>
+                    </div>
+                </details>
             </div>
+
             <div class="card">
                 <h2>🛡️ Trivy</h2>
                 <p>Scans project dependencies for known CVEs on every pull request and push, with severity-based gating to prevent vulnerable packages from reaching production.</p>
+                <details class="details">
+                    <summary>Workflow excerpt</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>jobs:
+  dependencies:
+    name: Scan Dependencies with Trivy
+    steps:
+      - uses: actions/checkout@v4
+      - run: trivy fs --severity HIGH,CRITICAL .</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/security-vulnerability-all-check.yml" rel="noopener noreferrer">View source →</a>
+                    </div>
+                </details>
             </div>
+
             <div class="card">
                 <h2>🔑 Gitleaks</h2>
                 <p>Inspects every commit for accidentally committed credentials, tokens and other secrets, blocking pull requests when high-confidence matches are found.</p>
+                <details class="details">
+                    <summary>Workflow excerpt</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>jobs:
+  secrets:
+    name: Detect Secrets with Gitleaks
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: gitleaks/gitleaks-action@v2</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/security-secrets-check.yml" rel="noopener noreferrer">View source →</a>
+                    </div>
+                </details>
             </div>
+
             <div class="card">
                 <h2>🐛 Bandit &amp; Lizard</h2>
                 <p>Bandit performs Python-focused security analysis and Lizard enforces cyclomatic complexity limits so code stays auditable and maintainable.</p>
+                <details class="details">
+                    <summary>Workflow excerpt</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>jobs:
+  complexity-check:
+    name: Check Code Complexity with Lizard
+    steps:
+      - run: pip install lizard bandit
+      - run: lizard -C 10 -L 60 .
+      - run: bandit -r .scripts/</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/hygiene-complexity-check.yml" rel="noopener noreferrer">View source →</a>
+                    </div>
+                </details>
             </div>
+
             <div class="card">
                 <h2>♿ axe-core</h2>
                 <p>Industry-standard accessibility engine, run via Playwright on every page to flag WCAG 2.1 AA violations on PRs, after deploys and on a daily schedule.</p>
+                <details class="details">
+                    <summary>Workflow excerpt</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>name: Accessibility Check
+on:
+  pull_request:      { branches: [main] }
+  push:              { branches: [main] }
+  deployment_status:
+  schedule: [ { cron: '0 6 * * *' } ]    # daily</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/reliability-accessibility-check.yml" rel="noopener noreferrer">View source →</a>
+                        <br>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/tests/accessibility.spec.ts" rel="noopener noreferrer">View accessibility spec →</a>
+                    </div>
+                </details>
             </div>
+
             <div class="card">
                 <h2>⚡ Lighthouse CI</h2>
                 <p>Measures Core Web Vitals (LCP, INP, CLS) plus performance, accessibility and best-practice scores on every PR and nightly against production.</p>
+                <details class="details">
+                    <summary>.lighthouserc.json</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>{
+  "ci": {
+    "collect": { "url": ["http://localhost:8080/"] },
+    "assert":  {
+      "preset": "lighthouse:no-pwa",
+      "assertions": { "categories:performance": ["error", { "minScore": 0.95 }] }
+    }
+  }
+}</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.lighthouserc.json" rel="noopener noreferrer">View .lighthouserc.json →</a>
+                        <br>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/reliability-core-web-vitals.yml" rel="noopener noreferrer">View workflow →</a>
+                    </div>
+                </details>
             </div>
+
             <div class="card">
                 <h2>📝 markdownlint</h2>
                 <p>Lints all documentation as part of the hygiene checks, keeping markdown style, headings and link structure consistent across the repo.</p>
+                <details class="details">
+                    <summary>Workflow excerpt</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>jobs:
+  check-docs-structure:
+    steps:
+      - uses: actions/checkout@v4
+      - run: npx markdownlint-cli 'docs/**/*.md'</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/hygiene-docs-structure-check.yml" rel="noopener noreferrer">View source →</a>
+                    </div>
+                </details>
             </div>
         </div>
     </main>
     <footer>
-        <p>SlopStopper is open source — <a href="https://github.com/hungovercoders/slopstopper" rel="noopener noreferrer">view the repository on GitHub</a>.</p>
+        <p>
+            <span class="mascot mascot--wave" aria-hidden="true">
+                <svg viewBox="0 0 240 240" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M40 130 C40 75, 80 50, 120 50 C160 50, 200 75, 200 130 C200 180, 165 210, 120 210 C75 210, 40 180, 40 130 Z" fill="#FBF5EC" stroke="#2A2118" stroke-width="6" stroke-linejoin="round"/>
+                    <circle cx="92" cy="130" r="13" fill="#2A2118"/>
+                    <circle cx="148" cy="130" r="13" fill="#2A2118"/>
+                    <circle cx="96" cy="125" r="4" fill="#FBF5EC"/>
+                    <circle cx="152" cy="125" r="4" fill="#FBF5EC"/>
+                    <path d="M100 165 Q120 182, 140 165" stroke="#2A2118" stroke-width="5" stroke-linecap="round" fill="none"/>
+                    <path d="M198 105 Q230 90, 222 56" stroke="#2A2118" stroke-width="9" stroke-linecap="round" fill="none"/>
+                    <circle cx="222" cy="50" r="9" fill="#FBF5EC" stroke="#2A2118" stroke-width="5"/>
+                </svg>
+            </span>
+            SlopStopper is open source — <a href="https://github.com/hungovercoders/slopstopper" rel="noopener noreferrer">view the repository on GitHub</a>.
+        </p>
     </footer>
 </body>
 </html>

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,140 +1,26 @@
-# Agents Instructions for template.netlify
+# Agent instructions — pointer
 
-This is an open standard for agents, AI assistants, and automation tools to understand project conventions and best practices.
+The canonical agent instructions for this repo now live at the repo root:
 
-> 📚 **Documentation Hub**: For comprehensive documentation navigation, see [docs/index.md](index.md) which provides a structured map of all project documentation.
+→ [`../AGENTS.md`](../AGENTS.md)
 
-> 🏗️ **Structure Convention**: The categories in [docs/index.md](index.md) drive naming across the project—Taskfile tasks use `category:action` (e.g., `hygiene:complexity`), GitHub Actions use `category-action-check.yml` (e.g., `hygiene-complexity-check.yml`).
+This file is kept as a thin pointer so that existing references (in
+workflows, README files, and external documentation) continue to resolve.
+Do not duplicate content here — update [`../AGENTS.md`](../AGENTS.md)
+instead.
 
-## Project Overview
+## Why
 
-This is a minimal static site template demonstrating Netlify deployment with GitHub Actions CI/CD. The application is a multi-page static site with separate HTML, CSS, and JS files—no build process, no bundlers, no frameworks.
+The [agents.md](https://agents.md) open standard expects `AGENTS.md` at the
+repo root, alongside `README.md` and `CONTRIBUTING.md`. Agents (Claude
+Code, GitHub Copilot, Cursor, etc.) look for it there first. The root
+[`CLAUDE.md`](../CLAUDE.md) imports it via Claude Code's `@AGENTS.md`
+directive so all agents converge on the same source of truth.
 
-## Architecture
+## Quick map of related files
 
-**Static Multi-Page Site**: The site (SlopStopper) consists of three pages (`app/index.html`, `app/features.html`, `app/tools.html`), each with its own CSS file. TypeScript source files live in `src/` and compile to JavaScript in `app/` via `tsc`.
-
-**Deployment Pipeline**: 
-- Production: Pushes to `main` trigger production deployment via [.github/workflows/netlify-deploy.yml](../.github/workflows/netlify-deploy.yml)
-- Preview: PRs to `main` create preview deployments at `https://pr-{number}--{site-name}.netlify.app`
-- Cleanup: PRs closed/merged trigger automatic preview deletion via [.github/workflows/netlify-cleanup-preview.yml](../.github/workflows/netlify-cleanup-preview.yml)
-
-**Configuration**: [netlify.toml](../netlify.toml) publishes the `app/` directory and runs `npm run build` (TypeScript compilation) before deployment.
-
-## Critical Workflows
-
-### Local Development
-```bash
-npm start  # Runs node server.js on port 8080
-```
-The custom `server.js` reads security headers from `netlify.toml` so local dev matches production behavior. Alternative: Run `npm run build` first, then open `app/index.html` directly in browser.
-
-### Deployment
-- **Production**: Push/merge to `main` → Auto-deploys → Commit comment with URL
-- **Preview**: Open PR → Auto-deploys preview → PR comment with preview URL
-- **Cleanup**: Close/merge PR → Auto-deletes preview deployment (frees Netlify resources)
-- **Secrets Required**: `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` in GitHub repo secrets
-
-### GitHub Actions Workflows
-**Deploy** ([.github/workflows/netlify-deploy.yml](../.github/workflows/netlify-deploy.yml)):
-- Uses `nwtgck/actions-netlify@v2.1` action
-- Runs on `ubuntu-latest` with `pull-requests: write` permission
-- Has separate steps for production (main branch) and preview (PRs) with different comment settings
-- Times out after 5 minutes
-
-**Cleanup** ([.github/workflows/netlify-cleanup-preview.yml](../.github/workflows/netlify-cleanup-preview.yml)):
-- Triggers on `pull_request: [closed]` events
-- Queries Netlify API for deployment matching `pr-{number}` alias
-- Deletes the preview deployment via Netlify API
-- Handles gracefully if no deployment exists
-
-### Agentic Workflows
-
-**Copilot Coding Agent** ([.github/workflows/copilot-setup-steps.yml](../.github/workflows/copilot-setup-steps.yml)):
-- Enables GitHub Copilot to be assigned to issues and autonomously create PRs
-- Sets up Node.js, Playwright, Taskfile, Python analysis tools, and gh-aw MCP server
-- Agent uses `AGENTS.md` and `docs/` for project context and conventions
-
-**Documentation Updater** ([.github/workflows/hygiene-doc-updater.md](../.github/workflows/hygiene-doc-updater.md)):
-- GitHub Agentic Workflow (gh-aw) that runs weekly on Fridays (or on-demand via `workflow_dispatch`)
-- Scans merged PRs from the last 7 days and identifies documentation gaps
-- Checks open `documentation`-labeled issues for unaddressed gaps
-- Creates PRs with documentation updates, auto-assigned to Copilot for review
-- Respects `docs/index.md` governance model and project conventions
-- Requires `ANTHROPIC_API_KEY` secret for Claude engine
-
-**Auto-label PRs** ([.github/workflows/hygiene-auto-label-pr.yml](../.github/workflows/hygiene-auto-label-pr.yml)):
-- Automatically labels PRs based on changed files using [.github/labeler.yml](../.github/labeler.yml)
-- Categories match project structure: `docs`, `security`, `reliability`, `hygiene`, `deployment`, `tests`, `ci`, `content`
-- Labels sync on PR open, synchronize, and reopen
-
-**Accessibility Monitor** ([.github/workflows/reliability-accessibility-check.yml](../.github/workflows/reliability-accessibility-check.yml)):
-- Audits all pages for WCAG 2.1 AA violations using axe-core + Playwright
-- Runs on PRs (local build), push to main (local build), successful deployments, and daily schedule
-- Configurable impact threshold (`ACCESSIBILITY_IMPACT`) and violation limit (`ACCESSIBILITY_THRESHOLD`)
-- Posts PR comments, creates GitHub issues on main-branch failures, and closes them on recovery
-- See [docs/reliability/ACCESSIBILITY.md](reliability/ACCESSIBILITY.md) for full details
-
-## Project Conventions
-
-**Dev Dependencies Only**: [package.json](../package.json) has dev dependencies (`@playwright/test`, `markdownlint-cli`, `typescript`) for testing, linting, and TypeScript compilation. The `start` script runs `node server.js`.
-
-**Separate Stylesheets**: Each page has its own CSS file (e.g., `index.css`). The homepage uses a dark gradient background (`linear-gradient(135deg, #1a1a2e 0%, #16213e 100%)`) with teal accent (`#00d4aa`) and flexbox centering.
-
-**TypeScript Build**: [netlify.toml](../netlify.toml) runs `npm run build` (which runs `tsc`) before deployment. The publish directory is `app/`. TypeScript source is in `src/`, compiled output in `app/`.
-
-**Conventional Commits**: All commits follow the [Conventional Commits](https://www.conventionalcommits.org/) standard for clear, predictable commit history. Format: `<type>(<scope>): <description>` where type is one of:
-- `feat:` - New feature or content
-- `fix:` - Bug fix or issue correction
-- `docs:` - Documentation updates
-- `style:` - Styling or visual changes
-- `test:` - Test additions or updates
-- `chore:` - Build, dependencies, or maintenance
-- `refactor:` - Code restructuring without feature changes
-
-Examples: `feat(hero): add gradient animation`, `fix(nav): correct mobile menu alignment`, `docs(complexity): update threshold guidance`
-
-## Customization Guide
-
-This is a **template** repository—here's how to customize it:
-
-**Visual Changes** (in individual CSS files, e.g., `app/index.css`):
-- Background gradient: Modify `linear-gradient(135deg, #1a1a2e 0%, #16213e 100%)` with new color stops
-- Font sizes: `h1 { font-size: 4rem }` and `p { font-size: 1.5rem }`
-- Layout: Change flexbox properties in `body` or `.container`
-
-**Content Changes** (in HTML and TypeScript files):
-- Homepage: Edit [app/index.html](../app/index.html) and [src/index.ts](../src/index.ts) — heading, subtext, navigation
-- Features: Edit [app/features.html](../app/features.html) and [src/features.ts](../src/features.ts) — text input interactive feature
-- Tools: Edit [app/tools.html](../app/tools.html) and [src/tools.ts](../src/tools.ts) — counter interactive feature
-
-**Site Configuration**:
-- Set `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` as GitHub repo secrets (see [README.md](README.md) Netlify Setup)
-- Netlify site name determines preview URLs: `pr-{number}--{site-name}.netlify.app`
-
-**Adding Pages**: Create HTML/CSS in `app/` and TypeScript in `src/`. Run `npm run build` to compile. Add navigation links in each page's `<nav>` block. See existing pages for the pattern.
-
-## Integration Points
-
-**Netlify**: Direct deployment via GitHub Actions (not Netlify's automatic git integration).
-
-**GitHub Actions**: Workflows require repo secrets (`NETLIFY_AUTH_TOKEN`, `NETLIFY_SITE_ID`) and use `secrets.GITHUB_TOKEN` for PR commenting.
-
-**Netlify API**: Cleanup workflow uses `https://api.netlify.com/api/v1/sites/{site_id}/deploys` endpoint to query and delete preview deployments.
-
-## When Making Changes
-
-- Content/style edits: Modify [index.html](../app/index.html) directly
-- Deployment behavior: Edit [.github/workflows/netlify-deploy.yml](../.github/workflows/netlify-deploy.yml)
-- Cleanup behavior: Edit [.github/workflows/netlify-cleanup-preview.yml](../.github/workflows/netlify-cleanup-preview.yml)
-- Netlify settings: Update [netlify.toml](../netlify.toml) (though current config is minimal)
-- No need to run builds or install dependencies—changes are deployed as-is
-
-## Common Patterns
-
-This project demonstrates:
-- GitHub Actions workflows with conditional steps (`if: github.event_name == 'push'`)
-- PR preview deployments using dynamic aliases (`alias: pr-${{ github.event.number }}`)
-- Automatic resource cleanup on PR close using Netlify API
-- Zero-build static site deployment pattern
-- Multi-page static sites with separate CSS/JS files
+- [`../README.md`](../README.md) — consumer-facing project overview and install
+- [`../AGENTS.md`](../AGENTS.md) — canonical agent conventions
+- [`../CLAUDE.md`](../CLAUDE.md) — Claude Code entry point (imports `AGENTS.md`)
+- [`../docs/contributing/README.md`](contributing/README.md) — contributor workflow
+- [`index.md`](index.md) — documentation hub and naming governance

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,279 +1,37 @@
-# Slopstopper
-
-SlopStopper — a static site promoting deterministic feedback for AI-driven development, with automated Netlify deployment and feature branch preview support.
-
-The live site is at [https://griff-template.netlify.app/](https://griff-template.netlify.app/).
-
-## Features
-
-- 🛡️ SlopStopper: deterministic feedback for AI-driven development
-- 🚀 Automated deployment to Netlify via GitHub Actions
-- 🔄 Feature branch preview deployments for PRs
-- 💻 Local development server
-
-## 📚 Documentation
-
-This project follows a structured documentation framework. For comprehensive navigation and to find specific topics:
-
-**→ [Documentation Hub (index.md)](index.md)** - Central navigation for all project documentation
-
-> **Note**: The categories defined in [index.md](index.md) drive naming conventions across the project—local tasks use `category:action` format, CI/CD workflows use `category-action-check.yml` format.
-
-## Installing the Tooling into Another Repository
-
-You can install the SlopStopper tooling (Taskfile tasks, analysis scripts, and
-generic GitHub Actions workflows) into any existing repository.
-
-**Recommended two-step approach** (review the script before running):
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/happydevs-studio/template-netlify/main/install.sh -o install.sh
-bash install.sh [TARGET_DIR]
-```
-
-Or, if you already have this repo checked out, use the Task runner:
-
-```bash
-task install TARGET=/path/to/your-repo
-```
-
-**What gets installed:**
-
-| Item | Description |
-|------|-------------|
-| `Taskfile.yml` | All task definitions (`task --list` to see them) |
-| `.scripts/` | Python/shell analysis scripts used by the tasks |
-| `.github/workflows/` | Hygiene, security, and reliability workflows |
-| `package.json` | Created (or `devDependencies` merged into an existing file) |
-
-Existing files are never overwritten — remove them first if you want to
-reinstall.
-
-**After installing**, run:
-
-```bash
-# 1. Install Task runner (if you don't have it)
-curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
-
-# 2. Install npm dependencies
-npm install
-
-# 3. See all available tasks
-task --list
-```
-
-## Quick Start
-
-### Running Locally
-
-1. Clone the repository:
-```bash
-git clone https://github.com/happydevs-studio/template-netlify.git
-cd template-netlify
-```
-
-2. Start the local development server:
-```bash
-npm start
-```
-
-This runs `node server.js`, which starts a local HTTP server on port 8080 that reads security headers from `netlify.toml` to match production behavior.
-
-Alternatively, you can open `app/index.html` directly in your browser (note: JS interactions require the compiled files from `npm run build`).
-
-## Local Development
-
-### Prerequisites
-
-- **Task** (task runner): Install from [taskfile.dev](https://taskfile.dev/)
-  ```bash
-  curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
-  ```
-
-### Available Tasks
-
-All development tasks can be run with the `task` command. View available tasks:
-
-```bash
-task --list
-```
-
-### Code Complexity Analysis
-
-Analyze code complexity locally using Lizard:
-
-```bash
-task hygiene:complexity
-```
-
-This will:
-- Automatically install Lizard if not already installed
-- Analyze the codebase for cyclomatic complexity
-- Generate both human-readable and CSV reports in `.complexity-reports/`
-- Display a summary with any high-complexity items (CCN > 10)
-
-**Reports location**: `.complexity-reports/`
-- `complexity-report.md` - Human-readable Markdown report
-- `complexity-report.csv` - Machine-readable format for processing
-
-**Complexity guidelines for this template:**
-- Functions with cyclomatic complexity (CCN) > 10 should be simplified
-- Keep functions under 50 lines when possible
-- For this static template, code should remain minimal
-
-The same analysis runs in CI/CD on pull requests and pushes to `main`.
-
-**For customizing complexity thresholds or configuration:**
-See [hygiene/COMPLEXITY_CONFIG.md](hygiene/COMPLEXITY_CONFIG.md) for detailed setup instructions, threshold customization, and troubleshooting.
-
-## Netlify Setup
-
-### Prerequisites
-
-1. A Netlify account (sign up at [netlify.com](https://www.netlify.com))
-2. A GitHub repository with this code
-
-### Initial Netlify Site Setup
-
-1. **Create a new site on Netlify:**
-   - Log in to your Netlify account
-   - Go to "Sites" and click "Add new site"
-   - Choose "Import an existing project"
-   - Connect to your GitHub repository
-   - For build settings:
-     - Build command: Leave empty or use `echo 'No build required'`
-     - Publish directory: `.` (current directory)
-   - Click "Deploy site"
-
-2. **Get your Netlify credentials:**
-   - **NETLIFY_SITE_ID**: 
-     - Go to Site settings → General → Site details
-     - Copy the "Site ID" (also called "API ID")
-   
-   - **NETLIFY_AUTH_TOKEN**:
-     - Go to your Netlify User settings → Applications → Personal access tokens
-     - Click "New access token"
-     - Give it a descriptive name (e.g., "GitHub Actions Deploy")
-     - Copy the generated token (save it securely, you won't see it again!)
-
-3. **Add secrets to your GitHub repository:**
-   - Go to your GitHub repository
-   - Navigate to Settings → Secrets and variables → Actions
-   - Click "New repository secret" and add:
-     - Name: `NETLIFY_AUTH_TOKEN`, Value: (your Netlify personal access token)
-     - Name: `NETLIFY_SITE_ID`, Value: (your Netlify site ID)
-
-## Deployment Workflow
-
-### Production Deployment
-
-The site automatically deploys to production when changes are pushed to the `main` branch:
-
-1. Make your changes locally
-2. Commit and push to `main`:
-```bash
-git add .
-git commit -m "Your commit message"
-git push origin main
-```
-
-3. GitHub Actions will automatically deploy to your production Netlify site
-4. A commit comment will be added with the deployment URL
-
-### Feature Branch Preview Deployment
-
-When you create a pull request, a preview deployment is automatically created:
-
-1. Create a new feature branch:
-```bash
-git checkout -b feature/my-new-feature
-```
-
-2. Make your changes and push:
-```bash
-git add .
-git commit -m "Add new feature"
-git push origin feature/my-new-feature
-```
-
-3. Create a Pull Request on GitHub
-
-4. GitHub Actions will automatically:
-   - Deploy a preview version of your site
-   - Add a comment to the PR with the preview URL
-   - Each new commit to the PR will update the preview
-
-5. Review the preview deployment before merging
-
-6. Once merged to `main`, the changes will be deployed to production
-
-## Project Structure
-
-```
-template-netlify/
-├── .github/
-│   └── workflows/           # GitHub Actions workflows
-├── docs/                    # Project documentation
-│   ├── index.md             # Documentation hub and governance
-│   ├── architecture/
-│   ├── contributing/
-│   ├── decisions/
-│   ├── deployment/
-│   ├── hygiene/
-│   ├── reliability/
-│   ├── runbooks/
-│   └── security/
-├── tests/                   # Playwright and other tests
-├── app/                     # Static site: HTML, CSS, compiled JS (publish dir)
-│   ├── index.html           # SlopStopper home page
-│   ├── index.css            # Home styles
-│   ├── features.html        # Features page
-│   ├── features.css         # Features styles
-│   ├── tools.html           # Tools page
-│   └── tools.css            # Tools styles
-├── src/                     # TypeScript source files
-│   ├── index.ts             # Home interaction (compiled → app/index.js)
-│   ├── features.ts          # Features interaction (compiled → app/features.js)
-│   └── tools.ts             # Tools interaction (compiled → app/tools.js)
-├── server.js                # Local dev server (reads netlify.toml headers, serves app/)
-├── netlify.toml             # Netlify configuration
-├── tsconfig.json            # TypeScript configuration
-├── package.json             # NPM config and dev dependencies
-├── playwright.config.js     # Playwright test configuration
-└── Taskfile.yml             # Task runner definitions
-```
-
-## Configuration Files
-
-### netlify.toml
-
-Configures Netlify build and deployment settings. The publish directory is `app/` and the build command runs `npm run build` (TypeScript compilation).
-
-### .github/workflows/netlify-deploy.yml
-
-GitHub Actions workflow that:
-- Triggers on pushes to `main` (production deployment)
-- Triggers on pull requests to `main` (preview deployment)
-- Uses the `nwtgck/actions-netlify` action for deployment
-- Adds deployment URLs as comments on PRs
-
-## Troubleshooting
-
-### Local Server Issues
-
-- **Port already in use**: If port 8080 is already in use, the server will try another port automatically
-- **npm not found**: Install Node.js from [nodejs.org](https://nodejs.org/)
-
-### Deployment Issues
-
-- **Deployment fails with "Unauthorized"**: Check that your `NETLIFY_AUTH_TOKEN` is correct
-- **Deployment fails with "Site not found"**: Verify your `NETLIFY_SITE_ID` is correct
-- **No preview comment on PR**: Ensure the GitHub Actions workflow has write permissions
-
-## Agent Instructions
-
-For instructions on project conventions, deployment workflows, and best practices intended for AI agents and automation tools, see [AGENTS.md](AGENTS.md) in the docs directory. This is an open standard that applies across all tooling.
-
-## License
-
-MIT
+# SlopStopper documentation
+
+This directory holds the structured project documentation.
+
+- **Documentation hub:** [`index.md`](index.md) is the naming-governance
+  spec and category map for everything under `docs/`.
+- **Project overview, install instructions, contributor pointers:** see the
+  repo root [`README.md`](../README.md).
+- **Canonical agent instructions:** see the repo root
+  [`AGENTS.md`](../AGENTS.md) (this directory keeps a thin
+  [`AGENTS.md`](AGENTS.md) pointer for backwards compatibility).
+
+## Categories
+
+See [`index.md`](index.md) for the canonical list, but at a glance:
+
+| Category | Purpose |
+| -------- | ------- |
+| [`app/`](app/) | What the site does and how pages are organised |
+| [`architecture/`](architecture/) | System structure and boundaries |
+| [`contributing/`](contributing/) | Contributor workflow and expectations |
+| [`decisions/`](decisions/) | Significant decisions and rationale |
+| [`deployment/`](deployment/) | Release and environment workflows |
+| [`hygiene/`](hygiene/) | Quality gates and maintenance |
+| [`reliability/`](reliability/) | Service level, accessibility, incident response |
+| [`runbooks/`](runbooks/) | Operational procedures |
+| [`security/`](security/) | Security scanning and controls |
+| [`support/`](support/) | How to get help and escalation flow |
+
+## Tasks
+
+Documentation has its own Task targets — see
+[`Taskfile.yml`](../Taskfile.yml) and run `task --list` for the full set.
+Examples:
+
+- `task decisions:validate`
+- `task decisions:new SLUG=<name>`

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -15,7 +15,7 @@ Notation: C4 (Context + Container).
 ```mermaid
 flowchart LR
     U[User Browser]
-    A[template-netlify site]
+    A[SlopStopper site]
     N[Netlify Platform]
     G[GitHub Repository]
 
@@ -74,7 +74,7 @@ flowchart LR
     PR["📤 Push / Open PR"]
     SC["🔒 Security\nSAST · DAST · Secrets · CVEs"]
     HY["🧹 Hygiene\nComplexity · Docs"]
-    RE["✅ Reliability\nE2E · Smoke Tests"]
+    RE["✅ Reliability\nE2E · Smoke · A11y · CWV"]
     DP["🚀 Deploy\nPreview URL"]
     FB["💬 Feedback\nto Developer"]
 

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,10 +1,12 @@
 # Deployment
 
-Release and environment workflows for the template-netlify project.
+Release and environment workflows for the SlopStopper project.
 
 ## Overview
 
-This project deploys a static site to Netlify using GitHub Actions. There is no build step — static files are published as-is.
+This project deploys a static site to Netlify using GitHub Actions. The
+build step compiles TypeScript via `npm run build` (`tsc`) before Netlify
+publishes the `app/` directory.
 
 ## Workflows
 
@@ -28,5 +30,6 @@ This project deploys a static site to Netlify using GitHub Actions. There is no 
 ## Configuration
 
 Deployment is configured via [netlify.toml](../../netlify.toml):
-- Publish directory: `.` (root)
-- Build command: `echo 'No build step required for static site'`
+- Publish directory: `app`
+- Build command: `npm run build` (runs `tsc`)
+- Security headers (CSP, frame-ancestors, etc.) are defined in `netlify.toml` and applied by Netlify in production and by `server.js` locally for parity.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,6 +1,6 @@
 # Runbooks
 
-Operational procedures for the template-netlify project.
+Operational procedures for the SlopStopper project.
 
 ## Overview
 

--- a/install.sh
+++ b/install.sh
@@ -5,18 +5,18 @@
 #   ./install.sh [TARGET_DIR]
 #
 # Usage (recommended two-step from GitHub):
-#   curl -fsSL https://raw.githubusercontent.com/happydevs-studio/template-netlify/main/install.sh -o install.sh
+#   curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install.sh -o install.sh
 #   bash install.sh [TARGET_DIR]
 #
 # Usage (one-liner from GitHub, review the script first):
-#   curl -fsSL https://raw.githubusercontent.com/happydevs-studio/template-netlify/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install.sh | bash
 #
 # When piped from curl the script clones a temporary copy of the repo and
 # installs from there, so no local checkout is required.
 
 set -euo pipefail
 
-REPO_URL="https://github.com/happydevs-studio/template-netlify.git"
+REPO_URL="https://github.com/hungovercoders/slopstopper.git"
 TARGET_DIR="${1:-$(pwd)}"
 
 # ── helpers ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **Full visual rebrand** to an indie-playful style: cream/peach background + tomato accent, "Stoppy" mascot, sticker cards with offset shadows and tiny rotations, sun-highlighter underlines, hand-drawn SVG arrows on the loops diagram. Replaces the dark navy/teal theme.
- **GitHub backlinks everywhere**: a "View on GitHub" button on every page header; each sub-feature on `features.html` and each tool on `tools.html` deep-links to the relevant `.github/workflows/*.yml` (or config file) on the repo.
- **Three layers of demo content**: a one-liner Get Started install block on the homepage with a 3-step adoption flow; per-capability workflow YAML excerpts inside `<details>` on every feature and tool card; four inline-SVG mock report mockups (axe-core, Lighthouse, Trivy, ZAP) in a new "Reports, not lectures" section on features.

## Implementation notes
- Vanilla HTML + CSS, no framework, no build tool. New `app/shared.css` carries the brand system (palette as custom properties, system font stack, components — `.btn` / `.card` / `.codeblock` / `.details` / `.mascot` / `.bubble` / `.arrow` / `.kicker` / `.highlight` / `.report`). Per-page CSS trimmed to page-specific layout only.
- All assets are self-hosted to satisfy the existing strict CSP (`default-src 'self'; …`). No web fonts, no external images, no third-party scripts. Mascot and the four mock reports are inline SVG.
- Workflow YAML excerpts are hand-curated 5–10 line illustrative blocks; the visible "View source" link is the canonical reference. Each block has a `<!-- sync this excerpt if the workflow's first job step changes -->` comment.
- Two contrast fixes during a11y verification: `.btn--primary` switched to `--accent-deep` (was 4.2:1 on white); `.kicker` text switched to `--ink` on peach (was 4.46:1, just under AA threshold).

## Test plan
- [x] `npm run build` clean
- [x] Playwright smoke tests pass (7/7) against local server
- [x] axe-core accessibility audit at strictest `minor` threshold — **0 violations** on `/`, `/features.html`, `/tools.html`
- [x] Visual check at 375 × 812, 768 × 1024, 1280 × 900 — layouts intact, card grids reflow 1/2/3 cols, mascot doesn't overflow, mock reports scale to width, YAML `<pre>` blocks scroll horizontally
- [ ] Netlify preview deploy spot-check (this PR will produce one)
- [ ] Core Web Vitals + Lighthouse CI workflow results on this PR (existing thresholds: Perf ≥ 95, A11y 100, BP ≥ 95, SEO ≥ 95)