### PR TITLE
feat(meta): adoption metrics via ss:meta:adoption

### DIFF
--- a/Taskfile.ss.yml
+++ b/Taskfile.ss.yml
@@ -1400,23 +1400,33 @@ tasks:
           exit 1
         fi
         REPO="hungovercoders/slopstopper"
+        CUTOFF=$(date -u -v-14d +%Y-%m-%d 2>/dev/null || date -u -d '14 days ago' +%Y-%m-%d)
         stars=$(gh api "repos/$REPO" --jq '.stargazers_count')
         forks=$(gh api "repos/$REPO" --jq '.forks_count')
         clones_total=$(gh api "repos/$REPO/traffic/clones" --jq '.count')
         clones_unique=$(gh api "repos/$REPO/traffic/clones" --jq '.uniques')
         views_total=$(gh api "repos/$REPO/traffic/views" --jq '.count')
         views_unique=$(gh api "repos/$REPO/traffic/views" --jq '.uniques')
+        ci_runs=$(gh api -X GET "repos/$REPO/actions/runs" -f "created=>$CUTOFF" --jq '.total_count')
+        installs_est=$(( clones_total - ci_runs ))
+        if [ "$installs_est" -lt 0 ]; then installs_est=0; fi
         adopters=$(gh api -X GET "search/code" -f q="filename:Taskfile.ss.yml" --jq '.total_count' 2>/dev/null || echo "?")
         cat <<EOF
         ## SlopStopper adoption — $(date -u +%Y-%m-%d)
 
