### PR TITLE
chore: prep for public launch — LICENSE, SECURITY.md, doc-updater secret fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,7 +210,7 @@ exists for adopters as much as for this repo.
 
 - [`workflow-failure-issue.yml`](./.github/workflows/ss-workflow-failure-issue.yml) — failed workflow runs on `main` raise (or update) a tracking issue labelled `workflow-failure`. Linked from the live site
 - [`hygiene-auto-label-pr.yml`](./.github/workflows/ss-hygiene-auto-label-pr.yml) — labels PRs by changed paths via [`labeler.yml`](./.github/labeler.yml)
-- [`hygiene-doc-updater.md`](./.github/workflows/ss-hygiene-doc-updater.md) — gh-aw agentic workflow; weekly scan of merged PRs + open `documentation` issues, opens sync PRs labelled `documentation, automation`. Requires `ANTHROPIC_API_KEY` secret
+- [`hygiene-doc-updater.md`](./.github/workflows/ss-hygiene-doc-updater.md) — gh-aw agentic workflow; weekly scan of merged PRs + open `documentation` issues, opens sync PRs labelled `documentation, automation`. Requires `COPILOT_GITHUB_TOKEN` secret (gh-aw runs the GitHub Copilot CLI engine)
 
 ## Commit conventions
 
@@ -253,7 +253,7 @@ behaviour matches CI exactly.
 - **Netlify:** deployment is driven by GitHub Actions (not Netlify's git
   integration). DNS is managed externally.
 - **GitHub Actions:** workflows require `NETLIFY_AUTH_TOKEN`,
-  `NETLIFY_SITE_ID`, and (for the agentic doc updater) `ANTHROPIC_API_KEY`.
+  `NETLIFY_SITE_ID`, and (for the agentic doc updater) `COPILOT_GITHUB_TOKEN`.
 - **Netlify API:** the cleanup workflow uses
   `https://api.netlify.com/api/v1/sites/{site_id}/deploys` to delete
   preview deployments.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Richard Griffiths
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The 20 workflows split into four portability layers. Layer 1 runs the moment you
 | **1. Static analysis** (any code) | SAST, Secrets, Trivy, Dependency Review, Complexity, Doc Structure / Accuracy / Size, Auto-label PRs, Workflow-failure tracker | Nothing — works out of the box |
 | **2. Web-app dynamic** (need a URL) | Smoke, Broken Links, Accessibility, Core Web Vitals, SEO Metatags, DAST, Playwright | `SMOKE_TEST_URL` · `BROKEN_LINKS_TEST_URL` · `ACCESSIBILITY_TEST_URL` · `LIGHTHOUSE_URL` · `SEO_TEST_URL` · optionally `SMOKE_PAGES` / `BROKEN_LINKS_PAGES` / `ACCESSIBILITY_PAGES` / `SEO_PAGES` |
 | **3. Netlify deploy** | Preview deploys, production releases, preview cleanup | `NETLIFY_AUTH_TOKEN` + `NETLIFY_SITE_ID` repo secrets |
-| **4. Agentic doc-updater** | Weekly doc-sync PRs | `ANTHROPIC_API_KEY` repo secret |
+| **4. Agentic doc-updater** | Weekly doc-sync PRs | `COPILOT_GITHUB_TOKEN` repo secret |
 
 Don't use Netlify or the doc-updater? Delete those workflows from `.github/workflows/` — re-running the installer respects deletions (tracked in `.ss/.workflows-installed`).
 
