### PR TITLE
chore: launch-readiness polish — drift fixes + adopter friction

### DIFF
--- a/.github/workflows/ss-netlify-cleanup-preview.yml
+++ b/.github/workflows/ss-netlify-cleanup-preview.yml
@@ -16,6 +16,11 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           PR_NUMBER: ${{ github.event.number }}
         run: |
+          if [ -z "${NETLIFY_AUTH_TOKEN:-}" ] || [ -z "${NETLIFY_SITE_ID:-}" ]; then
+            echo "::warning::Netlify secrets not set — skipping cleanup. If you don't use Netlify, delete this workflow (see README §Configure)."
+            exit 0
+          fi
+
           echo "Cleaning up preview deployment for PR #${PR_NUMBER}"
           
           # Get the deploy ID for this PR's preview alias

--- a/.github/workflows/ss-netlify-deploy.yml
+++ b/.github/workflows/ss-netlify-deploy.yml
@@ -15,22 +15,39 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - name: Check Netlify is configured
+        id: netlify-check
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        run: |
+          if [ -z "${NETLIFY_AUTH_TOKEN:-}" ] || [ -z "${NETLIFY_SITE_ID:-}" ]; then
+            echo "::warning::Netlify secrets not set — skipping deploy. If you don't use Netlify, delete this workflow (see README §Configure)."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout code
+        if: steps.netlify-check.outputs.configured == 'true'
         uses: actions/checkout@v4
 
       - name: Setup Node.js
+        if: steps.netlify-check.outputs.configured == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
       - name: Install dependencies
+        if: steps.netlify-check.outputs.configured == 'true'
         run: npm ci
 
       - name: Build
+        if: steps.netlify-check.outputs.configured == 'true'
         run: npm run build
 
       - name: Deploy to Netlify (Production)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: steps.netlify-check.outputs.configured == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: nwtgck/actions-netlify@v2.1
         with:
           publish-dir: './app'
@@ -46,7 +63,7 @@ jobs:
         timeout-minutes: 5
 
       - name: Deploy to Netlify (Preview)
-        if: github.event_name == 'pull_request'
+        if: steps.netlify-check.outputs.configured == 'true' && github.event_name == 'pull_request'
         uses: nwtgck/actions-netlify@v2.1
         with:
           publish-dir: './app'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ slopstopper/
 ├── app/                      # Static site — Netlify publish dir
 │   ├── index.html            # Hero + Get Started + capability grid
 │   ├── features.html         # 5 category cards with YAML excerpts + mock reports
-│   ├── tools.html            # 14 tool cards with YAML/config excerpts
+│   ├── tools.html            # 15 tool cards with YAML/config excerpts
 │   ├── shared.css            # Brand system, components, layout primitives
 │   ├── index.css             # Page-specific layout
 │   ├── features.css          # Page-specific layout (loops, bridge, reports)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 # Contributing to SlopStopper
 
+> 📌 **This guide is for contributors to the SlopStopper project itself.**
+> If you've installed SlopStopper into your own repo and want to customise
+> or extend it there, the main [`README.md`](./README.md) and
+> [`docs/`](./docs/) cover that. Read on if you want to push a change up to
+> this repository.
+
 Thanks for considering a contribution. The full contributor guide lives at:
 
 → [`docs/contributing/README.md`](./docs/contributing/README.md)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Five loops of feedback, all running on every PR and push to `main`:
 | 🔒 **Security** | SAST, DAST, secrets detection, dependency CVE scanning | Semgrep, OWASP ZAP, Gitleaks, Trivy | [Security →](./docs/security/README.md) |
 | 🧹 **Hygiene** | Cyclomatic complexity caps, doc structure / accuracy / size checks, auto-labelled PRs | Lizard, Bandit, markdownlint | [Hygiene →](./docs/hygiene/README.md) |
 | ✅ **Reliability** | E2E + smoke tests, internal broken-link audits, accessibility audits (WCAG 2.1 AA), Core Web Vitals, SEO + OpenGraph metatag checks | Playwright, axe-core, Lighthouse CI, stdlib Python | [Reliability →](./docs/reliability/README.md) |
