### PR TITLE
fix(worker): serve / from /index.html

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -41,7 +41,15 @@ export default {
       return Response.redirect(`${url.origin}/feedback.html`, 301);
     }
 
-    const response = await env.ASSETS.fetch(request);
+    // html_handling: "none" disables the auto root → index.html lookup, so
+    // rewrite explicitly. Path matching for headers still uses the original
+    // pathname ("/"), so the /* rule applies as expected.
+    const assetRequest =
+      url.pathname === "/"
+        ? new Request(new URL("/index.html", url.origin).toString(), request)
+        : request;
+
+    const response = await env.ASSETS.fetch(assetRequest);
     const next = new Response(response.body, response);
     for (const [name, value] of Object.entries(headersForPath(url.pathname))) {
       next.headers.set(name, value);


### PR DESCRIPTION
## Summary

Side-effect of #159. With `html_handling: "none"`, Cloudflare's `[assets]` binding no longer auto-maps `GET /` → `/index.html`, so the homepage 404s while the rest of the site is fine.

Verified just now against `https://slopstopper.griff182uk.workers.dev`:

| Path | Result |
|------|--------|
| `/` | ❌ 404 (this PR fixes) |
| `/features.html` | ✅ 200 + strict CSP |
| `/tools.html` | ✅ 200 + strict CSP |
| `/feedback.html` | ✅ 200 + Giscus-relaxed CSP |
| `/og-image.png` | ✅ 200 + `Cross-Origin-Resource-Policy: cross-origin` |
| `/feedback` | ✅ 301 → `/feedback.html` |

## Fix

`worker/index.ts` now rewrites the request to `/index.html` when `pathname === "/"`. The header-matching key stays the original pathname (`"/"`), so the `/*` rule applies as expected.

## Test plan

- [ ] Workers Builds redeploys this commit.
- [ ] `curl -I https://slopstopper.griff182uk.workers.dev/` returns 200 with strict CSP.
- [ ] Merge and proceed with the DNS cutover (Phase B/C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)