### PR TITLE
fix(hygiene): wire docs-size script thresholds through to report

### DIFF
--- a/.ss/scripts/check-docs-size.sh
+++ b/.ss/scripts/check-docs-size.sh
@@ -113,7 +113,10 @@ python3 ".ss/scripts/generate-docs-size-report.py" \
   --avg-size-kb "$AVG_SIZE_KB" \
   --largest-files "$LARGEST_FILES" \
   --has-alerts "$HAS_ALERTS" \
-  --alerts "$ALERTS"
+  --alerts "$ALERTS" \
+  --max-total-size-kb "$MAX_TOTAL_SIZE_KB" \
+  --max-file-size-kb "$MAX_FILE_SIZE_KB" \
+  --max-files "$MAX_FILES"
 
 echo "📁 Reports saved to: .ss/reports/docs/"
 echo "   • docs-size-report.md (human-readable)"

--- a/.ss/scripts/generate-docs-size-report.py
+++ b/.ss/scripts/generate-docs-size-report.py
@@ -24,6 +24,9 @@ def main():
     parser.add_argument("--largest-files", type=str, required=True)
     parser.add_argument("--has-alerts", type=str, required=True)
     parser.add_argument("--alerts", type=str, default="")
+    parser.add_argument("--max-total-size-kb", type=int, required=True)
+    parser.add_argument("--max-file-size-kb", type=int, required=True)
+    parser.add_argument("--max-files", type=int, required=True)
 
     args = parser.parse_args()
 
@@ -63,9 +66,9 @@ def main():
 
     report += f"""## Thresholds
 
-- **Max Total Size:** 150 KB
-- **Max File Size:** 20 KB
-- **Max File Count:** 15
+- **Max Total Size:** {args.max_total_size_kb} KB
+- **Max File Size:** {args.max_file_size_kb} KB
+- **Max File Count:** {args.max_files}
 
 ## Recommendations
 

--- a/docs/hygiene/DOCS_SIZE_MONITORING.md
+++ b/docs/hygiene/DOCS_SIZE_MONITORING.md
@@ -100,7 +100,7 @@ It contains:
 2. **Validation Phase**
    - Checks total documentation size against 150 KB limit
    - Checks individual file sizes against 20 KB limit
-   - Checks file count against 15 file limit
+   - Checks file count against 25 file limit
    - Identifies any violations
 
 3. **Reporting Phase**

--- a/docs/hygiene/README.md
+++ b/docs/hygiene/README.md
@@ -41,7 +41,7 @@ Monitors overall documentation size and checks against configured thresholds:
 
 - **Total documentation size:** max 150 KB
 - **Individual file sizes:** max 20 KB
-- **Number of documentation files:** max 15
+- **Number of documentation files:** max 25
 
 This check is particularly important for AI-assisted development where documentation needs to fit within context windows efficiently. Running this check generates a detailed report in `.ss/reports/docs/docs-size-report.md`.
 


### PR DESCRIPTION
## Summary

- The docs-size report's **Thresholds** section was hardcoded to `150 / 20 / 15`, but the check script actually uses `MAX_FILES=25`. A 23-file repo passed correctly (`23 < 25`) while the report claimed the cap was 15 — making the pass look like a bug.
- `check-docs-size.sh` now passes all three `MAX_*` values into `generate-docs-size-report.py`, which reads them as args instead of hardcoding. The two can't drift again.
- Swept docs for the same 15-vs-25 drift: `docs/hygiene/README.md` and `docs/hygiene/DOCS_SIZE_MONITORING.md` had stale "15 files" claims (the latter already said 25 elsewhere — internal contradiction). Both updated to match the active script.

## Test plan

- [x] `bash .ss/scripts/check-docs-size.sh` — confirmed report now shows `Max File Count: 25`
- [ ] CI: `ss-hygiene-docs-size-check` workflow still green on this branch
- [ ] Spot-check `.ss/reports/docs/docs-size-report.md` after CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)