### PR TITLE
fix(reliability): broken-links workflow YAML + name convention

### DIFF
--- a/.github/workflows/ss-reliability-broken-links-check.yml
+++ b/.github/workflows/ss-reliability-broken-links-check.yml
@@ -1,4 +1,4 @@
-name: SlopStopper · Broken Link Checker
+name: SlopStopper · Broken Links Check
 
 on:
   pull_request:
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   broken-links:
-    name: Reliability Broken Link Check
+    name: Broken Links Check
     if: |
       github.event_name != 'deployment_status' ||
       github.event.deployment_status.state == 'success'
@@ -59,27 +59,11 @@ jobs:
         run: |
           validate_url() {
             local url="$1"
-            python3 - "$url" <<'PY'
-import re
-import sys
-from urllib.parse import urlparse
-
-candidate = sys.argv[1]
-if re.search(r'[\s\x00-\x1F\x7F]', candidate):
-  raise ValueError("contains whitespace or control characters")
-
-parsed = urlparse(candidate)
-if parsed.scheme not in ("http", "https"):
-  raise ValueError("must use http/https")
-if not parsed.netloc:
-  raise ValueError("missing host")
-
-print(candidate, end="")
-PY
-            if [ $? -ne 0 ]; then
+            if [[ ! "$url" =~ ^https?://[^[:space:][:cntrl:]]+$ ]]; then
               echo "Error: Invalid URL format: $url" >&2
               exit 1
             fi
+            printf '%s' "$url"
           }
 
           if [ "$EVENT_NAME" == "workflow_dispatch" ] && [ -n "$INPUT_URL" ]; then
@@ -151,7 +135,7 @@ PY
             const checkUrl = process.env.CHECK_URL;
 
             const body = [
-              `## 🔗 Broken Link Checker ${status}`,
+              `## 🔗 Broken Links Check ${status}`,
               '',
               `**Checked URL:** ${checkUrl}`,
               '',


### PR DESCRIPTION
## Summary

Two issues with `ss-reliability-broken-links-check.yml`, fixed together since they touch the same file.

### 1. YAML was broken (workflow was silently failing every run)

The workflow used a Python heredoc inside a `run:` block. The heredoc's column-0 indentation terminated YAML's block scalar early, so the whole file failed to parse. GitHub silently failed to load it on every push — runs showed 0s with `jobs: []`, and the GitHub API returned the file path (`.github/workflows/ss-reliability-broken-links-check.yml`) instead of the parsed workflow name, which is the giveaway.

Verified locally with `js-yaml`:

```
$ node -e "yaml.load(fs.readFileSync('.github/workflows/ss-reliability-broken-links-check.yml','utf8'))"
INVALID: bad indentation of a mapping entry ...
```

Replaced the heredoc with the same shell regex pattern that `ss-reliability-seo-check.yml` already uses for URL validation. Same security properties (rejects whitespace/control chars, requires http/https scheme), no YAML parsing pitfalls.

After the fix:

```
$ node -e "yaml.load(fs.readFileSync('.github/workflows/ss-reliability-broken-links-check.yml','utf8'))"
valid YAML now
```

### 2. Workflow name didn't follow the SlopStopper convention

Was `SlopStopper · Broken Link Checker`. Every other reliability workflow uses the noun-verb "X Check" / "X Tests" pattern:

- `SlopStopper · Accessibility Check`
- `SlopStopper · SEO Metatag Check`
- `SlopStopper · Core Web Vitals`
- `SlopStopper · Reliability Smoke Tests`

Renamed to `SlopStopper · Broken Links Check` — matches the file name `ss-reliability-broken-links-check.yml`, matches the existing README badge label `Broken Links`, and matches the noun-verb convention. Job name and PR comment header brought into line too.

## Test plan

- [ ] Merge — the workflow should now actually run on push to main (instead of failing instantly).
- [ ] First post-merge run completes with real results (pass or fail with a real reason).
- [ ] Badge in README renders with the new name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)