-| 🤖 **Operational** | Failed workflows auto-raise GitHub issues; an agentic doc updater opens weekly sync PRs | GitHub Actions, gh-aw | [Runbooks →](./docs/runbooks/README.md) |
+| 🤖 **Runbooks** | Failed workflows auto-raise GitHub issues; an agentic doc updater opens weekly sync PRs | GitHub Actions, gh-aw | [Runbooks →](./docs/runbooks/README.md) |
 | 🚀 **Deployment** | Preview deploys per PR, automated production releases, preview cleanup | Netlify, GitHub Actions | [Deployment →](./docs/deployment/README.md) |
 
 ### What each check needs
@@ -185,21 +185,6 @@ afterwards.
 ```bash
 curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install.sh | bash
 ```
-
----
-
-## Run the demo site locally
-
-This repo also hosts the SlopStopper marketing site (the same set of HTML
-pages you'd see at the live URL). To run it yourself:
-
-```bash
-npm install
-npm run build      # compiles TypeScript
-npm start          # serves app/ on http://localhost:8080
-```
-
-`server.js` parses `netlify.toml` so local headers match production.
 
 ---
 

--- a/app/feedback.html
+++ b/app/feedback.html
@@ -76,27 +76,12 @@
             <p class="lede">Sign in with GitHub. Your comment goes straight to <a href="https://github.com/hungovercoders/slopstopper/discussions/categories/feedback" rel="noopener noreferrer">our Discussions tab</a>.</p>
 
             <!--
-                Giscus embed.
-
-                This page (and ONLY this page) has a relaxed CSP — see
-                netlify.toml's [[headers]] block for /feedback.html and the
-                full rationale in docs/security/CSP_EXCEPTIONS.md. The
-                ss:hygiene:csp-exceptions check enforces that the two stay
-                in sync.
-
-                Three placeholders below need filling once Discussions is
-                enabled on the repo and the Giscus app is installed
-                (https://github.com/apps/giscus):
-                  - data-repo-id
-                  - data-category
-                  - data-category-id
-                The giscus.app config wizard generates them. Until then the
-                widget will fail to render and the fallback link below stays
-                useful.
-
+                Giscus embed. This page (and ONLY this page) has a relaxed
+                CSP — see netlify.toml's [[headers]] block for /feedback.html
+                and the full rationale in docs/security/CSP_EXCEPTIONS.md.
+                The ss:hygiene:csp-exceptions check keeps the two in sync.
                 The integrity= attribute pins the exact bundle hash served
-                by giscus.app. Refresh procedure documented in
-                docs/security/CSP_EXCEPTIONS.md.
+                by giscus.app — refresh procedure in CSP_EXCEPTIONS.md.
             -->
             <div class="giscus"></div>
             <script src="https://giscus.app/client.js"

--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,7 @@
 #   1. Static analysis  — work on any code (SAST, Secrets, Trivy, complexity, doc checks)
 #   2. Web-app dynamic  — need a URL (Smoke, Accessibility, CWV, Playwright)
 #   3. Netlify deploy   — need NETLIFY_AUTH_TOKEN + NETLIFY_SITE_ID secrets
-#   4. Agentic updater  — needs ANTHROPIC_API_KEY (gh-aw doc-updater)
+#   4. Agentic updater  — needs COPILOT_GITHUB_TOKEN (gh-aw doc-updater)
 # Don't use one of the layers? Delete its workflows from .github/workflows/.
 # Re-running this installer will respect that deletion (it tracks what it
 # installed in .ss/.workflows-installed).
@@ -53,6 +53,41 @@ warn()    { echo "  ⚠️  $*"; }
 error()   { echo "  ❌ $*" >&2; exit 1; }
 
 sep() { echo "────────────────────────────────────────────────────────────"; }
+
+# ── prerequisite check ────────────────────────────────────────────────────────
+#
+# Surface missing tools up front rather than letting the install fail mid-flight
+# with a cryptic "command not found". `git` is hard-required (the installer
+# clones this repo); the rest are soft-required (you'll need them to actually
+# run any check, but the install itself will succeed without them).
+
+preflight() {
+  local missing_hard=()
+  local missing_soft=()
+
+  command -v git     >/dev/null 2>&1 || missing_hard+=("git")
+  command -v node    >/dev/null 2>&1 || missing_soft+=("node (Playwright, Lighthouse CI, markdownlint, TypeScript): https://nodejs.org/")
+  command -v python3 >/dev/null 2>&1 || missing_soft+=("python3 (analysis scripts under .ss/scripts): https://www.python.org/downloads/")
+  command -v task    >/dev/null 2>&1 || missing_soft+=("task (canonical interface — every check is 'task ss:...'): https://taskfile.dev/installation/")
+  command -v docker  >/dev/null 2>&1 || info "Docker not found — only needed for DAST (task ss:security:dast). Skipping check."
+
+  if [ "${#missing_hard[@]}" -gt 0 ]; then
+    for tool in "${missing_hard[@]}"; do
+      echo "  ❌ Required tool missing: $tool" >&2
+    done
+    error "Install the tools above and re-run."
+  fi
+
+  if [ "${#missing_soft[@]}" -gt 0 ]; then
+    warn "The following tools aren't installed — you'll need them to run the checks SlopStopper installs:"
+    for tool in "${missing_soft[@]}"; do
+      echo "      • $tool"
+    done
+    info "Continuing with install; install the tools above before running any task."
+  fi
+}
+
+preflight
 
 # ── locate source directory ───────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Second pass on the launch-readiness review. Six concrete adopter-facing fixes plus one workflow-resilience change.

**Visible drift**
- `AGENTS.md` line 87: `14 tool cards` → `15`. The markdownlint card was added in the SEO PR but the doc never updated.
- `app/feedback.html`: trim the now-stale Giscus comment. The `data-repo-id` / `data-category` / `data-category-id` placeholders have been filled for some time. Kept the CSP-exception pointer + SRI refresh note.
- `README.md`: rename the **Operational** loop to **Runbooks** so the heading matches the link target (`docs/runbooks/`, not `docs/operational/`). The AGENTS.md naming convention says categories drive naming across the project — this brings README back in line.

**Adopter focus**
- `README.md`: drop the *Run the demo site locally* section. That's internal-contributor content; `CONTRIBUTING.md` and `docs/contributing/` already cover it. README stays focused on adopters installing into their own repo.
- `CONTRIBUTING.md`: prominent banner at the top noting the guide is for SlopStopper-project contributors, not adopters customising their installed copy. GitHub surfaces CONTRIBUTING.md whenever anyone opens an issue or PR, so this prevents adopter confusion.

**Install resilience**
- `install.sh`: new `preflight()` function checks for `git` / `node` / `python3` / `task` before any work happens. Hard-required (`git`) blocks the install with a clear pointer; soft-required (everything else) prints friendly install URLs and continues. Docker is treated as info-only since it's only needed for DAST.
- Also folds in the doc-updater secret-name fix in the install.sh header comment — `ANTHROPIC_API_KEY` → `COPILOT_GITHUB_TOKEN`. Same class of bug as PR #152, missed there.

**Workflow guards**
- `ss-netlify-deploy.yml` + `ss-netlify-cleanup-preview.yml`: early guard step exits cleanly with an Actions warning if `NETLIFY_AUTH_TOKEN` / `NETLIFY_SITE_ID` aren't set, pointing at README §Configure. Replaces the previous behaviour of letting the workflow burn CI minutes and fail with opaque 401s.

## Deferred to a follow-up

The same guard pattern on `ss-hygiene-doc-updater` (gates on `COPILOT_GITHUB_TOKEN`) — requires editing the gh-aw `.md` spec and re-running `gh aw compile`. Separate concern, separate PR.

## Out of scope for this PR — landing next

- P3: surface `ss-hygiene-csp-exceptions-check.yml` and `ss-security-vulnerability-new-check.yml` on `features.html`.

## Test plan

- [x] `task ss:hygiene:docs-accuracy` — green locally
- [x] `task ss:hygiene:docs-structure` — green locally
- [x] `task ss:hygiene:csp-exceptions` — green locally (2 expected exceptions match)
- [x] `bash -n install.sh` — passes
- [ ] CI all-green on the PR (especially the Netlify deploy workflow, which now has the guard but should still find its secrets on this repo)
- [ ] Manual: verify preview deploy still posts a PR comment (proves guard didn't break the happy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)