### PR TITLE
feat(site): copy button on install curl command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ test-results/
 .ss/reports/
 # Local Netlify folder
 .netlify
-# TypeScript compiled output
+# TypeScript compiled output (copy.js is hand-written runtime JS, not a tsc artefact)
 app/*.js
+!app/copy.js
 # Local Claude Code state
 .claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ slopstopper/
 │   ├── index.css             # Page-specific layout
 │   ├── features.css          # Page-specific layout (loops, bridge, reports)
 │   ├── tools.css             # Page-specific layout
+│   ├── copy.js               # Progressive-enhancement copy button for [data-copyable] codeblocks; only runtime JS
 │   ├── favicon.svg           # Inline SVG favicon (CSP-safe)
 │   ├── apple-touch-icon.svg  # Source for the 180×180 iOS home-screen icon
 │   ├── apple-touch-icon.png  # Rendered via task ss:contributing:assets
@@ -98,7 +99,7 @@ slopstopper/
 │   ├── robots.txt            # Allows all, points at the sitemap
 │   └── sitemap.xml           # Lists the three indexable pages
 ├── docs/                     # Documentation hub — see docs/index.md
-├── src/                      # TypeScript stubs (build target; no runtime JS)
+├── src/                      # TypeScript stubs (build target; runtime JS is limited to app/copy.js)
 ├── tests/                    # Playwright smoke + accessibility specs
 ├── install.sh                # Adopter installer
 ├── netlify.toml              # Netlify config + strict CSP

--- a/app/copy.js
+++ b/app/copy.js
@@ -1,0 +1,41 @@
+(() => {
+    if (!navigator.clipboard || typeof navigator.clipboard.writeText !== "function") return;
+
+    const blocks = document.querySelectorAll(".codeblock[data-copyable]");
+    blocks.forEach((block) => {
+        const code = block.querySelector("code");
+        if (!code) return;
+
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "codeblock__copy";
+        button.textContent = "Copy";
+        const label = block.getAttribute("aria-label");
+        button.setAttribute("aria-label", label ? `Copy: ${label}` : "Copy to clipboard");
+
+        const status = document.createElement("span");
+        status.className = "visually-hidden";
+        status.setAttribute("aria-live", "polite");
+
+        let timer;
+        button.addEventListener("click", async () => {
+            const text = code.textContent.trim();
+            try {
+                await navigator.clipboard.writeText(text);
+                button.textContent = "Copied";
+                status.textContent = "Copied to clipboard";
+            } catch {
+                button.textContent = "Copy failed";
+                status.textContent = "Copy failed";
+            }
+            clearTimeout(timer);
+            timer = setTimeout(() => {
+                button.textContent = "Copy";
+                status.textContent = "";
+            }, 1500);
+        });
+
+        block.appendChild(button);
+        block.appendChild(status);
+    });
+})();

--- a/app/index.html
+++ b/app/index.html
@@ -89,7 +89,7 @@
             <span class="kicker">Get started</span>
             <h2>One command. Whole pipeline.</h2>
             <p class="lede">Drop SlopStopper into your repo and you get the full bundle: security, hygiene, reliability, accessibility, performance and deployment checks — all running on every PR.</p>
-            <div class="codeblock codeblock--sh" role="region" aria-label="Install command">
+            <div class="codeblock codeblock--sh" role="region" aria-label="Install command" data-copyable>
                 <pre><code>curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install.sh | bash</code></pre>
             </div>
             <details class="details">
@@ -152,5 +152,6 @@
     <footer>
         <p>SlopStopper is open source — <a href="https://github.com/hungovercoders/slopstopper" rel="noopener noreferrer">view the repository on GitHub</a>.</p>
     </footer>
+    <script src="copy.js" defer></script>
 </body>
 </html>

--- a/app/shared.css
+++ b/app/shared.css
@@ -345,6 +345,48 @@ main {
 .codeblock--yaml::before {
     content: none;
 }
+.codeblock[data-copyable] {
+    padding-right: 5.5rem;
+}
+.codeblock__copy {
+    position: absolute;
+    top: 0.6rem;
+    right: 0.6rem;
+    padding: 0.35rem 0.75rem;
+    font: inherit;
+    font-size: 0.8rem;
+    line-height: 1;
+    background: var(--peach);
+    color: var(--ink);
+    border: var(--border-thin);
+    border-radius: var(--r-sm);
+    box-shadow: var(--shadow-sticker-sm);
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.codeblock__copy:hover {
+    transform: translate(-1px, -1px) rotate(-1deg);
+    box-shadow: 3px 3px 0 var(--ink);
+}
+.codeblock__copy:active {
+    transform: translate(1px, 1px);
+    box-shadow: 1px 1px 0 var(--ink);
+}
+.codeblock__copy:focus-visible {
+    outline: 3px solid var(--ink);
+    outline-offset: 2px;
+}
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
 
 /* ─── Details (no JS, custom marker) ─────────────────────── */
 .details {


### PR DESCRIPTION
## Summary

- Adds a copy button to the install `curl` block on the landing page — the single most-important interaction for adopters
- New `app/copy.js` (~40 lines, vanilla) — opt-in via `data-copyable`, progressive enhancement (no JS → no button, no broken UI)
- No CSP changes. `script-src 'self'` already covers a local script; the strict default-src block is untouched
- Brand-consistent button styling — peach surface, ink border, sticker shadow, hover lift, focus ring

## Why this and not just a `<pre>`

Triple-clicking inside `<pre>` is fiddly, and `.codeblock--sh::before` injects a non-selectable `$` prefix that makes the selection visually ambiguous. Adopters can now click once.

## Why opt-in

Only `.codeblock[data-copyable]` gets a button. The YAML/curl snippets on `features.html` are illustrative, not things a user copies — `data-copyable` keeps them clean.

## Why we now have runtime JS

AGENTS.md previously said "no runtime JS". This PR adds the first runtime script. The doc is updated to reflect that `copy.js` is the one documented exception, and the `app/*.js` gitignore now has a `!app/copy.js` carve-out with a comment so future readers don't re-ignore it.

## Test plan

- [x] `task ss:contributing:build` — TypeScript build green
- [x] `task ss:contributing:run` + manual click — clipboard contains the exact curl one-liner; label restores after 1.5s
- [x] Programmatic Playwright check: button visible, `aria-label="Copy: Install command"`, click → `navigator.clipboard.readText()` returns the full curl line
- [x] `.ss/tests/smoke.spec.ts` — passes (would have failed if `copy.js` emitted a `pageerror`)
- [x] `.ss/tests/accessibility.spec.ts` — passes; no new axe violations
- [ ] Visual check on the Netlify preview before merge
- [ ] Verify CSP-strict default `/*` block on `netlify.toml` still holds in production via DAST run

## Out of scope

- Copy buttons on `features.html` / `tools.html` illustrative blocks
- A toast / snackbar system
- Touching `script-src 'self'` or any CSP directive

🤖 Generated with [Claude Code](https://claude.com/claude-code)