### PR TITLE
docs: promote docs/index.md as the documentation map across entry points

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,13 @@
 Open standard for agents, AI assistants and automation tools working in this
 repo. Conformant with [agents.md](https://agents.md).
 
-> 📚 **Documentation hub:** [`docs/index.md`](./docs/index.md) is the
-> structured map of all project documentation.
+> 🗺️ **Documentation map.** [`docs/index.md`](./docs/index.md) is the
+> single index of all project documentation. This file, [`CLAUDE.md`](./CLAUDE.md)
+> and [`README.md`](./README.md) are intentionally thin — they point at
+> the map rather than duplicating its content. When you need details on a
+> check, a runbook, or a decision, navigate the map. The
+> [hygiene docs-structure check](./docs/hygiene/README.md) keeps the map
+> honest against the directory tree.
 
 > 🏗️ **Naming convention:** the categories in
 > [`docs/index.md`](./docs/index.md) drive naming across the project. Task

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ and push to `main`.
 
 > 🪞 **Dogfooded here.** Every badge below is real. This repo runs the same suite it ships, on every PR and push to `main`.
 
+> 🗺️ **Documentation map:** [`docs/index.md`](./docs/index.md) is the single index of all project documentation. This README, [`AGENTS.md`](./AGENTS.md) and [`CLAUDE.md`](./CLAUDE.md) are deliberately thin entry points — all three defer to the map so each audience (humans, agents, AI assistants) has one short file to read and one shared place to find the truth. The [hygiene docs-structure check](./docs/hygiene/README.md) enforces that the map stays in sync with the directory tree.
+
 ## Pipeline status
 
 Every check below runs on every PR and push to `main` here, and ships to consumers via [`install.sh`](./install.sh). Netlify and Doc-Updater workflows are included by default but are inert until you add their secrets (see [Configure](#configure)).

--- a/app/features.html
+++ b/app/features.html
@@ -132,7 +132,7 @@ jobs:
                 <p class="card-intro">Keep the codebase auditable and the docs honest — complexity caps, structure / accuracy / size checks for docs, and auto-labelled PRs.</p>
                 <ul>
                     <li><strong>Complexity</strong> — Lizard + Bandit cap cyclomatic complexity and Python security smells</li>
-                    <li><strong>Doc Structure</strong> — Required docs sections present and linted</li>
+                    <li><strong>Doc Structure</strong> — Enforces <code>docs/index.md</code> as the documentation map; README / AGENTS.md / CLAUDE.md stay thin pointers</li>
                     <li><strong>Doc Accuracy</strong> — Documentation reflects the actual code</li>
                     <li><strong>Doc Size</strong> — Prevents documentation from going stale or unwieldy</li>
                     <li><strong>Auto-label PRs</strong> — PRs labelled from the paths changed</li>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,19 @@
 # Documentation Index
 
-This file defines documentation categories and governance.
+This file is **the map** — every other entry point in the repo defers to it.
 
 > 👋 **Saw a SlopStopper check fail in your PR?** Each category README below explains what the check does, how to read its output, and how to tune thresholds. Jump straight in: [Security](security/README.md) · [Hygiene](hygiene/README.md) · [Reliability](reliability/README.md) · [Runbooks](runbooks/README.md) · [Deployment](deployment/README.md). The full env-var contract for dynamic checks lives in [reliability/README.md](reliability/README.md).
+
+## The Map Pattern
+
+The repo has three small entry-point files — [`README.md`](../README.md) (humans), [`AGENTS.md`](../AGENTS.md) (automation tools, conformant with [agents.md](https://agents.md)) and [`CLAUDE.md`](../CLAUDE.md) (Claude Code) — and each one defers to this index instead of duplicating documentation inline.
+
+**Why this matters:**
+
+- **Agents stay focused.** Claude, Copilot or any agent loads only the thin entry file (typically <2K tokens) and navigates here when it needs detail. No bloated instruction files competing for context window.
+- **One source of truth.** The category READMEs are the canonical answer; entry files just point at them. Changes don't have to ripple through three places.
+- **Drift is caught by CI.** The [hygiene docs-structure check](hygiene/README.md) fails the build if the directory tree drifts from the map below, and the [docs-accuracy check](hygiene/README.md) catches broken cross-references in any doc.
+- **Reusable convention.** If you install SlopStopper into your own repo, dropping a `docs/index.md` and slimming `README.md` / `AGENTS.md` / `CLAUDE.md` to pointers gives you the same property for free.
 
 ## Governance Model
 


### PR DESCRIPTION
## Summary

Three thin entry files in this repo — \`README.md\` (humans), \`AGENTS.md\` (automation / [agents.md](https://agents.md) standard) and \`CLAUDE.md\` (Claude Code) — already defer to \`docs/index.md\` instead of duplicating documentation inline. That keeps each audience's first file short (typically <2K tokens for an agent), avoids drift between three sources of truth, and lets the docs themselves grow without bloating context.

This PR makes the pattern **explicit and discoverable**, so consumers who install SlopStopper can adopt it for the same benefits.

### Changes

- **README.md** — new "🗺️ Documentation map" callout next to the dogfooding callout, naming the three entry points and pointing at \`docs/index.md\`.
- **AGENTS.md** — strengthen the existing callout to name the pattern and cross-link \`README.md\` + \`CLAUDE.md\` so agents see how they fit together.
- **docs/index.md** — new "The Map Pattern" section explaining the *why*: why each entry file stays thin, how drift is caught (hygiene docs-structure + docs-accuracy checks), and why consumers should adopt the same shape.
- **features.html** — Hygiene > Doc Structure bullet rewritten to say it enforces \`docs/index.md\` as the map (was just "required sections present and linted").

### Why now

A first-time reader of this repo previously had to discover the pattern by noticing that \`CLAUDE.md\` is one line (\`@AGENTS.md\`) and that \`AGENTS.md\` points at \`docs/index.md\`. Now it's stated at the top of every entry point.

## Test plan

- [ ] \`task ss:hygiene:docs-accuracy\` clean (verified locally — no broken cross-refs).
- [ ] \`task ss:hygiene:docs-structure\` clean.
- [ ] Read \`README.md\` on GitHub — Documentation map callout renders correctly, links land on \`docs/index.md\`, \`AGENTS.md\`, \`CLAUDE.md\`, \`docs/hygiene/README.md\`.
- [ ] Open \`features.html\` on the live site — Hygiene card's Doc Structure bullet mentions the map.
- [ ] All workflow badges stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)