### PR TITLE
feat(reliability): add SEO + social-share metatag check

### DIFF
--- a/.github/workflows/ss-reliability-seo-check.yml
+++ b/.github/workflows/ss-reliability-seo-check.yml
@@ -1,0 +1,172 @@
+name: SlopStopper · SEO Metatag Check
+
+on:
+  pull_request:
+    branches: [main]
+
+  push:
+    branches: [main]
+
+  deployment_status:
+
+  schedule:
+    - cron: '0 7 * * *'
+
+  workflow_dispatch:
+    inputs:
+      url:
+        description: 'URL to audit (leave blank to audit local build)'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  seo:
+    name: SEO Metatag Audit (OpenGraph + Twitter Card + canonical)
+    if: |
+      github.event_name != 'deployment_status' ||
+      github.event.deployment_status.state == 'success'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Task
+        run: |
+          curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
+          task --version
+
+      - name: Determine audit URL
+        id: url
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_URL: ${{ github.event.inputs.url }}
+          DEPLOYMENT_URL: ${{ github.event.deployment_status.target_url }}
+        run: |
+          validate_url() {
+            local url="$1"
+            if [[ ! "$url" =~ ^https?://[^[:space:][:cntrl:]]+$ ]]; then
+              echo "Error: Invalid URL format: $url" >&2
+              exit 1
+            fi
+            printf '%s' "$url"
+          }
+
+          if [ "$EVENT_NAME" == "workflow_dispatch" ] && [ -n "$INPUT_URL" ]; then
+            SAFE_URL="$(validate_url "$INPUT_URL")"
+            echo "url=$SAFE_URL" >> "$GITHUB_OUTPUT"
+            echo "use_local=false" >> "$GITHUB_OUTPUT"
+          elif [ "$EVENT_NAME" == "deployment_status" ]; then
+            SAFE_URL="$(validate_url "$DEPLOYMENT_URL")"
+            echo "url=$SAFE_URL" >> "$GITHUB_OUTPUT"
+            echo "use_local=false" >> "$GITHUB_OUTPUT"
+          elif [ "$EVENT_NAME" == "schedule" ]; then
+            echo "url=https://slopstopper.dev" >> "$GITHUB_OUTPUT"
+            echo "use_local=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "url=http://localhost:8080" >> "$GITHUB_OUTPUT"
+            echo "use_local=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dependencies (local build only)
+        if: steps.url.outputs.use_local == 'true'
+        run: npm ci
+
+      - name: Start local server (PR / push builds)
+        if: steps.url.outputs.use_local == 'true'
+        # CUSTOMISE FOR YOUR APP: this step is wired for this repo's static
+        # site (build + node server.js). Replace with whatever starts your
+        # app on port 8080 — or set use_local=false in the Determine audit
+        # URL step and point SEO_TEST_URL at a deployed environment.
+        run: |
+          if [ -f server.js ] && [ -f package.json ] && node -e "process.exit(require('./package.json').scripts?.build ? 0 : 1)"; then
+            npm run build
+            node server.js &
+            echo "SERVER_PID=$!" >> "$GITHUB_ENV"
+            for i in $(seq 1 10); do
+              if curl -s http://localhost:8080 > /dev/null; then
+                echo "✅ Server ready"
+                break
+              fi
+              sleep 1
+            done
+          else
+            echo "ℹ️  No server.js to start. Customise this step or set SEO_TEST_URL."
+            exit 1
+          fi
+
+      - name: Pages to audit (this repo)
+        if: steps.url.outputs.use_local == 'true'
+        # CUSTOMISE FOR YOUR APP: comma-separated paths to audit. Defaults
+        # to '/' if unset.
+        run: echo "SEO_PAGES=/,/features.html,/tools.html" >> "$GITHUB_ENV"
+
+      - name: Run SEO metatag audit
+        id: audit
+        env:
+          SEO_TEST_URL: ${{ steps.url.outputs.url }}
+        run: task ss:reliability:seo:ci
+
+      - name: Stop local server
+        if: steps.url.outputs.use_local == 'true' && always()
+        run: kill "$SERVER_PID" || true
+
+      - name: Upload SEO report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: seo-metatags-report-${{ github.run_id }}
+          path: .ss/reports/seo/
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Comment on PR with SEO results
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        env:
+          JOB_STATUS: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const status = process.env.JOB_STATUS === 'success' ? '✅ PASSED' : '❌ FAILED';
+            const runUrl = process.env.RUN_URL;
+
+            let body = `## 🔎 SEO Metatag Audit ${status}\n\n`;
+            body += 'Checks each page for `<title>`, meta description, canonical, viewport, the OpenGraph set (og:title/description/type/url/image) and the Twitter Card set (twitter:card/title/description/image). Also HEAD-fetches `og:image` to confirm reachability.\n\n';
+
+            if (process.env.JOB_STATUS !== 'success') {
+              body += '> ⚠️ Missing or unreachable tags. See workflow logs / artifact for details.\n\n';
+            }
+
+            body += '### 🔍 How to Check Locally\n\n';
+            body += '```bash\n';
+            body += '# Audit the local build\n';
+            body += 'task ss:reliability:seo -- http://localhost:8080\n\n';
+            body += '# Or audit a deployed URL\n';
+            body += 'task ss:reliability:seo -- https://your-site.netlify.app\n';
+            body += '```\n\n';
+            body += `[Full report in workflow artifacts](${runUrl})\n`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });

