### PR TITLE
fix(sast): silence 6 Semgrep WARNINGs with narrow, documented suppressions

### DIFF
--- a/.github/workflows/ss-security-secrets-check.yml
+++ b/.github/workflows/ss-security-secrets-check.yml
@@ -29,9 +29,20 @@ jobs:
           python-version: '3.11'
 
       - name: Install Gitleaks
+        # Pinned to a specific release rather than dynamically resolving the
+        # latest tag. The previous approach piped an unauthenticated
+        # `curl https://api.github.com/...` to extract the tag — anonymous
+        # API requests from Actions runners are heavily rate-limited and
+        # frequently return empty, producing a `gitleaks__linux_x64.tar.gz`
+        # URL that 404s. Bump GITLEAKS_VERSION manually when a refresh is
+        # wanted; Dependabot's github-actions ecosystem can also be pointed
+        # at this file.
+        env:
+          GITLEAKS_VERSION: "8.30.1"
         run: |
           set -e
-          curl -sSfL https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks_$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep '"tag_name"' | sed 's/.*"v\([^"]*\)".*/\1/')_linux_x64.tar.gz | tar -xz -C /usr/local/bin gitleaks
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
           gitleaks version
         shell: bash
 

--- a/.ss/scripts/check-seo-metatags.py
+++ b/.ss/scripts/check-seo-metatags.py
@@ -38,6 +38,24 @@ from typing import Optional
 REPORT_DIR = Path(".ss/reports/seo")
 USER_AGENT = "SlopStopper-SEO-Check/1.0"
 TIMEOUT_SECONDS = 15
+ALLOWED_SCHEMES = ("http", "https")
+
+
+def _require_safe_url(url: str) -> None:
+    """Reject any URL whose scheme isn't http/https.
+
+    urllib.request.urlopen happily handles file:// and ftp:// too, which
+    could let a hostile SEO_TEST_URL value (e.g. file:///etc/passwd) be
+    read by this checker. Validating the scheme up-front makes the
+    urlopen calls safe by construction even though they take a variable
+    URL — Semgrep's dynamic-urllib-use-detected rule cannot see that
+    safety, hence the # nosemgrep annotations downstream.
+    """
+    scheme = urllib.parse.urlparse(url).scheme.lower()
+    if scheme not in ALLOWED_SCHEMES:
+        raise ValueError(
+            f"SEO check refuses scheme {scheme!r} (only http/https allowed). url={url!r}"
+        )
 
 
 # ── HTML parser: only walks the <head>, captures meta/title/link ─────
@@ -77,15 +95,28 @@ class HeadParser(HTMLParser):
 
 
 def fetch(url: str) -> tuple[int, str, str]:
+    # Scheme validated by _require_safe_url; URL originates from the
+    # SEO_TEST_URL env var (operator-supplied), not end-user input. The
+    # # nosemgrep on the urlopen line below references that guarantee;
+    # # nosec B310 is the same suppression in Bandit's syntax.
+    _require_safe_url(url)
     req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    with urllib.request.urlopen(req, timeout=TIMEOUT_SECONDS) as resp:  # nosec B310 — URL comes from env, not user input
+    # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+    with urllib.request.urlopen(req, timeout=TIMEOUT_SECONDS) as resp:  # nosec B310
         return resp.status, resp.headers.get("Content-Type", ""), resp.read().decode("utf-8", errors="replace")
 
 
 def head_ok(url: str) -> tuple[bool, str]:
     """Return (ok, detail). Validates og:image is reachable and is an image."""
+    # Scheme validated by _require_safe_url; URL is derived from a
+    # page-resolved og:image, which itself came from operator-supplied
+    # SEO_TEST_URL. The # nosemgrep on the urlopen line below references
+    # that guarantee; # nosec B310 is the same suppression in Bandit's
+    # syntax.
     try:
+        _require_safe_url(url)
         req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT}, method="HEAD")
