### PR TITLE
docs(readme): add pipeline status badges for all SlopStopper workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,38 @@ and push to `main`.
 
 📍 **Live reference site:** see [the SlopStopper showcase](https://github.com/hungovercoders/slopstopper) — built with the same suite it advertises.
 
+## Pipeline status
+
+Every check below runs on every PR and push to `main` against SlopStopper itself — what consumers get when they install SlopStopper is exactly what gates this repo.
+
+### 🔒 Security
+[![SAST](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-security-sast-check.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-security-sast-check.yml)
+[![DAST](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-security-dast-check.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-security-dast-check.yml)
+[![Secrets](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-security-secrets-check.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-security-secrets-check.yml)
+[![Dependency Vulnerabilities](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-security-vulnerability-all-check.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-security-vulnerability-all-check.yml)
+[![Dependency Review](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-security-vulnerability-new-check.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-security-vulnerability-new-check.yml)
+
+### 🧹 Hygiene
+[![Complexity](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-hygiene-complexity-check.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-hygiene-complexity-check.yml)
+[![Docs Accuracy](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-hygiene-docs-accuracy-check.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-hygiene-docs-accuracy-check.yml)
+[![Docs Size](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-hygiene-docs-size-check.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-hygiene-docs-size-check.yml)
+[![Docs Structure](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-hygiene-docs-structure-check.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-hygiene-docs-structure-check.yml)
+[![Auto Label PRs](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-hygiene-auto-label-pr.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-hygiene-auto-label-pr.yml)
+
+### ✅ Reliability
+[![Playwright](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-playwright-tests.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-playwright-tests.yml)
+[![Smoke Tests](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-reliability-smoke-tests.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-reliability-smoke-tests.yml)
+[![Accessibility](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-reliability-accessibility-check.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-reliability-accessibility-check.yml)
+[![Core Web Vitals](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-reliability-core-web-vitals.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-reliability-core-web-vitals.yml)
+
+### 🤖 Operational
+[![Doc Auto-Updater](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-hygiene-doc-updater.lock.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-hygiene-doc-updater.lock.yml)
+[![Failure Alerts](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-workflow-failure-issue.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-workflow-failure-issue.yml)
+
+### 🚀 Deployment
+[![Netlify Deploy](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-netlify-deploy.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-netlify-deploy.yml)
+[![Preview Cleanup](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-netlify-cleanup-preview.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-netlify-cleanup-preview.yml)
+
 ---
 
 ## Install


### PR DESCRIPTION
## Summary
Add a **Pipeline status** section to the top of the README with badges for every SlopStopper workflow, grouped by the five loops:

- 🔒 **Security** (5): SAST · DAST · Secrets · Dependency Vulnerabilities · Dependency Review
- 🧹 **Hygiene** (5): Complexity · Docs Accuracy · Docs Size · Docs Structure · Auto Label PRs
- ✅ **Reliability** (4): Playwright · Smoke · Accessibility · Core Web Vitals
- 🤖 **Operational** (2): Doc Auto-Updater · Failure Alerts
- 🚀 **Deployment** (2): Netlify Deploy · Preview Cleanup

Each badge uses GitHub's native action-badge endpoint (`/actions/workflows/<file>/badge.svg?branch=main`) — same-domain, no third-party badge service. Each links to the workflow's runs page so a visitor can drill straight in.

Excluded: `copilot-setup-steps.yml` (platform-internal, doesn't run as a gate) and `ss-hygiene-doc-updater.md` (the gh-aw source — the `.lock.yml` companion is what actually runs).

## Test plan
- [x] Markdown renders correctly in GitHub preview
- [x] All 18 badge URLs follow the canonical pattern and point at existing workflow files
- [ ] After merge, badges show the actual current status on main