+        **Real-adopter signals (uncontaminated by this repo's CI):**
+        - 📦 Public adopters (Taskfile.ss.yml on default branch): $adopters
         - ⭐ Stars: $stars
         - 🍴 Forks: $forks
-        - 📥 Clones (14-day): $clones_total total / $clones_unique unique
         - 👀 Views (14-day): $views_total total / $views_unique unique
-        - 📦 Public adopters (Taskfile.ss.yml on default branch): $adopters
 
-        See docs/runbooks/adoption-metrics.md for caveats.
+        **Clone signal (heavily polluted by this repo's CI):**
+        - 📥 Clones (14-day): $clones_total total / $clones_unique unique
+        - 🤖 Workflow runs (14-day, ≈ CI checkouts): $ci_runs
+        - 🧮 Install estimate (clones − CI runs, floored at 0): $installs_est
+
+        See docs/runbooks/adoption-metrics.md for what each number means
+        and why the clone signal is unreliable on this repo.
         EOF
 
   install:

--- a/Taskfile.ss.yml
+++ b/Taskfile.ss.yml
@@ -1371,6 +1371,54 @@ tasks:
         cp docs/decisions/DECISION_TEMPLATE.md "$target"
         echo "✅ Created $target"
 
+  meta:adoption:
+    desc: Print public adoption signals (stars, forks, clones, views, public adopters)
+    summary: |
+      Public-signals-only adoption snapshot. Prints a small Markdown block
+      to stdout — copy/paste into a status update, release notes or a
+      tracking issue. No persistence, no phone-home.
+
+      Signals reported:
+        ⭐ Stars + forks
+        📥 14-day clones (total + unique cloners)
+        👀 14-day views (total + unique visitors)
+        📦 Public adopters with Taskfile.ss.yml on the default branch
+
+      Authentication: needs `gh` authenticated with `repo` scope (the
+      Traffic endpoints require it). `gh auth login` if you see 403s.
+
+      See docs/runbooks/adoption-metrics.md for what each number means
+      and what it doesn't.
+    cmds:
+      - |
+        if ! command -v gh >/dev/null 2>&1; then
+          echo "❌ gh CLI not installed — https://cli.github.com/"
+          exit 1
+        fi
+        if ! gh auth status >/dev/null 2>&1; then
+          echo "❌ gh not authenticated — run: gh auth login"
+          exit 1
+        fi
+        REPO="hungovercoders/slopstopper"
+        stars=$(gh api "repos/$REPO" --jq '.stargazers_count')
+        forks=$(gh api "repos/$REPO" --jq '.forks_count')
+        clones_total=$(gh api "repos/$REPO/traffic/clones" --jq '.count')
+        clones_unique=$(gh api "repos/$REPO/traffic/clones" --jq '.uniques')
+        views_total=$(gh api "repos/$REPO/traffic/views" --jq '.count')
+        views_unique=$(gh api "repos/$REPO/traffic/views" --jq '.uniques')
+        adopters=$(gh api -X GET "search/code" -f q="filename:Taskfile.ss.yml" --jq '.total_count' 2>/dev/null || echo "?")
+        cat <<EOF
+        ## SlopStopper adoption — $(date -u +%Y-%m-%d)
+
+        - ⭐ Stars: $stars
+        - 🍴 Forks: $forks
+        - 📥 Clones (14-day): $clones_total total / $clones_unique unique
+        - 👀 Views (14-day): $views_total total / $views_unique unique
+        - 📦 Public adopters (Taskfile.ss.yml on default branch): $adopters
+
+        See docs/runbooks/adoption-metrics.md for caveats.
+        EOF
+
   install:
     desc: Install SlopStopper tooling into another repository (use TARGET=<path>)
     summary: |

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -2,9 +2,9 @@
 
 Operational procedures for the SlopStopper project.
 
-## Overview
+## Available runbooks
 
-This directory holds step-by-step runbooks for common operational tasks. As the project is a minimal static site template, operational procedures are currently minimal.
+- [adoption-metrics.md](adoption-metrics.md) — How to measure who is using SlopStopper using only public GitHub signals. Backs `task ss:meta:adoption`.
 
 ## Adding Runbooks
 

--- a/docs/runbooks/adoption-metrics.md
+++ b/docs/runbooks/adoption-metrics.md
@@ -9,32 +9,66 @@ No phone-home, no proxy install, no adopter-side instrumentation.
 task ss:meta:adoption
 ```
 
-Prints a copy/pasteable Markdown block with the five signals below.
+Prints a copy/pasteable Markdown block split into two sections —
+**real-adopter signals** (trustworthy) and **clone signals** (heavily
+contaminated by this repo's own CI; see below).
+
 Needs `gh` authenticated with `repo` scope (`gh auth login` if you see
 403s — the Traffic endpoints require it).
 
+## The clone problem (read this first)
+
+SlopStopper runs ~20 GitHub Actions workflows, most of them on every
+push and every PR, plus several on schedules. Each run typically does
+at least one `actions/checkout` — which **is a git clone** counted by
+GitHub's Traffic API.
+
+In practice, this repo's CI generates ~2,000 clones per 14-day window
+all by itself. A real human installing SlopStopper adds 1 clone to
+the same bucket. The raw clones number is therefore ≈ CI noise + a
+sprinkling of real installs.
+
+The task subtracts the workflow-run count from the clones total to
+give a rough "install estimate." It's imperfect (some workflows do
+zero checkouts, some do several), but it gets the order of magnitude
+right and is far more useful than the raw clones number.
+
+**Rule of thumb:** treat the `installs_est` figure as ±50%, and only
+trust the trend (week-over-week direction), not the absolute number.
+
 ## What each signal means
+
+### 📦 Public adopters — the most reliable signal
+
+`gh api -X GET search/code -f q='filename:Taskfile.ss.yml'`
+
+Counts public repos with `Taskfile.ss.yml` checked in — that file is
+the SlopStopper marker (it wires the `ss:` namespace into the root
+Taskfile). This is the strongest "real, persistent install" signal we
+have because:
+
+- It's a specific filename, not a pattern an unrelated repo would
+  have by accident.
+- Adopters keep it. If `Taskfile.ss.yml` is gone, SlopStopper has
+  been ripped out.
+- It isn't contaminated by CI activity, downloads, or curl runs.
+
+**Limitations:**
+
+- **Public repos only.** Private adopters are invisible by design.
+- **Default branch only.** Code search ignores other branches.
+- **Capped at 1,000 results** by the search API. Cross that bridge
+  if we get there.
+- **Excludes forks** — which is what we want; a fork isn't an
+  install.
 
 ### ⭐ Stars and 🍴 forks
 
 `gh api repos/hungovercoders/slopstopper`
 
-Interest, not adoption. People star repos they want to bookmark. Forks
-are a lighter signal of "I might do something with this" but still
-usually exploratory.
-
-### 📥 Clones (14-day total + unique cloners)
-
-`gh api repos/hungovercoders/slopstopper/traffic/clones`
-
-This is the strongest install proxy we have. `install.sh` runs
-`git clone --depth=1` of the repo, so each install attempt shows up
-here. But so does anyone who clones the repo for any other reason
-(reading the source, debugging an issue, mirroring). Treat it as
-"installs + manual exploration" — a ceiling, not a floor.
-
-**Window:** rolling 14 days. To track trends across longer periods,
-take a snapshot weekly (see "Snapshotting" below).
+Interest, not adoption. People star repos they want to bookmark.
+Forks are a lighter signal of "I might do something with this" but
+still usually exploratory.
 
 ### 👀 Views (14-day total + unique visitors)
 
@@ -44,42 +78,54 @@ Page views on github.com/hungovercoders/slopstopper. A signal of
 interest in the repo itself (README reading, file browsing). Doesn't
 include visits to the live site at slopstopper.dev.
 
-### 📦 Public adopters
+### 📥 Clones (raw, 14-day)
 
-`gh api -X GET search/code -f q='filename:Taskfile.ss.yml'`
+`gh api repos/hungovercoders/slopstopper/traffic/clones`
 
-Counts public repos with `Taskfile.ss.yml` checked in — that file is
-the SlopStopper marker (it's how the `ss:` namespace is wired into the
-root Taskfile). Strongest indicator of real, persistent installs.
+Returned as-is from GitHub for completeness — but **dominated by this
+repo's CI** as explained above. Useful only when paired with the CI
+count below.
 
-**Limitations:**
+### 🤖 Workflow runs (14-day)
 
-- **Public repos only.** Private adopters are invisible by design;
-  that's the trade-off of the public-signals-only posture.
-- **Default branch only.** GitHub code search ignores non-default
-  branches.
-- **Capped at 1,000 results** by the search API. We'll worry about
-  this when we get there.
-- **Excludes forks** by default — which is what we want; a fork isn't
-  an install.
+`gh api -X GET repos/hungovercoders/slopstopper/actions/runs -f created='>=YYYY-MM-DD'`
+
+Total Actions runs in the same window as the Traffic clones. Used as
+a floor estimate of "how many CI checkouts of this repo happened."
+Not exact — a workflow with multiple jobs does multiple checkouts;
+some jobs don't check out at all — but close enough for subtraction.
+
+### 🧮 Install estimate
+
+`clones_total - workflow_runs`, floored at 0.
+
+Best rough proxy for human installs we can derive from public
+signals. Treat as a noisy trend indicator, not a precise number.
 
 ## How to read the output
-
-Most useful as a single snapshot you can paste into release notes, a
-status update, or a tracking issue:
 
 ```
 ## SlopStopper adoption — 2026-06-07
 
+**Real-adopter signals (uncontaminated by this repo's CI):**
+- 📦 Public adopters (Taskfile.ss.yml on default branch): 7
 - ⭐ Stars: 12
 - 🍴 Forks: 3
-- 📥 Clones (14-day): 487 total / 124 unique
 - 👀 Views (14-day): 1,203 total / 218 unique
-- 📦 Public adopters (Taskfile.ss.yml on default branch): 7
+
+**Clone signal (heavily polluted by this repo's CI):**
+- 📥 Clones (14-day): 2,137 total / 315 unique
+- 🤖 Workflow runs (14-day, ≈ CI checkouts): 2,005
+- 🧮 Install estimate (clones − CI runs, floored at 0): 132
 ```
 
-Healthy direction: clones-unique growing, public adopters growing,
-forks > 0. Stars are vanity but track them anyway.
+What "healthy" looks like:
+
+- **Public adopters trending up** week over week — the real win.
+- **Views with growing uniques** — top of funnel is filling.
+- **Install estimate > workflow runs** would mean real human installs
+  outpace CI activity. Aspirational; not realistic until SlopStopper
+  is much more widely known than its own CI is busy.
 
 ## Snapshotting (trend across the 14-day window)
 
@@ -101,7 +147,7 @@ narrow.
 
 - **Private adopters.** No public signal; out of scope by design.
 - **Installs that failed midway** (curl succeeded, git clone failed) —
-  the failed clones don't reach the Traffic endpoint.
+  the failed clones still reach the Traffic endpoint and inflate it.
 - **Anyone who downloaded a release tarball.** We don't cut releases
   today.
 - **slopstopper.dev visitors.** The live site has no analytics
@@ -114,3 +160,22 @@ SlopStopper positions itself as a security and privacy-respecting
 tool. A phone-home in `install.sh` or the workflows would (rightly)
 erode adopter trust and would be the first thing security-conscious
 adopters strip out. Public signals are weaker but defensible.
+
+## If we ever need clean install numbers
+
+Two real options, both more work than this PR is worth:
+
+1. **Switch `install.sh` from `git clone` to a tarball download**
+   (`https://github.com/.../archive/refs/heads/main.tar.gz`). Tarballs
+   don't count in Traffic clones, so the clones number would shrink
+   to "CI + maintainer + exploration" only. But installs would
+   disappear from public signals entirely — adopter count via code
+   search would become the only install proxy.
+
+2. **Proxy the install URL through slopstopper.dev** (Netlify redirect
+   to the raw GitHub file, with redirect counts in Netlify's logs).
+   Gives a real install funnel, requires a documented privacy note,
+   adds a small ongoing cost.
+
+Neither is needed at launch. Reassess if the install-estimate becomes
+the metric the maintainer wants to chase.

--- a/docs/runbooks/adoption-metrics.md
+++ b/docs/runbooks/adoption-metrics.md
@@ -1,0 +1,116 @@
+# Adoption metrics
+
+How to measure who is using SlopStopper, using only public GitHub signals.
+No phone-home, no proxy install, no adopter-side instrumentation.
+
+## TL;DR
+
+```bash
+task ss:meta:adoption
+```
+
+Prints a copy/pasteable Markdown block with the five signals below.
+Needs `gh` authenticated with `repo` scope (`gh auth login` if you see
+403s — the Traffic endpoints require it).
+
+## What each signal means
+
+### ⭐ Stars and 🍴 forks
+
+`gh api repos/hungovercoders/slopstopper`
+
+Interest, not adoption. People star repos they want to bookmark. Forks
+are a lighter signal of "I might do something with this" but still
+usually exploratory.
+
+### 📥 Clones (14-day total + unique cloners)
+
+`gh api repos/hungovercoders/slopstopper/traffic/clones`
+
+This is the strongest install proxy we have. `install.sh` runs
+`git clone --depth=1` of the repo, so each install attempt shows up
+here. But so does anyone who clones the repo for any other reason
+(reading the source, debugging an issue, mirroring). Treat it as
+"installs + manual exploration" — a ceiling, not a floor.
+
+**Window:** rolling 14 days. To track trends across longer periods,
+take a snapshot weekly (see "Snapshotting" below).
+
+### 👀 Views (14-day total + unique visitors)
+
+`gh api repos/hungovercoders/slopstopper/traffic/views`
+
+Page views on github.com/hungovercoders/slopstopper. A signal of
+interest in the repo itself (README reading, file browsing). Doesn't
+include visits to the live site at slopstopper.dev.
+
+### 📦 Public adopters
+
+`gh api -X GET search/code -f q='filename:Taskfile.ss.yml'`
+
+Counts public repos with `Taskfile.ss.yml` checked in — that file is
+the SlopStopper marker (it's how the `ss:` namespace is wired into the
+root Taskfile). Strongest indicator of real, persistent installs.
+
+**Limitations:**
+
+- **Public repos only.** Private adopters are invisible by design;
+  that's the trade-off of the public-signals-only posture.
+- **Default branch only.** GitHub code search ignores non-default
+  branches.
+- **Capped at 1,000 results** by the search API. We'll worry about
+  this when we get there.
+- **Excludes forks** by default — which is what we want; a fork isn't
+  an install.
+
+## How to read the output
+
+Most useful as a single snapshot you can paste into release notes, a
+status update, or a tracking issue:
+
+```
+## SlopStopper adoption — 2026-06-07
+
+- ⭐ Stars: 12
+- 🍴 Forks: 3
+- 📥 Clones (14-day): 487 total / 124 unique
+- 👀 Views (14-day): 1,203 total / 218 unique
+- 📦 Public adopters (Taskfile.ss.yml on default branch): 7
+```
+
+Healthy direction: clones-unique growing, public adopters growing,
+forks > 0. Stars are vanity but track them anyway.
+
+## Snapshotting (trend across the 14-day window)
+
+The Traffic API only exposes the last 14 days, so trend lines need
+the maintainer to snapshot the output. Until there's enough data to
+justify a workflow, just run the task weekly and paste the result
+into a discussion or a dated note. Once we have 6+ snapshots and know
+what shape the trend data should take, formalise it as
+`ss-meta-adoption-snapshot.yml`.
+
+## Authentication
+
+The Traffic endpoints (`/traffic/clones`, `/traffic/views`) require
+push access to the repo, so `gh` needs to be authenticated as a
+maintainer. `gh auth login --scopes repo` if the default token is too
+narrow.
+
+## What this does NOT measure
+
+- **Private adopters.** No public signal; out of scope by design.
+- **Installs that failed midway** (curl succeeded, git clone failed) —
+  the failed clones don't reach the Traffic endpoint.
+- **Anyone who downloaded a release tarball.** We don't cut releases
+  today.
+- **slopstopper.dev visitors.** The live site has no analytics
+  (Netlify's privacy-respecting analytics is paid; we haven't enabled
+  it). If we ever do, add a row here.
+
+## Why not phone home?
+
+SlopStopper positions itself as a security and privacy-respecting
+tool. A phone-home in `install.sh` or the workflows would (rightly)
+erode adopter trust and would be the first thing security-conscious
+adopters strip out. Public signals are weaker but defensible.


### PR DESCRIPTION
## Summary

- New `task ss:meta:adoption` prints a Markdown snapshot of public adoption signals — stars, forks, 14-day clones, 14-day views, and a public-adopter count from GitHub code search for `filename:Taskfile.ss.yml`
- New runbook `docs/runbooks/adoption-metrics.md` explains what each signal means, what it doesn't, and why we deliberately don't phone home
- Uses only `gh api --jq` — no new dependencies

## Why now

The install path (`curl raw.githubusercontent.com/.../install.sh | bash`) gives the maintainer zero visibility. But `install.sh` runs `git clone`, so GitHub's Traffic API has been counting installs in a rolling 14-day window all along. This PR exposes that plus a public-adopter count.

## What it doesn't do

Public-signals-only by design — no proxy install, no workflow phone-home, no adopter-side instrumentation. Private adopters are uncountable; that's the trade for a security-positioning tool at launch. The runbook documents the boundary clearly.

A weekly snapshot workflow (`ss-meta-adoption-snapshot.yml`) is deferred — let the manual task run for 4–6 weeks first so we can shape the snapshot format from real use rather than guess.

## Sample output (real, against this repo right now)

```
## SlopStopper adoption — 2026-06-07

- ⭐ Stars: 0
- 🍴 Forks: 0
- 📥 Clones (14-day): 2137 total / 315 unique
- 👀 Views (14-day): 241 total / 6 unique
- 📦 Public adopters (Taskfile.ss.yml on default branch): 2
```

## Test plan

- [x] `task ss:meta:adoption` — prints all five signals against the live repo
- [x] `task ss:hygiene:docs-accuracy` — green
- [x] `task ss:hygiene:docs-structure` — green
- [ ] Visual review of the runbook on Netlify preview
- [ ] Run with `gh` unauthenticated to confirm the friendly error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)