### PR TITLE
feat(dast): honour consumer-side .zap/rules.tsv overrides

### DIFF
--- a/Taskfile.ss.yml
+++ b/Taskfile.ss.yml
@@ -805,13 +805,28 @@ tasks:
           echo "📍 Using Docker-compatible target: $TARGET"
         fi
         
+        # Honour consumer-side ZAP rule overrides at .zap/rules.tsv if present.
+        # Format (tab-separated): <plugin-id>\tIGNORE\t# why this is accepted.
+        # Lets adopters silence false-positive rules (e.g. SRI on a GTM-served
+        # script with rotating content, SQL Source Code Disclosure firing on
+        # blog posts containing SQL code blocks) without modifying slopstopper.
+        # Keep the list short and document each entry — every line is a
+        # justified gate exception, not a way to quiet findings you should fix.
+        ZAP_RULES_VOL=""
+        ZAP_RULES_FLAG=""
+        if [ -f .zap/rules.tsv ]; then
+          ZAP_RULES_VOL="-v $(pwd)/.zap:/zap/wrk/.zap:ro"
+          ZAP_RULES_FLAG="-c .zap/rules.tsv"
+        fi
         docker run --rm \
           -v "$(pwd)/.ss/reports/dast:/zap/wrk/:rw" \
+          $ZAP_RULES_VOL \
           ghcr.io/zaproxy/zaproxy:stable \
           zap-baseline.py \
           -t "$TARGET" \
           -J "dast-report.json" \
           -I \
+          $ZAP_RULES_FLAG \
           || true
         
         python3 .ss/scripts/generate-dast-md.py


### PR DESCRIPTION
## Summary

The DAST workflow has no per-rule allowlist mechanism today. Adopters that hit a genuine false-positive rule (e.g. SRI on a GTM-served script with rotating content, Source Code Disclosure - SQL firing on a blog post containing SQL code blocks) have no way to silence it without modifying slopstopper itself.

`zap-baseline.py` natively supports a `-c` config flag that takes a tab-separated file of plugin IDs to skip. This PR makes the `dast:analyze` task pass that flag when the consumer ships a `.zap/rules.tsv`, and mounts the file into the ZAP container.

## Behaviour

- **Consumer ships `.zap/rules.tsv`** → flag added, file mounted, rules honoured. Each line is `<plugin-id>\tIGNORE\t# why this is accepted`.
- **Consumer doesn't ship it** → flag absent, no mount, business as usual.

Example consumer file:

```
90003	IGNORE	# SRI: GTM script rotates, no stable hash viable
10099	IGNORE	# SQL disclosure: false positive on blog tutorials
```

## Why this is safe

The trust model is unchanged. The gate (`check-dast-alerts.py`) still fails on every other medium/high finding. `.zap/rules.tsv` only lets the consumer opt-out of specific plugin IDs where the rule is structurally wrong for their site. Each line is a documented exception, justified by its `# why` comment.

This is the DAST equivalent of `docs/security/CSP_EXCEPTIONS.md` (per-path CSP relaxations) — both are consumer-controlled allowlists for narrow, defensible cases, with the trust burden moved from "is slopstopper too strict?" to "is the consumer's exception documented and justified?"

## How it was surfaced

[hungovercoders/site#22](https://github.com/hungovercoders/site/pull/22) installed slopstopper and surfaced two unfixable false positives via the DAST scan:

- SRI Missing on the cross-domain GTM script (and a couple of older blog-post embeds) — GTM rotates script content per container update, so SRI is structurally non-viable.
- Source Code Disclosure - SQL on tutorial blog posts about Spark/Databricks/Cosmos that contain SQL code blocks — ZAP's heuristic matches the SQL syntax and treats the page as if the application were leaking source code.

Both are legitimate ZAP findings on slopstopper.dev's own site (it doesn't have GTM or SQL-tutorial blog posts), but structurally wrong for a content-heavy site that uses analytics. This change lets adopters silence them with provenance.

## Test plan

- [x] Slopstopper's own CI still passes — no `.zap/rules.tsv` shipped in this repo, so behaviour unchanged
- [x] Shell change is small and defensive: variables default to empty strings, `if [ -f ... ]` guards the override
- [ ] Manual: confirm slopstopper's own DAST workflow on this PR stays green (proving "no file = old behaviour")
- [ ] Manual: confirm [hungovercoders/site#22](https://github.com/hungovercoders/site/pull/22) — which ships a `.zap/rules.tsv` — goes green once this merges and they re-install

🤖 Generated with [Claude Code](https://claude.com/claude-code)