### PR TITLE
fix(docs): use absolute URLs for support issue + discussion links

### DIFF
--- a/docs/support/SUPPORT.md
+++ b/docs/support/SUPPORT.md
@@ -38,7 +38,7 @@ Use GitHub Copilot or another AI assistant to ask questions about the codebase b
 
 If AI cannot resolve your question and the problem is **specific to this repository**, open a support issue using the template provided:
 
-👉 [Open a Support Issue](../../issues/new?template=support-request.yml)
+👉 [Open a Support Issue](https://github.com/hungovercoders/slopstopper/issues/new?template=support-request.yml)
 
 Use this for:
 
@@ -50,7 +50,7 @@ Use this for:
 
 If the problem spans multiple repositories, teams, or is architectural in nature, start a **GitHub Discussion** rather than an issue:
 
-👉 [Start a Discussion](../../discussions/new)
+👉 [Start a Discussion](https://github.com/hungovercoders/slopstopper/discussions/new)
 
 Use this for:
 
@@ -63,6 +63,6 @@ Use this for:
 | Situation | Channel |
 |-----------|---------|
 | Quick question about the codebase | Ask AI / Copilot |
-| Bug or gap scoped to this repo | [Support Issue](../../issues/new?template=support-request.yml) |
-| Cross-repo or cross-team concern | [Discussion](../../discussions/new) |
+| Bug or gap scoped to this repo | [Support Issue](https://github.com/hungovercoders/slopstopper/issues/new?template=support-request.yml) |
+| Cross-repo or cross-team concern | [Discussion](https://github.com/hungovercoders/slopstopper/discussions/new) |
 | Security vulnerability | See [Security docs](../security/README.md) |


### PR DESCRIPTION
## Summary

The two CTAs in \`docs/support/SUPPORT.md\` ("Open a Support Issue" and "Start a Discussion"), plus the matching table rows, used relative paths like \`../../issues/new?template=support-request.yml\` and \`../../discussions/new\`. GitHub resolves those against the file's blob URL — \`https://github.com/.../blob/<branch>/issues/new\` — which 404s instead of opening the issue-creation form or the discussions page.

Replaced all four with absolute \`github.com/hungovercoders/slopstopper/...\` URLs so the links actually go where they're labelled.

Verified that \`.github/ISSUE_TEMPLATE/support-request.yml\` exists and Discussions are enabled on the repo, so the target URLs land correctly.

## Test plan

- [ ] Open \`docs/support/SUPPORT.md\` on GitHub and click "Open a Support Issue" → lands on the new-issue form with the support template pre-selected.
- [ ] Click "Start a Discussion" → lands on the new-discussion form.
- [ ] Same for the two table-row links lower down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)