+        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
         with urllib.request.urlopen(req, timeout=TIMEOUT_SECONDS) as resp:  # nosec B310
             ct = resp.headers.get("Content-Type", "")
             if resp.status != 200:

--- a/app/features.html
+++ b/app/features.html
@@ -7,6 +7,7 @@
     <meta name="description" content="Practices and automated feedback loops in SlopStopper: security, hygiene, reliability (E2E, smoke, accessibility, Core Web Vitals), operational and deployment. See the workflow behind each.">
     <meta name="theme-color" content="#FBF5EC">
     <meta name="author" content="SlopStopper">
+    <!-- nosemgrep: html.security.audit.missing-integrity.missing-integrity — <link rel="canonical"> declares URL identity for SEO; it loads no subresource so SRI is structurally inapplicable -->
     <link rel="canonical" href="https://slopstopper.dev/features.html">
 
     <meta property="og:type" content="website">

--- a/app/feedback.html
+++ b/app/feedback.html
@@ -7,6 +7,7 @@
     <meta name="description" content="Tell us what you think about SlopStopper. Comments are powered by GitHub Discussions via Giscus — embedded under a scoped, documented CSP exception you can copy.">
     <meta name="theme-color" content="#FBF5EC">
     <meta name="author" content="SlopStopper">
+    <!-- nosemgrep: html.security.audit.missing-integrity.missing-integrity — <link rel="canonical"> declares URL identity for SEO; it loads no subresource so SRI is structurally inapplicable -->
     <link rel="canonical" href="https://slopstopper.dev/feedback.html">
 
     <meta property="og:type" content="website">

--- a/app/index.html
+++ b/app/index.html
@@ -7,6 +7,7 @@
     <meta name="description" content="SlopStopper — a template for deterministic, automated quality feedback (security, hygiene, reliability, accessibility, performance) on any repo. Drop it in with one command.">
     <meta name="theme-color" content="#FBF5EC">
     <meta name="author" content="SlopStopper">
+    <!-- nosemgrep: html.security.audit.missing-integrity.missing-integrity — <link rel="canonical"> declares URL identity for SEO; it loads no subresource so SRI is structurally inapplicable -->
     <link rel="canonical" href="https://slopstopper.dev/">
 
     <meta property="og:type" content="website">

--- a/app/tools.html
+++ b/app/tools.html
@@ -7,6 +7,7 @@
     <meta name="description" content="The technology stack powering SlopStopper: GitHub Actions, Task, Playwright, TypeScript, Semgrep, ZAP, Trivy, Gitleaks, axe-core, Lighthouse CI and more. Each card links back to its source.">
     <meta name="theme-color" content="#FBF5EC">
     <meta name="author" content="SlopStopper">
+    <!-- nosemgrep: html.security.audit.missing-integrity.missing-integrity — <link rel="canonical"> declares URL identity for SEO; it loads no subresource so SRI is structurally inapplicable -->
     <link rel="canonical" href="https://slopstopper.dev/tools.html">
 
     <meta property="og:type" content="website">

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -63,6 +63,22 @@ task ss:security:sast
 | WARNING | ⚠️ Non-blocking | Review recommended |
 | INFO | ℹ️ Informational | Awareness only |
 
