### PR TITLE
chore: replace remaining magic8bi.com references with slopstopper.dev

### DIFF
--- a/.github/workflows/ss-reliability-core-web-vitals.yml
+++ b/.github/workflows/ss-reliability-core-web-vitals.yml
@@ -14,7 +14,7 @@ on:
       url:
         description: 'URL to audit'
         required: true
-        default: 'https://magic8bi.com/'
+        default: 'https://slopstopper.dev/'
         type: string
 
   # Run against local server on pull requests
@@ -109,7 +109,7 @@ jobs:
             echo "config=.lighthouserc.prod.json" >> "$GITHUB_OUTPUT"
           else
             # Scheduled run — use production URL with full preset
-            echo "url=https://magic8bi.com" >> "$GITHUB_OUTPUT"
+            echo "url=https://slopstopper.dev" >> "$GITHUB_OUTPUT"
             echo "config=.lighthouserc.prod.json" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/ss-reliability-smoke-tests.yml
+++ b/.github/workflows/ss-reliability-smoke-tests.yml
@@ -74,7 +74,7 @@ jobs:
             echo "url=$SAFE_URL" >> "$GITHUB_OUTPUT"
           else
             # Scheduled run - use production URL
-            echo "url=https://magic8bi.com" >> "$GITHUB_OUTPUT"
+            echo "url=https://slopstopper.dev" >> "$GITHUB_OUTPUT"
           fi
         
       - name: Run smoke tests

--- a/docs/reliability/ACCESSIBILITY.md
+++ b/docs/reliability/ACCESSIBILITY.md
@@ -65,7 +65,7 @@ The default threshold (`serious`) means the workflow fails when any `critical` o
 | `pull_request` → `main` | Local build (`localhost:8080`) |
 | `push` → `main` | Local build (`localhost:8080`) |
 | `deployment_status` (success) | Deployment URL from Netlify |
-| `schedule` (daily 06:00 UTC) | Production URL (`https://magic8bi.com`) |
+| `schedule` (daily 06:00 UTC) | Production URL (`https://slopstopper.dev`) |
 | `workflow_dispatch` | Configurable via inputs |
 
 ### Manual Trigger


### PR DESCRIPTION
## Summary
Three files still pointed at the old production URL (\`magic8bi.com\`) after the rebrand. README.md and \`ss-reliability-accessibility-check.yml\` already used \`slopstopper.dev\`, so the smoke + Core Web Vitals scheduled runs now match.

## Files changed
- \`.github/workflows/ss-reliability-smoke-tests.yml\` — workflow_dispatch default + scheduled URL
- \`.github/workflows/ss-reliability-core-web-vitals.yml\` — workflow_dispatch default + scheduled URL
- \`docs/reliability/ACCESSIBILITY.md\` — schedule-trigger documentation table

## Test plan
- [x] \`grep -r "magic8bi"\` returns zero matches across the repo
- [ ] Once merged, the next scheduled smoke + CWV runs target \`https://slopstopper.dev\`
- [ ] Once DNS / Netlify cert renewal completes for \`slopstopper.dev\`, those scheduled runs will start reporting real values