### PR TITLE
fix(worker): disable html_handling so .html URLs serve directly

### DIFF
--- a/.github/workflows/ss-reliability-seo-check.yml
+++ b/.github/workflows/ss-reliability-seo-check.yml
@@ -122,6 +122,13 @@ jobs:
         id: audit
         env:
           SEO_TEST_URL: ${{ steps.url.outputs.url }}
+          # og:image is an absolute URL pointing at the production domain
+          # (required by social-share crawlers). The reachability HEAD check
+          # can't succeed when auditing localhost, so skip it for local
+          # builds. Keep the presence assertion on. Schedule and
+          # deployment_status runs still verify reachability against the
+          # real deployed URL.
+          SEO_VERIFY_OG_IMAGE: ${{ steps.url.outputs.use_local == 'true' && '0' || '1' }}
         run: task ss:reliability:seo:ci
 
       - name: Stop local server

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,6 +7,7 @@
     "directory": "./app",
     "binding": "ASSETS",
     "not_found_handling": "404-page",
+    "html_handling": "none",
     "run_worker_first": true
   },
   "observability": {


### PR DESCRIPTION
## Summary

- Cloudflare's `[assets]` binding defaults to `html_handling: "auto-trailing-slash"`, which 307-redirects every `.html` URL to its extensionless variant.
- That breaks our canonical URLs: every `<link rel="canonical">`, `og:url`, and `sitemap.xml` entry points at the `.html` version. With auto-redirect, search engines and share-image crawlers would see canonical URLs that don't match the served URL.
- Setting `html_handling: "none"` makes `.html` URLs serve directly. The Worker still 301s `/feedback` → `/feedback.html` for the one pretty-URL alias that needed to stay supported.

## Confirmed on workers.dev

Before this change, against `https://slopstopper.griff182uk.workers.dev`:

```
/feedback.html → 307 Location: /feedback
/features.html → 307 Location: /features
/tools.html    → 307 Location: /tools
```

After this lands, those should all return 200 directly with their per-path headers applied (strict CSP for `/features.html` and `/tools.html`; Giscus-relaxed CSP for `/feedback.html`).

## Test plan

- [ ] Workers Builds deploys this commit.
- [ ] `curl -I` each of `/`, `/features.html`, `/tools.html`, `/feedback.html`, `/og-image.png`, `/feedback` on the workers.dev URL — confirm 200 on all `.html` paths and 301 for `/feedback` → `/feedback.html`.
- [ ] If all four pass, proceed with the DNS cutover (Phase B of `docs/deployment/README.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)