### PR TITLE
fix(readme): drop bogus GitHub Deployments badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ Every check below runs on every PR and push to `main` here, and ships to consume
 [![Failure Alerts](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-workflow-failure-issue.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-workflow-failure-issue.yml)
 
 ### 🚀 Deployment
+[![Site](https://img.shields.io/website?url=https%3A%2F%2Fslopstopper.dev&label=slopstopper.dev&up_message=up&down_message=down)](https://slopstopper.dev/)
 
-Deployed via [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/) — every push to `main` deploys, every PR gets a preview URL as a commit check, closing a PR retires the preview. Live deploy status is in the [Cloudflare dashboard](https://dash.cloudflare.com/) → Workers → `slopstopper` → Deployments. Live post-deploy health is the [Smoke Tests](#-reliability) badge above — it runs hourly *and* against the production URL on every successful build.
+Deployed via [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/) — every push to `main` deploys, every PR gets a preview URL as a commit check, closing a PR retires the preview. Live deploy status is in the [Cloudflare dashboard](https://dash.cloudflare.com/) → Workers → `slopstopper` → Deployments. The badge above pings the production URL via shields.io; live post-deploy *behaviour* is the [Smoke Tests](#-reliability) badge — it runs hourly *and* against the production URL on every successful build.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,8 @@ Every check below runs on every PR and push to `main` here, and ships to consume
 [![Failure Alerts](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-workflow-failure-issue.yml/badge.svg?branch=main)](https://github.com/hungovercoders/slopstopper/actions/workflows/ss-workflow-failure-issue.yml)
 
 ### 🚀 Deployment
-[![Production Deploy](https://img.shields.io/github/deployments/hungovercoders/slopstopper/Production?label=deploy&logo=cloudflare)](https://github.com/hungovercoders/slopstopper/deployments)
 
-Per-deploy status from the GitHub Deployments API (Cloudflare's GitHub App writes a deployment event for every push). Live post-deploy health is the [Smoke Tests](#-reliability) badge above — it runs hourly *and* on every `deployment_status` event.
+Deployed via [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/) — every push to `main` deploys, every PR gets a preview URL as a commit check, closing a PR retires the preview. Live deploy status is in the [Cloudflare dashboard](https://dash.cloudflare.com/) → Workers → `slopstopper` → Deployments. Live post-deploy health is the [Smoke Tests](#-reliability) badge above — it runs hourly *and* against the production URL on every successful build.
 
 ---
 


### PR DESCRIPTION
## Summary

The `🚀 Deployment` section showed `https://img.shields.io/github/deployments/hungovercoders/slopstopper/Production` rendering as "environment not found". Root cause: **Cloudflare Workers Builds doesn't write GitHub Deployment events** (only Cloudflare Pages does), so there's nothing for shields.io to render.

Confirmed: `gh api /repos/hungovercoders/slopstopper/deployments` returns `[]`.

## What changed

Replaced the broken badge with a one-paragraph blurb pointing at the Cloudflare dashboard (canonical per-deploy history) and noting that the existing Smoke Tests badge already covers post-deploy health.

This was a planning mistake in #157 — I assumed Workers Builds wrote deployments because Pages does. The Smoke Tests badge actually was the better signal all along: it tests live behavior on every `deployment_status` and hourly, instead of just "the build step finished".

## Test plan

- [ ] Merge — README badge row now renders without a broken image.
- [ ] No functional impact (badge was decorative only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)