@@ -159,7 +159,7 @@ Most checks work out of the box. Things to wire up if you want the full suite:
 **Repo secrets** (under your repo's Settings → Secrets and variables → Actions):
 
 - `NETLIFY_AUTH_TOKEN` + `NETLIFY_SITE_ID` — for the Netlify deploy + preview cleanup workflows
-- `ANTHROPIC_API_KEY` — for the agentic doc-updater (`ss-hygiene-doc-updater`)
+- `COPILOT_GITHUB_TOKEN` — for the agentic doc-updater (`ss-hygiene-doc-updater`), a [gh-aw](https://github.github.com/gh-aw/) workflow that runs via the GitHub Copilot CLI engine. See the [gh-aw Copilot setup guide](https://github.github.com/gh-aw/reference/engines/#github-copilot-default) for how to generate the token
 
 **Tunable env vars** (set in workflows or locally):
 
@@ -227,4 +227,4 @@ same instructions automatically.
 
 ## License
 
-MIT — see [LICENSE](./LICENSE) if present, or the package metadata.
+MIT — see [LICENSE](./LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security Policy
+
+## Supported versions
+
+SlopStopper is a rolling release shipped from `main`. Adopters re-run
+`install.sh` to pick up fixes. Only the latest `main` is supported with
+security patches.
+
+| Version | Supported |
+| ------- | --------- |
+| `main`  | ✅ |
+| Older installs | Re-run `install.sh` to pick up patches |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security bugs.**
+
+Use [GitHub Security Advisories](https://github.com/hungovercoders/slopstopper/security/advisories/new)
+to report privately. This routes the report to the maintainers and lets
+us coordinate disclosure with you.
+
+What to include:
+
+- A clear description of the issue and the impact you can demonstrate
+- Reproduction steps (a minimal example, ideally against a fork)
+- The commit SHA or workflow file affected
+- Any suggested mitigation
+
+## What to expect
+
+- **Acknowledgement** within 5 working days.
+- **Triage update** within 10 working days — confirming whether it's
+  in scope, an estimated severity, and a fix timeline.
+- **Coordinated disclosure** once a fix has shipped to `main`. We will
+  credit you in the advisory unless you ask us not to.
+
+## Scope
+
+In scope:
+
+- Code in this repository (`Taskfile.ss.yml`, `.ss/scripts/`,
+  `.github/workflows/ss-*.yml`, `install.sh`, the `app/` site).
+- Documentation that, if followed, would lead an adopter into an
+  insecure configuration.
+
+Out of scope:
+
+- Vulnerabilities in upstream tools (Semgrep, Trivy, ZAP, Gitleaks,
+  Lizard, axe-core, Lighthouse). Please report those upstream.
+- Findings produced by the suite running against adopter code — those
+  belong to the adopter.
+- Denial of service against `slopstopper.dev` (the demo site).
+
+## Related docs
+
+- [`docs/security/README.md`](./docs/security/README.md) — overview of
+  what each security check does and how to extend it.
+- [`docs/security/CSP_EXCEPTIONS.md`](./docs/security/CSP_EXCEPTIONS.md) —
+  the scoped CSP exception pattern used by the demo site, and the
+  pattern adopters should copy.


### PR DESCRIPTION
## Summary

Three launch-blockers surfaced by the public-launch readiness review.

- **Add `LICENSE` (MIT).** `README.md` already pointed at `./LICENSE` but the file didn't exist. Without it, adopters have no legal basis to use the suite.
- **Add `SECURITY.md`.** Vulnerability disclosure routed through [GitHub Security Advisories](https://github.com/hungovercoders/slopstopper/security/advisories/new), with scope notes (in-scope: this repo; out-of-scope: upstream tools and findings against adopter code). Standard expectation for an OSS security tool.
- **Fix the doc-updater secret name in docs.** The compiled gh-aw workflow (`ss-hygiene-doc-updater.lock.yml`) validates `COPILOT_GITHUB_TOKEN` because the source spec uses the GitHub Copilot CLI engine. README + AGENTS were telling adopters to set `ANTHROPIC_API_KEY` — silent fail at the validate-secret step. Fixed all four references and added a link to the gh-aw Copilot setup guide.

Out of scope for this PR — to follow next, branched from main once this lands:

- P1: tool-count off-by-one, stale feedback.html comment, "Operational" → "Runbooks" naming.
- P2: install.sh preflight checks, Netlify/doc-updater workflow guards, README demo-site relocation, CONTRIBUTING adopter disclaimer.
- P3: surfacing `ss-hygiene-csp-exceptions-check` and `ss-security-vulnerability-new-check` on `features.html`.

## Test plan

- [x] `task ss:hygiene:docs-accuracy` — green locally
- [x] `task ss:hygiene:docs-structure` — green locally
- [x] `grep -rn 'ANTHROPIC_API_KEY' README.md AGENTS.md docs/` returns zero hits
- [ ] CI all-green on the PR
- [ ] After merge, verify GitHub repo "About" sidebar shows the MIT licence badge
- [ ] After merge, verify `/security/policy` route on the repo renders SECURITY.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)