--- a/.ss/lighthouserc.json
+++ b/.ss/lighthouserc.json
@@ -6,6 +6,7 @@
     "assert": {
       "assertions": {
         "categories:performance": ["error", { "minScore": 0.7 }],
+        "categories:seo": ["error", { "minScore": 0.9 }],
         "largest-contentful-paint": ["error", { "maxNumericValue": 4000 }],
         "total-blocking-time": ["error", { "maxNumericValue": 600 }],
         "cumulative-layout-shift": ["error", { "maxNumericValue": 0.25 }],

--- a/.ss/lighthouserc.prod.json
+++ b/.ss/lighthouserc.prod.json
@@ -9,7 +9,7 @@
         "categories:performance": ["error", { "minScore": 0.7 }],
         "categories:accessibility": ["warn", { "minScore": 0.8 }],
         "categories:best-practices": ["warn", { "minScore": 0.8 }],
-        "categories:seo": ["warn", { "minScore": 0.8 }],
+        "categories:seo": ["error", { "minScore": 0.9 }],
         "largest-contentful-paint": ["error", { "maxNumericValue": 4000 }],
         "total-blocking-time": ["error", { "maxNumericValue": 600 }],
         "cumulative-layout-shift": ["error", { "maxNumericValue": 0.25 }],

--- a/.ss/scripts/check-seo-metatags.py
+++ b/.ss/scripts/check-seo-metatags.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+
+"""
+SEO / Social-Share Metatag Validator
+
+Fetches one or more pages and asserts the presence of the metadata that
+social-share crawlers (Slack, Twitter/X, LinkedIn, Discord, Facebook) and
+SEO indexers rely on. Complements `ss:reliability:cwv` — Lighthouse's SEO
+category covers core SEO (description, viewport, canonical, indexability)
+but does not flag missing OpenGraph or Twitter tags.
+
+Inputs (env vars):
+    SEO_TEST_URL       (required)  base URL, e.g. https://slopstopper.dev
+    SEO_PAGES          (default /) comma-separated paths to check
+    SEO_REQUIRE_OG_IMAGE  (default 1)  set to 0 to skip og:image presence check
+    SEO_VERIFY_OG_IMAGE   (default 1)  set to 0 to skip HEAD-fetching og:image
+
+Outputs:
+    .ss/reports/seo/seo-metatags-report.md   (human-readable)
+    .ss/reports/seo/seo-metatags-report.json (machine-readable)
+
+Exit code: 0 if all required tags present on all pages, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Optional
+
+
+REPORT_DIR = Path(".ss/reports/seo")
+USER_AGENT = "SlopStopper-SEO-Check/1.0"
+TIMEOUT_SECONDS = 15
+
+
+# ── HTML parser: only walks the <head>, captures meta/title/link ─────
+
+class HeadParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.in_head = False
+        self.in_title = False
+        self.title: Optional[str] = None
+        self.metas: list[dict[str, str]] = []
+        self.links: list[dict[str, str]] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
+        if tag == "head":
+            self.in_head = True
+            return
+        if not self.in_head:
+            return
+        a = {k: v or "" for k, v in attrs}
+        if tag == "title":
+            self.in_title = True
+        elif tag == "meta":
+            self.metas.append(a)
+        elif tag == "link":
+            self.links.append(a)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "head":
+            self.in_head = False
+        elif tag == "title":
+            self.in_title = False
+
+    def handle_data(self, data: str) -> None:
+        if self.in_title and self.title is None:
+            self.title = data.strip()
+
+
+def fetch(url: str) -> tuple[int, str, str]:
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=TIMEOUT_SECONDS) as resp:  # nosec B310 — URL comes from env, not user input
+        return resp.status, resp.headers.get("Content-Type", ""), resp.read().decode("utf-8", errors="replace")
+
+
+def head_ok(url: str) -> tuple[bool, str]:
+    """Return (ok, detail). Validates og:image is reachable and is an image."""
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT}, method="HEAD")
+        with urllib.request.urlopen(req, timeout=TIMEOUT_SECONDS) as resp:  # nosec B310
+            ct = resp.headers.get("Content-Type", "")
+            if resp.status != 200:
+                return False, f"HTTP {resp.status}"
+            if not ct.startswith("image/"):
+                return False, f"Content-Type is {ct!r}, expected image/*"
+            return True, ct
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as e:
+        return False, f"{type(e).__name__}: {e}"
+
+
+def get_meta(metas: list[dict[str, str]], key_attr: str, key_value: str) -> Optional[str]:
+    for m in metas:
+        if m.get(key_attr, "").lower() == key_value.lower():
+            return m.get("content", "")
+    return None
+
+
+def get_link(links: list[dict[str, str]], rel: str) -> Optional[str]:
+    for link in links:
+        if link.get("rel", "").lower() == rel.lower():
+            return link.get("href", "")
+    return None
+
+
+def check_page(base: str, path: str, require_og_image: bool, verify_og_image: bool) -> dict:
+    page_url = urllib.parse.urljoin(base.rstrip("/") + "/", path.lstrip("/"))
+    issues: list[str] = []
+    notes: list[str] = []
+
+    try:
+        status, ctype, body = fetch(page_url)
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as e:
+        return {
+            "url": page_url,
+            "status": "error",
+            "issues": [f"Failed to fetch: {type(e).__name__}: {e}"],
+            "notes": [],
+        }
+
+    if status != 200:
+        issues.append(f"HTTP status {status}")
+    if "text/html" not in ctype.lower():
+        notes.append(f"Content-Type is {ctype!r}, expected text/html")
+
+    parser = HeadParser()
+    parser.feed(body)
+
+    title = parser.title or ""
+    description = get_meta(parser.metas, "name", "description") or ""
+    canonical = get_link(parser.links, "canonical") or ""
+    og_title = get_meta(parser.metas, "property", "og:title") or ""
+    og_description = get_meta(parser.metas, "property", "og:description") or ""
+    og_type = get_meta(parser.metas, "property", "og:type") or ""
+    og_url = get_meta(parser.metas, "property", "og:url") or ""
+    og_image = get_meta(parser.metas, "property", "og:image") or ""
+    twitter_card = get_meta(parser.metas, "name", "twitter:card") or ""
+    twitter_title = get_meta(parser.metas, "name", "twitter:title") or ""
+    twitter_description = get_meta(parser.metas, "name", "twitter:description") or ""
+    twitter_image = get_meta(parser.metas, "name", "twitter:image") or ""
+    viewport = get_meta(parser.metas, "name", "viewport") or ""
+
+    # Required: core SEO
+    if not title:
+        issues.append("Missing <title>")
+    elif len(title) > 70:
+        notes.append(f"<title> is {len(title)} chars — consider ≤ 60")
+    if not description:
+        issues.append("Missing <meta name=\"description\">")
+    elif len(description) > 160:
+        notes.append(f"meta description is {len(description)} chars — consider ≤ 160")
+    if not viewport:
+        issues.append("Missing <meta name=\"viewport\">")
+    if not canonical:
+        issues.append("Missing <link rel=\"canonical\">")
+
+    # Required: OpenGraph
+    if not og_title:
+        issues.append("Missing og:title")
+    if not og_description:
+        issues.append("Missing og:description")
+    if not og_type:
+        issues.append("Missing og:type")
+    if not og_url:
+        issues.append("Missing og:url")
+    if require_og_image and not og_image:
+        issues.append("Missing og:image")
+
+    # Required: Twitter card
+    if not twitter_card:
+        issues.append("Missing twitter:card")
+    elif twitter_card not in {"summary", "summary_large_image", "app", "player"}:
+        notes.append(f"twitter:card is {twitter_card!r}, expected one of summary|summary_large_image|app|player")
+    if not twitter_title:
+        issues.append("Missing twitter:title")
+    if not twitter_description:
+        issues.append("Missing twitter:description")
+    if require_og_image and not twitter_image:
+        issues.append("Missing twitter:image")
+
+    # Verify og:image is reachable
+    image_check: Optional[dict] = None
+    if og_image and verify_og_image:
+        # Normalise relative og:image against page URL
+        og_image_abs = urllib.parse.urljoin(page_url, og_image)
+        ok, detail = head_ok(og_image_abs)
+        image_check = {"url": og_image_abs, "ok": ok, "detail": detail}
+        if not ok:
+            issues.append(f"og:image not reachable ({og_image_abs}): {detail}")
+
+    return {
+        "url": page_url,
+        "status": "fail" if issues else "pass",
+        "issues": issues,
+        "notes": notes,
+        "tags": {
+            "title": title,
+            "description": description,
+            "canonical": canonical,
+            "viewport": viewport,
+            "og:type": og_type,
+            "og:title": og_title,
+            "og:description": og_description,
+            "og:url": og_url,
+            "og:image": og_image,
+            "twitter:card": twitter_card,
+            "twitter:title": twitter_title,
+            "twitter:description": twitter_description,
+            "twitter:image": twitter_image,
+        },
+        "image_check": image_check,
+    }
+
+
+def write_reports(results: list[dict], base: str) -> None:
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    overall_pass = all(r["status"] == "pass" for r in results)
+
+    # JSON
+    json_path = REPORT_DIR / "seo-metatags-report.json"
+    json_path.write_text(json.dumps({
+        "base_url": base,
+        "overall": "pass" if overall_pass else "fail",
+        "pages": results,
+    }, indent=2) + "\n")
+
+    # Markdown
+    md_path = REPORT_DIR / "seo-metatags-report.md"
+    lines: list[str] = []
+    lines.append("# 🔎 SEO / Social-Share Metatag Report")
+    lines.append("")
+    lines.append(f"**Base URL:** {base}")
+    lines.append("")
+    lines.append(f"**Overall:** {'✅ PASS' if overall_pass else '❌ FAIL'}")
+    lines.append("")
+    for r in results:
+        status_icon = {"pass": "✅", "fail": "❌", "error": "💥"}.get(r["status"], "•")
+        lines.append(f"## {status_icon} {r['url']}")
+        lines.append("")
+        if r["issues"]:
+            lines.append("**Issues:**")
+            for issue in r["issues"]:
+                lines.append(f"- ❌ {issue}")
+            lines.append("")
+        if r.get("notes"):
+            lines.append("**Notes:**")
+            for note in r["notes"]:
+                lines.append(f"- ⚠️  {note}")
+            lines.append("")
+        if r.get("tags"):
+            lines.append("<details><summary>Tags detected</summary>")
+            lines.append("")
+            lines.append("| Tag | Value |")
+            lines.append("|---|---|")
+            for k, v in r["tags"].items():
+                display = (v[:120] + "…") if v and len(v) > 120 else v
+                lines.append(f"| `{k}` | {display or '_(empty)_'} |")
+            lines.append("")
+            lines.append("</details>")
+            lines.append("")
+        if r.get("image_check"):
+            ic = r["image_check"]
+            icon = "✅" if ic["ok"] else "❌"
+            lines.append(f"**og:image fetch:** {icon} `{ic['url']}` — {ic['detail']}")
+            lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append("## How to Fix")
+    lines.append("")
+    lines.append("- **Missing tag** → add it to the page's `<head>`. See [docs/reliability/SEO.md](../../../docs/reliability/SEO.md) for the full required set.")
+    lines.append("- **og:image not reachable** → confirm the URL is absolute, same-origin (or CORS-allowed for crawlers), and returns `image/*` content type.")
+    lines.append("- **Title / description too long** → trim to keep search-result snippets readable.")
+    lines.append("")
+    md_path.write_text("\n".join(lines) + "\n")
+
+
+def main() -> int:
+    base = os.environ.get("SEO_TEST_URL", "").strip()
+    if not base:
+        print("❌ Error: SEO_TEST_URL is required", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("Usage:", file=sys.stderr)
+        print("  SEO_TEST_URL=https://your-site.com task ss:reliability:seo", file=sys.stderr)
+        return 2
+
+    pages_raw = os.environ.get("SEO_PAGES", "/")
+    pages = [p.strip() for p in pages_raw.split(",") if p.strip()] or ["/"]
+    require_og_image = os.environ.get("SEO_REQUIRE_OG_IMAGE", "1") != "0"
+    verify_og_image = os.environ.get("SEO_VERIFY_OG_IMAGE", "1") != "0"
+
+    print(f"🔎 SEO metatag audit against: {base}")
+    print(f"   Pages: {', '.join(pages)}")
+    print("━" * 60)
+
+    results = [check_page(base, p, require_og_image, verify_og_image) for p in pages]
+    write_reports(results, base)
+
+    overall_pass = all(r["status"] == "pass" for r in results)
+    for r in results:
+        icon = {"pass": "✅", "fail": "❌", "error": "💥"}.get(r["status"], "•")
+        suffix = "" if r["status"] == "pass" else f" — {len(r['issues'])} issue(s)"
+        print(f"  {icon} {r['url']}{suffix}")
+        for issue in r["issues"]:
+            print(f"      - {issue}")
+
+    print("━" * 60)
+    if overall_pass:
+        print("✅ All pages pass.")
+    else:
+        print("❌ Failures detected. See .ss/reports/seo/seo-metatags-report.md for full details.")
+    return 0 if overall_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.ss/scripts/check-seo-metatags.py
+++ b/.ss/scripts/check-seo-metatags.py
@@ -111,6 +111,66 @@ def get_link(links: list[dict[str, str]], rel: str) -> Optional[str]:
     return None
 
 
+def value_or_empty(value: Optional[str]) -> str:
+    return value if value else ""
+
+
+def collect_tags(parser: HeadParser) -> dict[str, str]:
+    return {
+        "title": value_or_empty(parser.title),
+        "description": value_or_empty(get_meta(parser.metas, "name", "description")),
+        "canonical": value_or_empty(get_link(parser.links, "canonical")),
+        "viewport": value_or_empty(get_meta(parser.metas, "name", "viewport")),
+        "og:type": value_or_empty(get_meta(parser.metas, "property", "og:type")),
+        "og:title": value_or_empty(get_meta(parser.metas, "property", "og:title")),
+        "og:description": value_or_empty(get_meta(parser.metas, "property", "og:description")),
+        "og:url": value_or_empty(get_meta(parser.metas, "property", "og:url")),
+        "og:image": value_or_empty(get_meta(parser.metas, "property", "og:image")),
+        "twitter:card": value_or_empty(get_meta(parser.metas, "name", "twitter:card")),
+        "twitter:title": value_or_empty(get_meta(parser.metas, "name", "twitter:title")),
+        "twitter:description": value_or_empty(get_meta(parser.metas, "name", "twitter:description")),
+        "twitter:image": value_or_empty(get_meta(parser.metas, "name", "twitter:image")),
+    }
+
+
+def validate_core_tags(tags: dict[str, str], issues: list[str], notes: list[str]) -> None:
+    title = tags["title"]
+    description = tags["description"]
+    if not title:
+        issues.append("Missing <title>")
+    elif len(title) > 70:
+        notes.append(f"<title> is {len(title)} chars — consider ≤ 60")
+    if not description:
+        issues.append("Missing <meta name=\"description\">")
+    elif len(description) > 160:
+        notes.append(f"meta description is {len(description)} chars — consider ≤ 160")
+    if not tags["viewport"]:
+        issues.append("Missing <meta name=\"viewport\">")
+    if not tags["canonical"]:
+        issues.append("Missing <link rel=\"canonical\">")
+
+
+def validate_open_graph_tags(tags: dict[str, str], issues: list[str], require_og_image: bool) -> None:
+    for key in ("og:title", "og:description", "og:type", "og:url"):
+        if not tags[key]:
+            issues.append(f"Missing {key}")
+    if require_og_image and not tags["og:image"]:
+        issues.append("Missing og:image")
+
+
+def validate_twitter_tags(tags: dict[str, str], issues: list[str], notes: list[str], require_og_image: bool) -> None:
+    twitter_card = tags["twitter:card"]
+    if not twitter_card:
+        issues.append("Missing twitter:card")
+    elif twitter_card not in {"summary", "summary_large_image", "app", "player"}:
+        notes.append(f"twitter:card is {twitter_card!r}, expected one of summary|summary_large_image|app|player")
+    for key in ("twitter:title", "twitter:description"):
+        if not tags[key]:
+            issues.append(f"Missing {key}")
+    if require_og_image and not tags["twitter:image"]:
+        issues.append("Missing twitter:image")
+
+
 def check_page(base: str, path: str, require_og_image: bool, verify_og_image: bool) -> dict:
     page_url = urllib.parse.urljoin(base.rstrip("/") + "/", path.lstrip("/"))
     issues: list[str] = []
@@ -133,64 +193,16 @@ def check_page(base: str, path: str, require_og_image: bool, verify_og_image: bo
 
     parser = HeadParser()
     parser.feed(body)
-
-    title = parser.title or ""
-    description = get_meta(parser.metas, "name", "description") or ""
-    canonical = get_link(parser.links, "canonical") or ""
-    og_title = get_meta(parser.metas, "property", "og:title") or ""
-    og_description = get_meta(parser.metas, "property", "og:description") or ""
-    og_type = get_meta(parser.metas, "property", "og:type") or ""
-    og_url = get_meta(parser.metas, "property", "og:url") or ""
-    og_image = get_meta(parser.metas, "property", "og:image") or ""
-    twitter_card = get_meta(parser.metas, "name", "twitter:card") or ""
-    twitter_title = get_meta(parser.metas, "name", "twitter:title") or ""
-    twitter_description = get_meta(parser.metas, "name", "twitter:description") or ""
-    twitter_image = get_meta(parser.metas, "name", "twitter:image") or ""
-    viewport = get_meta(parser.metas, "name", "viewport") or ""
-
-    # Required: core SEO
-    if not title:
-        issues.append("Missing <title>")
-    elif len(title) > 70:
-        notes.append(f"<title> is {len(title)} chars — consider ≤ 60")
-    if not description:
-        issues.append("Missing <meta name=\"description\">")
-    elif len(description) > 160:
-        notes.append(f"meta description is {len(description)} chars — consider ≤ 160")
-    if not viewport:
-        issues.append("Missing <meta name=\"viewport\">")
-    if not canonical:
-        issues.append("Missing <link rel=\"canonical\">")
-
-    # Required: OpenGraph
-    if not og_title:
-        issues.append("Missing og:title")
-    if not og_description:
-        issues.append("Missing og:description")
-    if not og_type:
-        issues.append("Missing og:type")
-    if not og_url:
-        issues.append("Missing og:url")
-    if require_og_image and not og_image:
-        issues.append("Missing og:image")
-
-    # Required: Twitter card
-    if not twitter_card:
-        issues.append("Missing twitter:card")
-    elif twitter_card not in {"summary", "summary_large_image", "app", "player"}:
-        notes.append(f"twitter:card is {twitter_card!r}, expected one of summary|summary_large_image|app|player")
-    if not twitter_title:
-        issues.append("Missing twitter:title")
-    if not twitter_description:
-        issues.append("Missing twitter:description")
-    if require_og_image and not twitter_image:
-        issues.append("Missing twitter:image")
+    tags = collect_tags(parser)
+    validate_core_tags(tags, issues, notes)
+    validate_open_graph_tags(tags, issues, require_og_image)
+    validate_twitter_tags(tags, issues, notes, require_og_image)
 
     # Verify og:image is reachable
     image_check: Optional[dict] = None
-    if og_image and verify_og_image:
+    if tags["og:image"] and verify_og_image:
         # Normalise relative og:image against page URL
-        og_image_abs = urllib.parse.urljoin(page_url, og_image)
+        og_image_abs = urllib.parse.urljoin(page_url, tags["og:image"])
         ok, detail = head_ok(og_image_abs)
         image_check = {"url": og_image_abs, "ok": ok, "detail": detail}
         if not ok:
@@ -201,23 +213,77 @@ def check_page(base: str, path: str, require_og_image: bool, verify_og_image: bo
         "status": "fail" if issues else "pass",
         "issues": issues,
         "notes": notes,
-        "tags": {
-            "title": title,
-            "description": description,
-            "canonical": canonical,
-            "viewport": viewport,
-            "og:type": og_type,
-            "og:title": og_title,
-            "og:description": og_description,
-            "og:url": og_url,
-            "og:image": og_image,
-            "twitter:card": twitter_card,
-            "twitter:title": twitter_title,
-            "twitter:description": twitter_description,
-            "twitter:image": twitter_image,
-        },
+        "tags": tags,
         "image_check": image_check,
     }
+
+
+def append_issues(lines: list[str], issues: list[str]) -> None:
+    lines.append("**Issues:**")
+    for issue in issues:
+        lines.append(f"- ❌ {issue}")
+    lines.append("")
+
+
+def append_notes(lines: list[str], notes: list[str]) -> None:
+    lines.append("**Notes:**")
+    for note in notes:
+        lines.append(f"- ⚠️  {note}")
+    lines.append("")
+
+
+def append_tags(lines: list[str], tags: dict[str, str]) -> None:
+    lines.append("<details><summary>Tags detected</summary>")
+    lines.append("")
+    lines.append("| Tag | Value |")
+    lines.append("|---|---|")
+    for k, v in tags.items():
+        display = (v[:120] + "…") if v and len(v) > 120 else v
+        lines.append(f"| `{k}` | {display or '_(empty)_'} |")
+    lines.append("")
+    lines.append("</details>")
+    lines.append("")
+
+
+def append_image_check(lines: list[str], image_check: dict) -> None:
+    icon = "✅" if image_check["ok"] else "❌"
+    lines.append(f"**og:image fetch:** {icon} `{image_check['url']}` — {image_check['detail']}")
+    lines.append("")
+
+
+def append_page_markdown(lines: list[str], result: dict) -> None:
+    status_icon = {"pass": "✅", "fail": "❌", "error": "💥"}.get(result["status"], "•")
+    lines.append(f"## {status_icon} {result['url']}")
+    lines.append("")
+    if result["issues"]:
+        append_issues(lines, result["issues"])
+    if result.get("notes"):
+        append_notes(lines, result["notes"])
+    if result.get("tags"):
+        append_tags(lines, result["tags"])
+    if result.get("image_check"):
+        append_image_check(lines, result["image_check"])
+
+
+def build_markdown_report(results: list[dict], base: str, overall_pass: bool) -> str:
+    lines: list[str] = []
+    lines.append("# 🔎 SEO / Social-Share Metatag Report")
+    lines.append("")
+    lines.append(f"**Base URL:** {base}")
+    lines.append("")
+    lines.append(f"**Overall:** {'✅ PASS' if overall_pass else '❌ FAIL'}")
+    lines.append("")
+    for result in results:
+        append_page_markdown(lines, result)
+    lines.append("---")
+    lines.append("")
+    lines.append("## How to Fix")
+    lines.append("")
+    lines.append("- **Missing tag** → add it to the page's `<head>`. See [docs/reliability/SEO.md](../../../docs/reliability/SEO.md) for the full required set.")
+    lines.append("- **og:image not reachable** → confirm the URL is absolute, same-origin (or CORS-allowed for crawlers), and returns `image/*` content type.")
+    lines.append("- **Title / description too long** → trim to keep search-result snippets readable.")
+    lines.append("")
+    return "\n".join(lines) + "\n"
 
 
 def write_reports(results: list[dict], base: str) -> None:
@@ -234,67 +300,35 @@ def write_reports(results: list[dict], base: str) -> None:
 
     # Markdown
     md_path = REPORT_DIR / "seo-metatags-report.md"
-    lines: list[str] = []
-    lines.append("# 🔎 SEO / Social-Share Metatag Report")
-    lines.append("")
-    lines.append(f"**Base URL:** {base}")
-    lines.append("")
-    lines.append(f"**Overall:** {'✅ PASS' if overall_pass else '❌ FAIL'}")
-    lines.append("")
+    md_path.write_text(build_markdown_report(results, base, overall_pass))
+
+
+def read_config() -> tuple[str, list[str], bool, bool]:
+    base = os.environ.get("SEO_TEST_URL", "").strip()
+    pages_raw = os.environ.get("SEO_PAGES", "/")
+    pages = [p.strip() for p in pages_raw.split(",") if p.strip()] or ["/"]
+    require_og_image = os.environ.get("SEO_REQUIRE_OG_IMAGE", "1") != "0"
+    verify_og_image = os.environ.get("SEO_VERIFY_OG_IMAGE", "1") != "0"
+    return base, pages, require_og_image, verify_og_image
+
+
+def print_results(results: list[dict]) -> None:
     for r in results:
-        status_icon = {"pass": "✅", "fail": "❌", "error": "💥"}.get(r["status"], "•")
-        lines.append(f"## {status_icon} {r['url']}")
-        lines.append("")
-        if r["issues"]:
-            lines.append("**Issues:**")
-            for issue in r["issues"]:
-                lines.append(f"- ❌ {issue}")
-            lines.append("")
-        if r.get("notes"):
-            lines.append("**Notes:**")
-            for note in r["notes"]:
-                lines.append(f"- ⚠️  {note}")
-            lines.append("")
-        if r.get("tags"):
-            lines.append("<details><summary>Tags detected</summary>")
-            lines.append("")
-            lines.append("| Tag | Value |")
-            lines.append("|---|---|")
-            for k, v in r["tags"].items():
-                display = (v[:120] + "…") if v and len(v) > 120 else v
-                lines.append(f"| `{k}` | {display or '_(empty)_'} |")
-            lines.append("")
-            lines.append("</details>")
-            lines.append("")
-        if r.get("image_check"):
-            ic = r["image_check"]
-            icon = "✅" if ic["ok"] else "❌"
-            lines.append(f"**og:image fetch:** {icon} `{ic['url']}` — {ic['detail']}")
-            lines.append("")
-    lines.append("---")
-    lines.append("")
-    lines.append("## How to Fix")
-    lines.append("")
-    lines.append("- **Missing tag** → add it to the page's `<head>`. See [docs/reliability/SEO.md](../../../docs/reliability/SEO.md) for the full required set.")
-    lines.append("- **og:image not reachable** → confirm the URL is absolute, same-origin (or CORS-allowed for crawlers), and returns `image/*` content type.")
-    lines.append("- **Title / description too long** → trim to keep search-result snippets readable.")
-    lines.append("")
-    md_path.write_text("\n".join(lines) + "\n")
+        icon = {"pass": "✅", "fail": "❌", "error": "💥"}.get(r["status"], "•")
+        suffix = "" if r["status"] == "pass" else f" — {len(r['issues'])} issue(s)"
+        print(f"  {icon} {r['url']}{suffix}")
+        for issue in r["issues"]:
+            print(f"      - {issue}")
 
 
 def main() -> int:
-    base = os.environ.get("SEO_TEST_URL", "").strip()
+    base, pages, require_og_image, verify_og_image = read_config()
     if not base:
         print("❌ Error: SEO_TEST_URL is required", file=sys.stderr)
         print("", file=sys.stderr)
         print("Usage:", file=sys.stderr)
         print("  SEO_TEST_URL=https://your-site.com task ss:reliability:seo", file=sys.stderr)
         return 2
-
-    pages_raw = os.environ.get("SEO_PAGES", "/")
-    pages = [p.strip() for p in pages_raw.split(",") if p.strip()] or ["/"]
-    require_og_image = os.environ.get("SEO_REQUIRE_OG_IMAGE", "1") != "0"
-    verify_og_image = os.environ.get("SEO_VERIFY_OG_IMAGE", "1") != "0"
 
     print(f"🔎 SEO metatag audit against: {base}")
     print(f"   Pages: {', '.join(pages)}")
@@ -304,13 +338,7 @@ def main() -> int:
     write_reports(results, base)
 
     overall_pass = all(r["status"] == "pass" for r in results)
-    for r in results:
-        icon = {"pass": "✅", "fail": "❌", "error": "💥"}.get(r["status"], "•")
-        suffix = "" if r["status"] == "pass" else f" — {len(r['issues'])} issue(s)"
-        print(f"  {icon} {r['url']}{suffix}")
-        for issue in r["issues"]:
-            print(f"      - {issue}")
-
+    print_results(results)
     print("━" * 60)
     if overall_pass:
         print("✅ All pages pass.")

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Every check below runs on every PR and push to `main` here, and ships to consume
 [![Smoke Tests](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-reliability-smoke-tests.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-reliability-smoke-tests.yml)
 [![Accessibility](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-reliability-accessibility-check.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-reliability-accessibility-check.yml)
 [![Core Web Vitals](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-reliability-core-web-vitals.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-reliability-core-web-vitals.yml)
+[![SEO Metatags](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-reliability-seo-check.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-reliability-seo-check.yml)
 
 ### 🤖 Operational
 [![Doc Auto-Updater](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-hygiene-doc-updater.lock.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-hygiene-doc-updater.lock.yml)
@@ -115,18 +116,18 @@ Five loops of feedback, all running on every PR and push to `main`:
 | ---- | ------------ | ----- | ---- |
 | 🔒 **Security** | SAST, DAST, secrets detection, dependency CVE scanning | Semgrep, OWASP ZAP, Gitleaks, Trivy | [Security →](./docs/security/README.md) |
 | 🧹 **Hygiene** | Cyclomatic complexity caps, doc structure / accuracy / size checks, auto-labelled PRs | Lizard, Bandit, markdownlint | [Hygiene →](./docs/hygiene/README.md) |
-| ✅ **Reliability** | E2E + smoke tests, accessibility audits (WCAG 2.1 AA), Core Web Vitals | Playwright, axe-core, Lighthouse CI | [Reliability →](./docs/reliability/README.md) |
+| ✅ **Reliability** | E2E + smoke tests, accessibility audits (WCAG 2.1 AA), Core Web Vitals, SEO + OpenGraph metatag checks | Playwright, axe-core, Lighthouse CI, stdlib Python | [Reliability →](./docs/reliability/README.md) |
 | 🤖 **Operational** | Failed workflows auto-raise GitHub issues; an agentic doc updater opens weekly sync PRs | GitHub Actions, gh-aw | [Runbooks →](./docs/runbooks/README.md) |
 | 🚀 **Deployment** | Preview deploys per PR, automated production releases, preview cleanup | Netlify, GitHub Actions | [Deployment →](./docs/deployment/README.md) |
 
 ### What each check needs
 
-The 19 workflows split into four portability layers. Layer 1 runs the moment you install. Layers 2–3 need a small amount of configuration:
+The 20 workflows split into four portability layers. Layer 1 runs the moment you install. Layers 2–3 need a small amount of configuration:
 
 | Layer | Checks | What you provide |
 | ----- | ------ | ---------------- |
 | **1. Static analysis** (any code) | SAST, Secrets, Trivy, Dependency Review, Complexity, Doc Structure / Accuracy / Size, Auto-label PRs, Workflow-failure tracker | Nothing — works out of the box |
-| **2. Web-app dynamic** (need a URL) | Smoke, Accessibility, Core Web Vitals, DAST, Playwright | `SMOKE_TEST_URL` · `ACCESSIBILITY_TEST_URL` · `LIGHTHOUSE_URL` · optionally `SMOKE_PAGES` / `ACCESSIBILITY_PAGES` |
+| **2. Web-app dynamic** (need a URL) | Smoke, Accessibility, Core Web Vitals, SEO Metatags, DAST, Playwright | `SMOKE_TEST_URL` · `ACCESSIBILITY_TEST_URL` · `LIGHTHOUSE_URL` · `SEO_TEST_URL` · optionally `SMOKE_PAGES` / `ACCESSIBILITY_PAGES` / `SEO_PAGES` |
 | **3. Netlify deploy** | Preview deploys, production releases, preview cleanup | `NETLIFY_AUTH_TOKEN` + `NETLIFY_SITE_ID` repo secrets |
 | **4. Agentic doc-updater** | Weekly doc-sync PRs | `ANTHROPIC_API_KEY` repo secret |
 

--- a/Taskfile.ss.yml
+++ b/Taskfile.ss.yml
@@ -117,6 +117,66 @@ tasks:
           --config=.ss/lighthouserc.json
     silent: false
 
+  reliability:seo:
+    desc: Validate SEO + social-share metatags on a live URL
+    summary: |
+      Fetches one or more pages and asserts the presence of the metadata
+      that social-share crawlers (Slack, Twitter/X, LinkedIn, Discord) and
+      SEO indexers rely on: title, meta description, canonical, viewport,
+      OpenGraph (og:title/description/type/url/image) and Twitter Card
+      (twitter:card/title/description/image). Also HEAD-checks og:image
+      to confirm it is reachable and returns image/* content.
+
+      Complements ss:reliability:cwv — Lighthouse's SEO category covers
+      core indexability but does not flag missing OG / Twitter tags.
+
+      Configuration (environment variables):
+        SEO_TEST_URL          - base URL to audit (required)
+        SEO_PAGES             - comma-separated paths (default: /)
+        SEO_REQUIRE_OG_IMAGE  - 0 to skip og:image presence check (default: 1)
+        SEO_VERIFY_OG_IMAGE   - 0 to skip HEAD-fetching og:image (default: 1)
+
+      Usage:
+        task ss:reliability:seo -- https://your-site.netlify.app
+        SEO_TEST_URL=https://your-site.netlify.app task ss:reliability:seo
+    cmds:
+      - |
+        {{if .CLI_ARGS}}
+          export SEO_TEST_URL="{{.CLI_ARGS}}"
+        {{end}}
+
+        if [ -z "$SEO_TEST_URL" ]; then
+          echo "❌ Error: SEO_TEST_URL is required"
+          echo ""
+          echo "Usage:"
+          echo "  task ss:reliability:seo -- https://your-site.netlify.app"
+          echo "  SEO_TEST_URL=https://example.com task ss:reliability:seo"
+          exit 1
+        fi
+
+        python3 .ss/scripts/check-seo-metatags.py
+    silent: false
+
+  reliability:seo:ci:
+    desc: Validate SEO + social-share metatags (CI mode)
+    summary: |
+      Same as ss:reliability:seo, intended for GitHub Actions.
+
+      Usage:
+        SEO_TEST_URL=https://your-site.netlify.app task ss:reliability:seo:ci
+    cmds:
+      - |
+        if [ -z "$SEO_TEST_URL" ]; then
+          echo "❌ Error: SEO_TEST_URL environment variable is required"
+          exit 1
+        fi
+
+        echo "🔎 Running SEO metatag audit (CI mode) against: $SEO_TEST_URL"
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+        python3 .ss/scripts/check-seo-metatags.py
+    silent: false
+
   reliability:accessibility:
     desc: Run accessibility audit against a live URL
     summary: |

--- a/app/features.html
+++ b/app/features.html
@@ -194,12 +194,13 @@ jobs:
             <!-- ─── Reliability ─────────────────────────────────── -->
             <div class="card" id="reliability">
                 <h2>✅ Reliability</h2>
-                <p class="card-intro">Catch broken pages, slow loads and accessibility regressions before users do — E2E, smoke, axe-core WCAG 2.1 AA and Lighthouse CI on every change.</p>
+                <p class="card-intro">Catch broken pages, slow loads, accessibility regressions and broken social-share previews before users do — E2E, smoke, axe-core WCAG 2.1 AA, Lighthouse CI and SEO/OpenGraph checks on every change.</p>
                 <ul>
                     <li><strong>E2E Tests</strong> — Playwright covers navigation and critical user journeys</li>
                     <li><strong>Smoke Tests</strong> — Lightweight checks after every deploy</li>
                     <li><strong>Accessibility</strong> — axe-core audits every page against WCAG 2.1 AA</li>
                     <li><strong>Core Web Vitals</strong> — Lighthouse CI measures LCP, INP and CLS</li>
+                    <li><strong>SEO &amp; Social-Share</strong> — Lighthouse SEO budget + OpenGraph / Twitter Card / canonical presence check</li>
                 </ul>
                 <a class="card-link" href="https://github.com/hungovercoders/slopstopper/blob/main/docs/reliability/README.md" rel="noopener noreferrer">Learn more about Reliability →</a>
 
@@ -266,6 +267,25 @@ jobs:
   cwv:
     name: Core Web Vitals (Lighthouse CI)</code></pre></div>
                         <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/ss-reliability-core-web-vitals.yml" rel="noopener noreferrer">View workflow on GitHub →</a>
+                    </div>
+                </details>
+
+                <details class="details">
+                    <summary>SEO &amp; Social-Share (OpenGraph + Twitter Card)</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>name: SlopStopper · SEO Metatag Check
+on:
+  pull_request: { branches: [main] }
+  push:         { branches: [main] }
+  deployment_status:
+  schedule: [ { cron: '0 7 * * *' } ]    # daily
+jobs:
+  seo:
+    name: SEO Metatag Audit (OpenGraph + Twitter Card + canonical)
+    steps:
+      - run: task ss:reliability:seo:ci   # title, description, canonical,
+                                           # og:*, twitter:*, og:image fetch</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/ss-reliability-seo-check.yml" rel="noopener noreferrer">View workflow on GitHub →</a>
                     </div>
                 </details>
             </div>

--- a/app/tools.html
+++ b/app/tools.html
@@ -256,7 +256,7 @@ on:
 
             <div class="card">
                 <h2>⚡ Lighthouse CI</h2>
-                <p>Measures Core Web Vitals (LCP, INP, CLS) plus performance, accessibility and best-practice scores on every PR and nightly against production.</p>
+                <p>Measures Core Web Vitals (LCP, INP, CLS) plus performance, accessibility, best-practice and SEO category scores on every PR and nightly against production.</p>
                 <a class="card-link" href="https://github.com/hungovercoders/slopstopper/blob/main/docs/reliability/README.md" rel="noopener noreferrer">Learn more about Reliability →</a>
                 <details class="details">
                     <summary>.ss/lighthouserc.json</summary>
@@ -266,13 +266,36 @@ on:
     "collect": { "url": ["http://localhost:8080/"] },
     "assert":  {
       "preset": "lighthouse:no-pwa",
-      "assertions": { "categories:performance": ["error", { "minScore": 0.95 }] }
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.7 }],
+        "categories:seo":         ["error", { "minScore": 0.9 }]
+      }
     }
   }
 }</code></pre></div>
                         <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.ss/lighthouserc.json" rel="noopener noreferrer">View .ss/lighthouserc.json →</a>
                         <br>
                         <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/ss-reliability-core-web-vitals.yml" rel="noopener noreferrer">View workflow →</a>
+                    </div>
+                </details>
+            </div>
+
+            <div class="card">
+                <h2>🔎 SEO Metatag Check</h2>
+                <p>Fetches each page and asserts the full set of social-share + indexer metadata: <code>&lt;title&gt;</code>, meta description, canonical, viewport, OpenGraph (og:title/description/type/url/image) and Twitter Card (twitter:card/title/description/image). HEAD-fetches <code>og:image</code> to confirm it is reachable. Stdlib Python — no new dependencies.</p>
+                <a class="card-link" href="https://github.com/hungovercoders/slopstopper/blob/main/docs/reliability/SEO.md" rel="noopener noreferrer">Learn more about SEO check config →</a>
+                <details class="details">
+                    <summary>Taskfile excerpt</summary>
+                    <div class="details__body">
+                        <div class="codeblock codeblock--yaml"><pre><code>reliability:seo:
+  desc: Validate SEO + social-share metatags on a live URL
+  cmds:
+    - python3 .ss/scripts/check-seo-metatags.py
+  # Env: SEO_TEST_URL, SEO_PAGES (csv, default /),
+  #      SEO_REQUIRE_OG_IMAGE, SEO_VERIFY_OG_IMAGE</code></pre></div>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.ss/scripts/check-seo-metatags.py" rel="noopener noreferrer">View check script →</a>
+                        <br>
+                        <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/ss-reliability-seo-check.yml" rel="noopener noreferrer">View workflow →</a>
                     </div>
                 </details>
             </div>

--- a/docs/reliability/README.md
+++ b/docs/reliability/README.md
@@ -18,6 +18,10 @@ All reliability checks read their target URL and audit scope from environment va
 | `ACCESSIBILITY_IMPACT` | `serious` | accessibility — min `critical`/`serious`/`moderate`/`minor` |
 | `ACCESSIBILITY_THRESHOLD` | `0` | accessibility — max violations before failing |
 | `LIGHTHOUSE_URL` / `CWV_URL` | (none) | Lighthouse CI — URL to audit |
+| `SEO_TEST_URL` | (none) | SEO metatag check — base URL to audit |
+| `SEO_PAGES` | `/` | SEO metatag check — comma-separated paths, e.g. `/,/features.html` |
+| `SEO_REQUIRE_OG_IMAGE` | `1` | SEO metatag check — set `0` to skip og:image presence check |
+| `SEO_VERIFY_OG_IMAGE` | `1` | SEO metatag check — set `0` to skip HEAD-fetching og:image |
 
 ## Smoke Tests
 

--- a/docs/reliability/SEO.md
+++ b/docs/reliability/SEO.md
@@ -1,0 +1,70 @@
+# SEO & Social-Share Metatag Check
+
+SlopStopper ships two complementary SEO-flavoured checks:
+
+1. **Lighthouse SEO category** — runs as part of `ss:reliability:cwv`, gated at score ≥ 0.9 (see [`.ss/lighthouserc.json`](../../.ss/lighthouserc.json)). Covers core SEO basics: meta description, `viewport`, `lang`, canonical, robots, indexability, link-text quality.
+2. **SEO metatag check** — `ss:reliability:seo`, runs the script at [`.ss/scripts/check-seo-metatags.py`](../../.ss/scripts/check-seo-metatags.py). Validates the social-share tags Lighthouse does **not** flag (OpenGraph + Twitter Card) plus reachability of the OG image.
+
+The metatag check is intentionally Python stdlib only — no new dependencies on top of Python 3.
+
+## What gets validated
+
+For each page in `SEO_PAGES`, the script asserts the following are present and non-empty:
+
+**Core SEO**
+
+- `<title>` (warns if > 70 chars)
+- `<meta name="description">` (warns if > 160 chars)
+- `<meta name="viewport">`
+- `<link rel="canonical">`
+
+**OpenGraph**
+
+- `og:title`, `og:description`, `og:type`, `og:url`
+- `og:image` (optional — disable via `SEO_REQUIRE_OG_IMAGE=0`)
+- If `og:image` is present and `SEO_VERIFY_OG_IMAGE` is not `0`, the script HEAD-fetches the URL and asserts a 200 response with an `image/*` content type.
+
+**Twitter Card**
+
+- `twitter:card` (warns if not `summary`, `summary_large_image`, `app` or `player`)
+- `twitter:title`, `twitter:description`
+- `twitter:image` (same toggle as `og:image`)
+
+## Configuration
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SEO_TEST_URL` | (none, required) | Base URL to audit |
+| `SEO_PAGES` | `/` | Comma-separated paths, e.g. `/,/features.html,/tools.html` |
+| `SEO_REQUIRE_OG_IMAGE` | `1` | `0` to skip OG/Twitter image presence assertions |
+| `SEO_VERIFY_OG_IMAGE` | `1` | `0` to skip the HEAD reachability check on the image URL |
+
+## Running it
+
+```bash
+# Audit a deployed site
+task ss:reliability:seo -- https://your-site.netlify.app
+
+# Audit the local build with specific paths
+SEO_TEST_URL=http://localhost:8080 \
+SEO_PAGES="/,/features.html,/tools.html" \
+task ss:reliability:seo
+
+# Skip the og:image reachability check (useful if the image lives behind auth or a CDN)
+SEO_TEST_URL=https://your-site.com \
+SEO_VERIFY_OG_IMAGE=0 \
+task ss:reliability:seo
+```
+
+Reports are written to:
+
+- `.ss/reports/seo/seo-metatags-report.md` (human-readable)
+- `.ss/reports/seo/seo-metatags-report.json` (machine-readable)
+
+## Why this exists
+
+Lighthouse's SEO category passes a site with no OpenGraph or Twitter Card metadata as long as the basics (description, viewport, canonical) are present. But the moment that site gets shared in Slack, Twitter/X, LinkedIn or Discord, the preview is empty — no image, no title, no description. That's the gap this check closes. It's also what tools like [metatags.io](https://metatags.io/) verify by eye; this check makes the same verification deterministic and CI-gated.
+
+## CI integration
+
+The [`ss-reliability-seo-check.yml`](../../.github/workflows/ss-reliability-seo-check.yml) workflow runs on every PR, every push to `main`, on `deployment_status` success, and daily. PR runs comment back with pass/fail and a link to the artefact.

--- a/install.sh
+++ b/install.sh
@@ -159,6 +159,7 @@ GENERIC_WORKFLOWS=(
   "ss-reliability-smoke-tests.yml"
   "ss-reliability-accessibility-check.yml"
   "ss-reliability-core-web-vitals.yml"
+  "ss-reliability-seo-check.yml"
   "ss-playwright-tests.yml"
   # Layer 3 — Netlify deploy (need NETLIFY_AUTH_TOKEN + NETLIFY_SITE_ID)
   "ss-netlify-deploy.yml"


### PR DESCRIPTION
## Summary

Adds a new reliability loop that catches missing OpenGraph, Twitter Card, canonical and other social-share metadata before they ship. Pairs with Lighthouse's existing SEO category — Lighthouse covers core indexability, this script covers the social-share tags it *doesn't* check.

### What gets added

**Script** — \`.ss/scripts/check-seo-metatags.py\`. Python stdlib only, no new deps. Fetches each page in \`SEO_PAGES\`, parses \`<head>\`, asserts presence of:

- Core: \`<title>\`, meta description, canonical, viewport
- OpenGraph: \`og:title\`, \`og:description\`, \`og:type\`, \`og:url\`, \`og:image\`
- Twitter Card: \`twitter:card\`, \`twitter:title\`, \`twitter:description\`, \`twitter:image\`

Also HEAD-fetches \`og:image\` to confirm it returns 200 + \`image/*\`. Writes a deterministic markdown + JSON report to \`.ss/reports/seo/\`.

**Tasks** — \`ss:reliability:seo\` + \`:ci\`, env-var contract mirroring smoke / accessibility:

- \`SEO_TEST_URL\` (required) · \`SEO_PAGES\` (csv, default \`/\`)
- \`SEO_REQUIRE_OG_IMAGE\` (default 1) · \`SEO_VERIFY_OG_IMAGE\` (default 1)

**Workflow** — \`.github/workflows/ss-reliability-seo-check.yml\`. Modelled on the accessibility workflow: PR, push, \`deployment_status\`, daily schedule, \`workflow_dispatch\`. Comments back on PRs with pass/fail + reproduction commands.

**Lighthouse SEO budget** — promoted from \`warn\` to \`error\` at \`minScore: 0.9\` in both \`.ss/lighthouserc.json\` and \`.ss/lighthouserc.prod.json\`.

**Site copy**

- New \`SEO & Social-Share\` bullet + collapsible in the Reliability features card
- New \`🔎 SEO Metatag Check\` tools card

**Docs / README / install**

- New \`docs/reliability/SEO.md\` (full config + rationale + why this exists)
- Env-var table extended in \`docs/reliability/README.md\`
- README: SEO badge, matrix updated, layer-2 row mentions \`SEO_TEST_URL\` / \`SEO_PAGES\`, workflow count 19 → 20
- \`install.sh\` ships the new workflow

## ⚠️ Sequencing note

This PR's SEO check will **fail on its first run** until #141 (full SEO metadata + OG image) is merged, because today's \`app/index.html\`, \`features.html\` and \`tools.html\` are missing the very tags this check asserts. Merge order should be: **#141 first, then this PR**, after which both green up.

I verified locally that the script fails *correctly* on the current site (reports exactly which tags are missing on each of the three pages) and that the report markdown is precise and actionable — that's the right behaviour pre-#141.

## Verification done locally

- \`task ss:reliability:seo\` against local site → correctly reports missing canonical/og:url/og:image/twitter:image, exits 1, writes report to \`.ss/reports/seo/\`
- \`task ss:hygiene:docs-accuracy\` → **clean**
- \`task ss:hygiene:docs-structure\` → **clean**

## Test plan

- [ ] Merge #141 first
- [ ] Rebase this PR; SEO check should pass against the preview deploy
- [ ] Confirm Lighthouse CI run passes the new SEO budget (≥ 0.9) — already passing in #141's preview
- [ ] Confirm the PR-comment workflow posts the expected pass/fail message
- [ ] Run \`bash install.sh\` in a scratch repo → confirm \`ss-reliability-seo-check.yml\` lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)