### PR TITLE
feat(skill): ship install-skill.sh one-liner for adopter distribution

### DIFF
--- a/.claude/skills/install-slopstopper/SKILL.md
+++ b/.claude/skills/install-slopstopper/SKILL.md
@@ -323,6 +323,8 @@ Triggers that require revisiting this skill:
 
 The companion to this is `AGENTS.md` in the slopstopper repo: its "When making changes" table flags the skill as a follow-on target whenever a change of the above kind ships. If you're updating slopstopper itself and that table isn't pointing readers back here, fix that first.
 
+This skill is distributed to adopter machines via `install-skill.sh` in the slopstopper repo (which writes a single `~/.claude/skills/install-slopstopper/SKILL.md` file and validates the download starts with frontmatter). If you rename the skill, move its file, change the frontmatter contract, or otherwise change the shape of what gets fetched, update `install-skill.sh` and `docs/runbooks/INSTALL_SKILL.md` in the same change — otherwise the install-skill one-liner silently drifts away from what this skill expects to land at.
+
 ## Notes for the agent
 
 - The install is reversible by deleting the slopstopper-added files. Commit the install as its own commit so it's easy to revert.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ between these.
 | New quality check | Add workflow under `.github/workflows/ss-*.yml`, add `task ss:<category>:<action>` target, add to `install.sh`'s `GENERIC_WORKFLOWS`, surface on `app/features.html` and `app/tools.html`, mention in `README.md`, **add to the install-slopstopper skill** (workflow inventory + Pass A/B example in [`.claude/skills/install-slopstopper/SKILL.md`](./.claude/skills/install-slopstopper/SKILL.md)) |
 | Renaming a `task ss:*` target or env var | `Taskfile.ss.yml`, `docs/<category>/README.md`, **the install-slopstopper skill** (local-task commands + env-var list) |
 | Editing `install.sh` (esp. `GENERIC_WORKFLOWS` or post-install stdout) | `install.sh` (the `REPO_URL` must always match this repo's actual location), **the install-slopstopper skill** (Step 3 "what just landed" inventory) |
+| Editing the install-slopstopper skill ([`.claude/skills/install-slopstopper/SKILL.md`](./.claude/skills/install-slopstopper/SKILL.md)) | [`install-skill.sh`](./install-skill.sh) (validates the fetched file looks like a skill — frontmatter contract), [`docs/runbooks/INSTALL_SKILL.md`](./docs/runbooks/INSTALL_SKILL.md) (adopter runbook), `README.md` "Using Claude Code?" section, `app/index.html` "Claude Code users" section |
+| Editing `install-skill.sh` | [`docs/runbooks/INSTALL_SKILL.md`](./docs/runbooks/INSTALL_SKILL.md) (keep the user-facing description aligned), `README.md` + `app/index.html` if the install command line changes |
 | New page | Add HTML + page-specific CSS in `app/`; link `app/shared.css` first; copy header/nav/footer; add to nav on the other pages; add to `tests/smoke.spec.ts` and `tests/accessibility.spec.ts` |
 | Headers / CSP | `worker/headers.json` (single source of truth — CSP changes are blast-radius, touch DAST tests too) |
 | Worker behaviour | `worker/index.ts` (path matching, redirects); `wrangler.jsonc` (assets binding, compatibility date) |
@@ -57,4 +59,4 @@ The right-hand column flags the [install-slopstopper skill](./.claude/skills/ins
 
 Skills under [`.claude/skills/`](./.claude/skills/) are committed and shipped with the repo (the `.gitignore` carves them out from local Claude Code state). They're the long-form playbooks an agent should follow when doing one of these jobs:
 
-- [`install-slopstopper`](./.claude/skills/install-slopstopper/SKILL.md) — installing SlopStopper into an existing repo. Covers pre-flight, the install command, post-install URL config, verification, and first-PR triage grounded in real installs into non-trivial repos.
+- [`install-slopstopper`](./.claude/skills/install-slopstopper/SKILL.md) — installing SlopStopper into an existing repo. Covers pre-flight, the install command, post-install URL config, a local-first verification loop, and a forward-looking gotcha table. Distributed to adopter machines via [`install-skill.sh`](./install-skill.sh) — see [`docs/runbooks/INSTALL_SKILL.md`](./docs/runbooks/INSTALL_SKILL.md).

--- a/README.md
+++ b/README.md
@@ -108,7 +108,11 @@ task --list
 
 **First-run note:** the first time you run any check (e.g. `task ss:hygiene:complexity`), SlopStopper auto-installs the underlying tool (Lizard, Semgrep, Trivy, Gitleaks…) via pip or curl. Expect a one-time delay — subsequent runs are fast.
 
-**Using Claude Code?** The shipped [`install-slopstopper`](./.claude/skills/install-slopstopper/SKILL.md) skill walks an agent through pre-flight, the install command, URL config, verification, and first-PR triage.
+**Using Claude Code?** Install the companion [`install-slopstopper`](./.claude/skills/install-slopstopper/SKILL.md) skill once per machine — Claude Code then auto-runs the install in any project on prompt. Runbook: [`docs/runbooks/INSTALL_SKILL.md`](./docs/runbooks/INSTALL_SKILL.md).
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install-skill.sh | bash
+```
 
 ---
 

--- a/app/index.html
+++ b/app/index.html
@@ -114,7 +114,23 @@
                 </div>
             </div>
             <p class="docs-pointer">Want the deep dive? <a href="https://github.com/hungovercoders/slopstopper/blob/main/docs/index.md" rel="noopener noreferrer">Browse the docs →</a></p>
-            <p class="docs-pointer">Using Claude Code? <a href="https://github.com/hungovercoders/slopstopper/blob/main/.claude/skills/install-slopstopper/SKILL.md" rel="noopener noreferrer">There's a skill that walks the install →</a></p>
+        </section>
+
+        <section class="section" id="claude-code-skill">
+            <span class="kicker">Claude Code users</span>
+            <h2>Let the agent drive the install.</h2>
+            <p class="lede">A companion <a href="https://github.com/hungovercoders/slopstopper/blob/main/.claude/skills/install-slopstopper/SKILL.md" rel="noopener noreferrer">install-slopstopper skill</a> drops into your Claude Code profile so any project can ask the agent to add SlopStopper — pre-flight, install command, URL config, local-first verification loop, forward-looking gotcha table.</p>
+            <div class="codeblock codeblock--sh" role="region" aria-label="Skill install command" data-copyable>
+                <pre><code>curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install-skill.sh | bash</code></pre>
+            </div>
+            <details class="details">
+                <summary>What does this do?</summary>
+                <div class="details__body">
+                    <p>The script writes a single file — <code>~/.claude/skills/install-slopstopper/SKILL.md</code> — that Claude Code auto-discovers across every project on your machine. Any prompt asking to add SlopStopper (e.g. "install slopstopper", "add the slopstopper quality suite") triggers the skill, which walks the install end-to-end. Re-run any time to refresh to the latest version.</p>
+                    <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/install-skill.sh" rel="noopener noreferrer">View install-skill.sh on GitHub →</a>
+                </div>
+            </details>
+            <p class="docs-pointer">Full runbook: <a href="https://github.com/hungovercoders/slopstopper/blob/main/docs/runbooks/INSTALL_SKILL.md" rel="noopener noreferrer">docs/runbooks/INSTALL_SKILL.md →</a></p>
         </section>
 
         <section class="section">

--- a/docs/runbooks/INSTALL_SKILL.md
+++ b/docs/runbooks/INSTALL_SKILL.md
@@ -1,0 +1,58 @@
+# Install the install-slopstopper Claude Code skill
+
+The companion to [`install.sh`](../../install.sh). Where `install.sh` drops the quality suite into a *repo*, [`install-skill.sh`](../../install-skill.sh) drops the install-slopstopper [skill](../../.claude/skills/install-slopstopper/SKILL.md) into your Claude Code *user profile* so it's available in every project on this machine.
+
+Run it once per machine. After that, any Claude Code prompt asking to add SlopStopper (e.g. "install slopstopper", "add the slopstopper quality suite to this repo") invokes the skill automatically.
+
+## What you need
+
+- **Claude Code** — [claude.com/claude-code](https://claude.com/claude-code). The script can run before Claude Code is installed (it just creates `~/.claude/skills/install-slopstopper/SKILL.md`); the skill is picked up the first time Claude Code launches.
+- **curl** — used to fetch the skill file from this repo.
+- **Write access to `~/.claude/skills/`** — the script creates the directory if it doesn't exist.
+
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install-skill.sh | bash
+```
+
+Or, two-step (review first):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install-skill.sh -o install-skill.sh
+bash install-skill.sh
+```
+
+## What lands
+
+A single file:
+
+```
+~/.claude/skills/install-slopstopper/SKILL.md
+```
+
+Nothing outside that path is touched. The script is atomic — it fetches to a temp file, validates the download looks like a Claude Code skill (frontmatter present), and only then overwrites the destination. An interrupted run cannot leave a half-file behind.
+
+## How it gets used
+
+Claude Code auto-discovers skills under `~/.claude/skills/`. The `description` field in the SKILL frontmatter is what Claude matches against incoming prompts — for this skill it covers "install slopstopper", "add the slopstopper quality suite", and any of the five loops (security, hygiene, reliability, runbooks, deployment).
+
+You don't invoke the skill manually. Drop into any repo, ask Claude Code to add SlopStopper, and the skill activates and walks the install end-to-end: pre-flight checks, the install command, post-install URL config, a local-first verification loop, and a forward-looking gotcha table that handles predictable adoption issues during the local loop instead of after CI is red.
+
+## Refresh
+
+Re-run the same command any time. The script compares the downloaded SKILL.md against what's already installed and only overwrites if the content differs — safe to put in a periodic update routine, or just run when you remember.
+
+## Uninstall
+
+```bash
+rm -rf ~/.claude/skills/install-slopstopper
+```
+
+Claude Code stops invoking the skill immediately on next prompt. No other state to clean up.
+
+## Why this is shipped as a separate one-liner
+
+The skill is *for installing SlopStopper into a target repo*. Committing it into target repos is circular (by the time the skill is there, you've done the install). User-global is the right shape — install once, every project benefits.
+
+Bundling the skill into `install.sh` was considered and rejected for the same reason: `install.sh` runs *inside* a target repo, but the skill needs to be available *before* you're inside a target repo (you need it to know how to install). Two scripts, two scopes — clean separation.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,10 +1,16 @@
 # Runbooks
 
-Operational procedures for the SlopStopper project.
+Operational procedures for the SlopStopper project — both the suite itself and the things adopters do once around it.
 
 ## Overview
 
 This directory holds step-by-step runbooks for common operational tasks. As the project is a minimal static site template, operational procedures are currently minimal.
+
+## Runbooks
+
+| Runbook | What it covers |
+| ------- | -------------- |
+| [INSTALL_SKILL.md](./INSTALL_SKILL.md) | Install the [`install-slopstopper`](../../.claude/skills/install-slopstopper/SKILL.md) Claude Code skill into your user profile so any project on this machine can ask Claude Code to add SlopStopper |
 
 ## Adding Runbooks
 

--- a/install-skill.sh
+++ b/install-skill.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# install-skill.sh — install the SlopStopper Claude Code skill.
+#
+# The companion to install.sh: install.sh drops the quality suite into a
+# *repo*, this script drops the install-slopstopper skill into your
+# Claude Code *user profile* so it's available in every project on this
+# machine. Run it once per machine.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install-skill.sh | bash
+#
+# Or, two-step (review first):
+#   curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install-skill.sh -o install-skill.sh
+#   bash install-skill.sh
+#
+# What lands:
+#   ~/.claude/skills/install-slopstopper/SKILL.md
+#
+# What this affects:
+#   Nothing outside ~/.claude/skills/install-slopstopper/. Re-running the
+#   script overwrites the SKILL.md in place so you always get the latest
+#   guidance — the skill is small, self-contained, and safe to refresh.
+
+set -euo pipefail
+
+REPO_RAW="https://raw.githubusercontent.com/hungovercoders/slopstopper/main"
+SKILL_PATH=".claude/skills/install-slopstopper/SKILL.md"
+DEST_DIR="${HOME}/.claude/skills/install-slopstopper"
+DEST_FILE="${DEST_DIR}/SKILL.md"
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+info()    { echo "  ℹ  $*"; }
+success() { echo "  ✅ $*"; }
+warn()    { echo "  ⚠️  $*"; }
+error()   { echo "  ❌ $*" >&2; exit 1; }
+
+sep() { echo "────────────────────────────────────────────────────────────"; }
+
+# ── preflight ────────────────────────────────────────────────────────────────
+
+command -v curl >/dev/null 2>&1 || error "curl is required to fetch the skill. Install it and re-run."
+
+if [ ! -d "${HOME}/.claude" ]; then
+  warn "${HOME}/.claude does not exist yet."
+  info "That's fine — this script will create the skills directory. If you"
+  info "haven't installed Claude Code, Claude Code will pick the skill up"
+  info "automatically once you do (https://claude.com/claude-code)."
+fi
+
+sep
+echo "  🧠  SlopStopper — installing the Claude Code skill"
+echo "  Source : ${REPO_RAW}/${SKILL_PATH}"
+echo "  Target : ${DEST_FILE}"
+sep
+
+# ── install ──────────────────────────────────────────────────────────────────
+
+mkdir -p "${DEST_DIR}"
+
+# Atomic fetch via temp file: only overwrite the destination if the
+# download succeeded, so an interrupted install can't leave a half-file
+# behind.
+TMP_FILE="$(mktemp)"
+trap 'rm -f "${TMP_FILE}"' EXIT
+
+if ! curl -fsSL "${REPO_RAW}/${SKILL_PATH}" -o "${TMP_FILE}"; then
+  error "Failed to download SKILL.md from ${REPO_RAW}/${SKILL_PATH}"
+fi
+
+# Sanity-check the file looks like a Claude Code skill (frontmatter present)
+# before we overwrite anything.
+if ! head -n 1 "${TMP_FILE}" | grep -q "^---$"; then
+  error "Downloaded file does not look like a Claude Code skill (no frontmatter). Aborting."
+fi
+
+if [ -f "${DEST_FILE}" ]; then
+  if cmp -s "${TMP_FILE}" "${DEST_FILE}"; then
+    success "Skill already up to date — no changes."
+  else
+    mv "${TMP_FILE}" "${DEST_FILE}"
+    success "Skill refreshed (existing SKILL.md was older)."
+  fi
+else
+  mv "${TMP_FILE}" "${DEST_FILE}"
+  success "Skill installed."
+fi
+
+# ── post-install guidance ────────────────────────────────────────────────────
+
+sep
+echo ""
+echo "  🎉 Skill installed!"
+echo ""
+echo "  Claude Code will auto-discover it in every project on this machine."
+echo "  Any prompt that asks to add SlopStopper — e.g. \"install slopstopper\""
+echo "  or \"add the slopstopper quality suite\" — will invoke the skill."
+echo ""
+echo "  To install SlopStopper into a repo:"
+echo "    cd <your-repo>"
+echo "    curl -fsSL ${REPO_RAW}/install.sh | bash"
+echo ""
+echo "  Re-running this script later refreshes the skill to latest."
+echo ""
+sep


### PR DESCRIPTION
## Summary

- Adds `install-skill.sh` — companion to `install.sh` — that installs the `install-slopstopper` Claude Code skill into a user's profile (`~/.claude/skills/install-slopstopper/SKILL.md`) via the same curl-pipe one-liner pattern.
- Surfaces the install in three places: `README.md` (Claude Code subsection of the install section), `app/index.html` (new \"Claude Code users\" section with codeblock + details), `docs/runbooks/INSTALL_SKILL.md` (canonical adopter runbook).
- Wires bidirectional drift protection: `AGENTS.md` \"When making changes\" table gains rows for editing the skill and editing the installer; the skill's Step 10 names the installer + runbook as the distribution pair it depends on staying aligned with.

## The shape

User runs one-liner once per machine:

\`\`\`bash
curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install-skill.sh | bash
\`\`\`

After that, Claude Code in any project on that machine triggers the skill on prompts asking to add SlopStopper (matched via the SKILL.md frontmatter \`description\`). The skill walks pre-flight → install → URL config → a local-first verification loop → forward-looking gotcha table.

The script is atomic (mktemp + mv), idempotent (compares hash before overwriting), and validates the download starts with frontmatter so a CDN error page can't replace a good install with garbage.

## Why a separate script, not bundled into install.sh

\`install.sh\` runs *inside* a target repo. The skill needs to be available *before* you're in a target repo (you need it to know how to install). Two scripts, two scopes — explained in `docs/runbooks/INSTALL_SKILL.md`.

## Test plan

- [x] `bash -n install-skill.sh` — syntax-check pass
- [x] `HOME=$(mktemp -d) bash install-skill.sh` — runs end-to-end, fetches SKILL.md from `main`, writes to the tmpdir, prints post-install guidance
- [x] `task ss:hygiene:entry-files` — all three entry files within 1500-word budget (README 1492, AGENTS 598, CLAUDE 39)
- [x] `task ss:hygiene:docs-accuracy` — passes (skill reference qualified as `.claude/skills/install-slopstopper/SKILL.md`)
- [x] `task ss:hygiene:docs-structure` — passes (new runbook indexed in `docs/runbooks/README.md`)
- [x] `task ss:hygiene:docs-size` — within limits
- [ ] After merge: smoke-test the live one-liner against a clean `~/.claude/` on a different machine
- [ ] After merge: verify `app/index.html`'s new section renders cleanly in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)