### PR TITLE
fix(workflows): drop || true silent-pass in docs-* checks

### DIFF
--- a/.github/workflows/ss-hygiene-docs-accuracy-check.yml
+++ b/.github/workflows/ss-hygiene-docs-accuracy-check.yml
@@ -72,8 +72,8 @@ jobs:
       - name: Run documentation accuracy check
         id: accuracy
         run: |
-          python3 .ss/scripts/check-docs-accuracy.py || true
-          python3 .ss/scripts/generate-docs-accuracy-md.py || true
+          python3 .ss/scripts/check-docs-accuracy.py
+          python3 .ss/scripts/generate-docs-accuracy-md.py
 
           if [ -f .ss/reports/docs/docs-accuracy-report.json ]; then
             ISSUE_COUNT=$(python3 -c "

--- a/.github/workflows/ss-hygiene-docs-size-check.yml
+++ b/.github/workflows/ss-hygiene-docs-size-check.yml
@@ -34,7 +34,7 @@ jobs:
         id: check
         run: |
           # Run the task and capture output
-          task ss:hygiene:docs-size || true
+          task ss:hygiene:docs-size
           
           # Check if alerts were triggered (report contains "exceeds thresholds")
           if grep -q "❌" .ss/reports/docs/docs-size-report.md; then

--- a/.github/workflows/ss-hygiene-docs-structure-check.yml
+++ b/.github/workflows/ss-hygiene-docs-structure-check.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run documentation structure check
         id: structure
         run: |
-          task ss:hygiene:docs-structure || true
+          task ss:hygiene:docs-structure
           
           # Parse violation count from JSON report
           if [ -f .ss/reports/docs/docs-structure-report.json ]; then


### PR DESCRIPTION
## Summary

Three workflows — `ss-hygiene-docs-accuracy-check.yml`, `ss-hygiene-docs-structure-check.yml`, `ss-hygiene-docs-size-check.yml` — wrap their analysis script/task in `|| true`, silently swallowing the script's non-zero exit. Combined with each workflow's "if no report file, default `has_issues=false`" fallback, this means any script failure produces a **green check** rather than failing the workflow.

## How it was surfaced

[hungovercoders/site#22](https://github.com/hungovercoders/site/pull/22) installed slopstopper into a non-Map-Pattern repo (no `docs/` directory) and added pipeline status badges to the README. The docs-accuracy badge was green — on a repo that has no docs directory at all. Trace:

```
1. check-docs-accuracy.py exits non-zero: "❌ docs/ directory not found"
2. `|| true` swallows the exit
3. Workflow looks for the JSON report → not generated → has_issues=false
4. Green check despite the audit never having run
```

Same pattern present in `docs-structure` and `docs-size`.

## Fix

Drop `|| true` from the analysis-script invocations so the script's exit code propagates to the workflow. The `|| true` on the post-script `cp report.md` lines is preserved — those copies have a downstream fallback in the comment step ("Failed to read accuracy report").

## Expected impact

Repos that were silently passing this check by accident — i.e. don't follow the Map Pattern and don't have a `docs/` directory — will now correctly fail until they either:
- Adopt the Map Pattern (add a `docs/` directory + `docs/index.md`), or
- Delete the workflow file (slopstopper's `.ss/.workflows-installed` tracker remembers deletions across re-installs).

Both are the right outcome. A red check that says "docs/ directory not found" is infinitely more useful than a green check that's lying.

This repo (slopstopper itself) follows the Map Pattern, so its own CI continues to pass.

## Test plan

- [x] Workflow YAML still valid (3 files modified, single-line changes)
- [x] Slopstopper's own docs-accuracy / docs-structure / docs-size still pass locally (repo follows the Map Pattern)
- [ ] Manual: confirm slopstopper's own CI on this PR stays green
- [ ] Manual: confirm hungovercoders/site#22 (with the docs-* workflows deleted) is unaffected by this change

## Related

- [hungovercoders/site#22](https://github.com/hungovercoders/site/pull/22) — first install where this was caught; docs-* workflows deleted on the site side
- [hungovercoders/slopstopper#171](https://github.com/hungovercoders/slopstopper/pull/171) — install-slopstopper skill PR, where this gotcha is being documented in pre-flight and first-PR triage

🤖 Generated with [Claude Code](https://claude.com/claude-code)