### PR TITLE
fix(site): keep header on one row on narrow viewports

### DIFF
--- a/app/features.html
+++ b/app/features.html
@@ -27,7 +27,7 @@
             <a href="tools.html" id="nav-tools">Tools</a>
             <a href="https://github.com/hungovercoders/slopstopper" class="btn btn--ghost btn--gh" rel="noopener noreferrer" aria-label="View SlopStopper on GitHub">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.33-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.11-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.06 0 0 .97-.31 3.18 1.18a11.1 11.1 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.77.12 3.06.74.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.4-5.25 5.68.41.35.78 1.05.78 2.12v3.14c0 .31.21.66.79.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z"/></svg>
-                GitHub
+                <span class="btn__label">GitHub</span>
             </a>
         </nav>
     </header>

--- a/app/index.html
+++ b/app/index.html
@@ -27,7 +27,7 @@
             <a href="tools.html" id="nav-tools">Tools</a>
             <a href="https://github.com/hungovercoders/slopstopper" class="btn btn--ghost btn--gh" rel="noopener noreferrer" aria-label="View SlopStopper on GitHub">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.33-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.11-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.06 0 0 .97-.31 3.18 1.18a11.1 11.1 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.77.12 3.06.74.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.4-5.25 5.68.41.35.78 1.05.78 2.12v3.14c0 .31.21.66.79.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z"/></svg>
-                GitHub
+                <span class="btn__label">GitHub</span>
             </a>
         </nav>
     </header>

--- a/app/shared.css
+++ b/app/shared.css
@@ -609,6 +609,29 @@ footer a {
     margin-top: 1.5rem;
 }
 
+/* ─── Mobile header ──────────────────────────────────────── */
+@media (max-width: 520px) {
+    header {
+        padding: 0.75rem 1rem;
+        gap: 0.5rem;
+    }
+    nav {
+        gap: 0.25rem;
+    }
+    nav a {
+        padding: 0.4rem 0.7rem;
+        font-size: 0.95rem;
+    }
+    .btn--gh {
+        padding: 0.5rem 0.6rem;
+        margin-left: 0;
+        gap: 0;
+    }
+    .btn--gh .btn__label {
+        display: none;
+    }
+}
+
 /* ─── Reduced motion ─────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
     .card-grid > .card,

--- a/app/tools.html
+++ b/app/tools.html
@@ -27,7 +27,7 @@
             <a href="tools.html" id="nav-tools" aria-current="page">Tools</a>
             <a href="https://github.com/hungovercoders/slopstopper" class="btn btn--ghost btn--gh" rel="noopener noreferrer" aria-label="View SlopStopper on GitHub">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.33-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.11-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.06 0 0 .97-.31 3.18 1.18a11.1 11.1 0 0 1 5.79 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.77.12 3.06.74.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.4-5.25 5.68.41.35.78 1.05.78 2.12v3.14c0 .31.21.66.79.55C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z"/></svg>
-                GitHub
+                <span class="btn__label">GitHub</span>
             </a>
         </nav>
     </header>


### PR DESCRIPTION
## Summary

- On mobile (≤520px) the GitHub link in the header nav wrapped onto a new line because the nav had four items and the GitHub button carried both an icon and the text "GitHub".
- Tightens nav spacing at narrow widths and collapses the GitHub button to icon-only — its `aria-label="View SlopStopper on GitHub"` already labels it for screen readers, so hiding the visible text is accessibility-safe.
- HTML markup change: wrapped the literal "GitHub" text in `<span class="btn__label">` across `index.html`, `features.html`, `tools.html`. CSS change: new `@media (max-width: 520px)` block in `app/shared.css` that hides `.btn__label` and reduces nav padding.

## Test plan

- [ ] DevTools mobile preview at 375px wide (iPhone SE): GitHub link is icon-only, on the same row as Home/Features/Tools below the title.
- [ ] DevTools at 520px boundary: layout switches cleanly.
- [ ] Desktop ≥ 521px: no visual change.
- [ ] CI smoke + accessibility checks pass (no copy/contrast changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)