+### Documented suppressions
+
+Some Semgrep rules are too broad for known-safe patterns. Rather than disable rules globally (which would hurt adopters whose code legitimately needs them), we use narrow inline annotations with a rationale at the call site:
+
+- `# nosemgrep: <full-rule-id>` for Python — placed on the affected statement, with a brief comment explaining why the pattern is safe here
+- `<!-- nosemgrep: <full-rule-id> --><rationale>` for HTML — placed on the line directly above the affected element
+
+Both are visible in code review and act as documentation; nothing is silently disabled. Current suppressions in this repo:
+
+| Rule | Where | Why it's safe here |
+| ---- | ----- | ------------------ |
+| `python.lang.security.audit.dynamic-urllib-use-detected` | `.ss/scripts/check-seo-metatags.py` (`fetch` + `head_ok`) | URL originates from `SEO_TEST_URL` env var (operator-supplied) and `_require_safe_url()` is called before every `urlopen()` to reject any scheme other than `http`/`https`. So `file://`/`ftp://` reads are impossible by construction. |
+| `html.security.audit.missing-integrity` | `<link rel="canonical">` in `app/index.html`, `app/features.html`, `app/tools.html`, `app/feedback.html` | Canonical links declare URL identity for search engines. They load no subresource, so Subresource Integrity is structurally inapplicable. The rule fires on any `<link>` without `integrity=` regardless of whether the tag loads anything. |
+
+**For adopters:** when SlopStopper flags noise in your code, prefer this narrow-suppression-with-rationale pattern over disabling a rule globally — it keeps the rule active for real findings while you accept the false positive at the exact site that needs it.
+
 ---
 
 ## Overview


### PR DESCRIPTION
## Summary

The Semgrep auto-config was producing **6 WARNING-severity findings** on every run. None blocked merges (the gate only fails on ERROR), but they were visible in every PR comment and on the SAST badge, eroding the signal.

Both classes of finding are genuine false positives for our context. Rather than blanket-disable the rules (they're useful for adopters and for real findings later), this PR applies **narrow inline suppressions at the exact call site with a rationale** — and codifies the pattern in \`docs/security/README.md\` so adopters inherit the technique when they install SlopStopper.

## What changed

### Python — \`dynamic-urllib-use-detected\` (2 findings)

\`.ss/scripts/check-seo-metatags.py\` calls \`urllib.request.urlopen()\` with a URL from the \`SEO_TEST_URL\` env var. Semgrep can't see that the URL is operator-supplied or that we check the scheme, so it conservatively flags both calls.

- New \`_require_safe_url()\` helper rejects anything other than \`http\`/\`https\` before \`urlopen()\` is called. So \`file://\` reads (e.g. \`/etc/passwd\`) are impossible by construction even though \`urlopen\` accepts variable URLs.
- \`# nosemgrep: <full-rule-id>\` annotations directly above each \`urlopen()\` line, with the rationale in the preceding block comment.
- Kept \`# nosec B310\` for Bandit — different scanner, different annotation syntax.

Verified locally:
\`\`\`bash
SEO_TEST_URL=file:///etc/passwd python3 .ss/scripts/check-seo-metatags.py
# ValueError: SEO check refuses scheme 'file' (only http/https allowed)
\`\`\`

### HTML — \`missing-integrity\` (4 findings)

\`<link rel=\"canonical\">\` on line 10 of each \`app/*.html\` page triggers this rule because Semgrep flags any \`<link>\` without \`integrity=\`. But canonical links load no subresource — they declare URL identity for search engines — so SRI is structurally inapplicable.

Inline \`<!-- nosemgrep: ... -->\` annotations directly above each canonical link in \`index.html\`, \`features.html\`, \`tools.html\`, \`feedback.html\`.

### Adopter docs

\`docs/security/README.md\` gains a **\"Documented suppressions\"** subsection under SAST that:
- Explains the narrow-suppression-with-rationale pattern
- Lists both current suppressions in a table with the rationale
- Tells adopters to prefer this pattern over globally disabling rules when they hit noise in their own code

## Verified locally

- \`semgrep --config=auto\`: **0 findings** (was 6 WARNINGs)
- \`python3 -m lizard -C 10 -L 60 .ss/scripts/check-seo-metatags.py\`: 0 warnings, max CCN 10, avg CCN 3.7
- \`task ss:hygiene:docs-accuracy\`: clean
- \`task ss:hygiene:csp-exceptions\`: clean
- Defence-in-depth verified: \`file://\` URL ValueErrors before \`urlopen\`

## Test plan

- [ ] CI Semgrep run shows 0 warnings on this PR
- [ ] All other green gates stay green
- [ ] PR-comment SAST report reflects the cleared state
- [ ] Confirm adopter-doc table renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)