### PR TITLE
chore: add CODE_OF_CONDUCT (Contributor Covenant 2.1 by reference)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,27 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)
+as its code of conduct. The canonical text — including the standards we
+expect, our responsibilities as maintainers, scope, and enforcement
+guidelines — lives at the link above.
+
+Please read it before contributing.
+
+## Reporting
+
+If you experience or witness behaviour that violates the Contributor
+Covenant in this project's spaces (issues, pull requests, discussions,
+or any other channel run by the project), please report it via
+[GitHub Security Advisories](https://github.com/hungovercoders/slopstopper/security/advisories/new).
+
+Reports are received privately by the maintainers. We will respond
+within 5 working days, and follow the
+[enforcement ladder](https://www.contributor-covenant.org/version/2/1/code_of_conduct/#enforcement-guidelines)
+defined in the Contributor Covenant.
+
+## Scope
+
+This Code of Conduct applies to all project spaces — the GitHub
+repository, the demo site at slopstopper.dev, and any public channels
+run on behalf of the project — and to project members representing
+SlopStopper in public spaces.


### PR DESCRIPTION
## Summary

Closes the last launch-readiness gap not covered by PRs #152 / #153 / #154.

Adopts the Contributor Covenant 2.1 **by reference** rather than inlining the full text. The canonical version lives at [contributor-covenant.org](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) and is the authoritative source; this file is a thin pointer that:

- Names the standard adopted
- Links to the canonical text
- States the reporting channel (GitHub Security Advisories, same as `SECURITY.md`)
- Names the scope (repo, demo site, project-run channels)

Satisfies GitHub's community-profile check while keeping the file small.

## Test plan

- [ ] CI all-green
- [ ] After merge, GitHub repo "Community standards" view shows Code of Conduct as ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)