### PR TITLE
feat(installer): hygiene batch — portable server, cross-platform Trivy, source fix (#75, #76, #80, #81, #85, #86)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@ test-results/
 .ss/test-results/
 # SlopStopper-generated reports (all under .ss/reports/<category>/)
 .ss/reports/
+# Python bytecode under .ss/scripts/. .workflows-installed is deliberately
+# NOT ignored — it's the install marker that tracks adopter deletions
+# across re-runs and must be tracked.
+.ss/scripts/**/__pycache__/
+.ss/tests/**/__pycache__/
 # Local Netlify folder
 .netlify
 # TypeScript compiled output (copy.js is hand-written runtime JS, not a tsc artefact)

--- a/.ss/server.js
+++ b/.ss/server.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/*
+ * Slopstopper portable static server — used by the local-first dynamic
+ * check loop (smoke, accessibility, broken-links, SEO, CWV, DAST).
+ *
+ * Usage:
+ *   node .ss/server.js                            # auto-detect SERVE_ROOT
+ *   SERVE_ROOT=dist/client node .ss/server.js     # explicit root
+ *   PORT=8000 node .ss/server.js                  # alternative port
+ *
+ * Auto-detect probes ./dist/client, ./dist, ./build, ./out, ./public, ./app
+ * in that order and picks the first one containing index.html. Pretty URLs:
+ * /foo → /foo.html or /foo/index.html (whichever exists).
+ *
+ * No security headers are applied; this is a local development convenience,
+ * not a production server. If your DAST scan needs to assert headers, run
+ * it against a deployed preview URL (Cloudflare Pages PR previews etc.)
+ * instead of localhost.
+ */
+
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = parseInt(process.env.PORT || '8080', 10);
+const CWD = process.cwd();
+
+function findServeRoot() {
+	if (process.env.SERVE_ROOT) {
+		const abs = path.resolve(CWD, process.env.SERVE_ROOT);
+		if (!fs.existsSync(abs)) {
+			console.error(`SERVE_ROOT=${process.env.SERVE_ROOT} does not exist (resolved to ${abs})`);
+			process.exit(1);
+		}
+		return abs;
+	}
+	const candidates = ['dist/client', 'dist', 'build', 'out', 'public', 'app'];
+	for (const candidate of candidates) {
+		const abs = path.resolve(CWD, candidate);
+		if (fs.existsSync(path.join(abs, 'index.html'))) return abs;
+	}
+	console.error(`Could not auto-detect SERVE_ROOT. Tried: ${candidates.join(', ')}`);
+	console.error('Set SERVE_ROOT explicitly, e.g. SERVE_ROOT=dist/client node .ss/server.js');
+	process.exit(1);
+}
+
+const SERVE_ROOT = findServeRoot();
+
+const MIME = {
+	'.html': 'text/html; charset=utf-8',
+	'.js': 'application/javascript',
+	'.mjs': 'application/javascript',
+	'.css': 'text/css',
+	'.json': 'application/json',
+	'.png': 'image/png',
+	'.jpg': 'image/jpeg',
+	'.jpeg': 'image/jpeg',
+	'.gif': 'image/gif',
+	'.webp': 'image/webp',
+	'.svg': 'image/svg+xml',
+	'.ico': 'image/x-icon',
+	'.txt': 'text/plain; charset=utf-8',
+	'.xml': 'application/xml; charset=utf-8',
+	'.webmanifest': 'application/manifest+json',
+	'.woff': 'font/woff',
+	'.woff2': 'font/woff2',
+};
+
+function resolveCandidate(urlPath) {
+	const stripped = urlPath.endsWith('/') ? urlPath.slice(0, -1) : urlPath;
+	const candidates = stripped === ''
+		? [path.join(SERVE_ROOT, 'index.html')]
+		: [
+			path.join(SERVE_ROOT, stripped),
+			path.join(SERVE_ROOT, `${stripped}.html`),
+			path.join(SERVE_ROOT, stripped, 'index.html'),
+		];
+	for (const candidate of candidates) {
+		try {
+			const stat = fs.statSync(candidate);
+			if (stat.isFile()) return candidate;
+		} catch (_) {
+			/* not found, try next */
+		}
+	}
+	return null;
+}
+
+const server = http.createServer((req, res) => { // nosemgrep: problem-based-packs.insecure-transport.js-node.using-http-server.using-http-server
+	let urlPath = req.url.split('?')[0];
+	try {
+		urlPath = decodeURIComponent(urlPath);
+	} catch (e) {
+		res.writeHead(400);
+		res.end('Bad Request');
+		return;
+	}
+
+	const target = resolveCandidate(urlPath);
+	if (!target) {
+		res.writeHead(404, { 'Content-Type': 'text/html; charset=utf-8' });
+		res.end(`<h1>404 Not Found</h1><pre>${urlPath}</pre>`);
+		return;
+	}
+
+	let resolved;
+	try {
+		resolved = fs.realpathSync(target);
+	} catch (_) {
+		resolved = target;
+	}
+	if (!resolved.startsWith(SERVE_ROOT + path.sep) && resolved !== SERVE_ROOT) {
+		res.writeHead(403);
+		res.end('Forbidden');
+		return;
+	}
+
+	const ext = path.extname(resolved).toLowerCase();
+	const contentType = MIME[ext] || 'application/octet-stream';
+
+	fs.readFile(resolved, (err, data) => {
+		if (err) {
+			res.writeHead(500);
+			res.end('Internal Server Error');
+			return;
+		}
+		res.writeHead(200, { 'Content-Type': contentType });
+		res.end(data);
+	});
+});
+
+server.listen(PORT, () => {
+	console.log(`Slopstopper server: http://localhost:${PORT}`);
+	console.log(`Serving from: ${path.relative(CWD, SERVE_ROOT) || '.'}`);
+});

--- a/Taskfile.ss.yml
+++ b/Taskfile.ss.yml
@@ -615,10 +615,32 @@ tasks:
       - |
         if ! command -v trivy &> /dev/null; then
           echo "📦 Installing Trivy..."
-          
+
           INSTALL_SUCCESS=0
-          
-          if command -v apt-get &> /dev/null && command -v wget &> /dev/null; then
+
+          # Trivy's GitHub release artefacts follow the naming convention
+          #   trivy_<version>_<OS>-<ARCH>.tar.gz
+          # where OS ∈ {Linux, macOS, FreeBSD, ...} and ARCH ∈ {64bit, ARM64, ...}.
+          # Detect both up front so the GitHub-releases fallback works on
+          # macOS and ARM64 Linux as well as the original x86_64 Linux path.
+          OS_RAW="$(uname -s)"
+          ARCH_RAW="$(uname -m)"
+          case "$OS_RAW" in
+            Linux)   TRIVY_OS="Linux" ;;
+            Darwin)  TRIVY_OS="macOS" ;;
+            FreeBSD) TRIVY_OS="FreeBSD" ;;
+            *)       TRIVY_OS="" ;;
+          esac
+          case "$ARCH_RAW" in
+            x86_64|amd64)  TRIVY_ARCH="64bit" ;;
+            arm64|aarch64) TRIVY_ARCH="ARM64" ;;
+            i?86)          TRIVY_ARCH="32bit" ;;
+            *)             TRIVY_ARCH="" ;;
+          esac
+
+          # Prefer the platform's package manager on Linux (apt) and macOS (brew),
+          # falling back to a direct GitHub-releases download when neither applies.
+          if [ "$TRIVY_OS" = "Linux" ] && command -v apt-get &> /dev/null && command -v wget &> /dev/null; then
             echo "Trying apt-get install..."
             wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
             echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main" | sudo tee /etc/apt/sources.list.d/trivy.list
@@ -626,32 +648,39 @@ tasks:
               INSTALL_SUCCESS=1
             fi
           fi
-          
-          if [ $INSTALL_SUCCESS -eq 0 ] && command -v curl &> /dev/null; then
-            echo "Trying GitHub releases install..."
+
+          if [ $INSTALL_SUCCESS -eq 0 ] && [ "$TRIVY_OS" = "macOS" ] && command -v brew &> /dev/null; then
+            echo "Trying brew install..."
+            if brew install aquasecurity/trivy/trivy; then
+              INSTALL_SUCCESS=1
+            fi
+          fi
+
+          if [ $INSTALL_SUCCESS -eq 0 ] && command -v curl &> /dev/null && [ -n "$TRIVY_OS" ] && [ -n "$TRIVY_ARCH" ]; then
+            echo "Trying GitHub releases install (${TRIVY_OS}-${TRIVY_ARCH})..."
             TRIVY_VERSION=$(curl -s https://api.github.com/repos/aquasecurity/trivy/releases/latest | grep '"tag_name"' | sed 's/.*"v\([^"]*\)".*/\1/')
             if [ -n "$TRIVY_VERSION" ]; then
               mkdir -p "$HOME/.local/bin"
-              if curl -sfL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" | tar -xz -C "$HOME/.local/bin" trivy; then
+              if curl -sfL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_${TRIVY_OS}-${TRIVY_ARCH}.tar.gz" | tar -xz -C "$HOME/.local/bin" trivy; then
                 export PATH="$PATH:$HOME/.local/bin"
                 INSTALL_SUCCESS=1
               fi
             fi
           fi
-          
+
           if [ $INSTALL_SUCCESS -eq 0 ]; then
-            echo "❌ Failed to install Trivy"
+            echo "❌ Failed to install Trivy automatically (OS=${OS_RAW}, arch=${ARCH_RAW})"
             echo "Please install Trivy manually:"
             echo "  - https://trivy.dev/latest/getting-started/installation/"
             exit 1
           fi
         fi
-        
+
         if ! command -v trivy &> /dev/null; then
           echo "❌ Trivy installed but not found in PATH"
           exit 1
         fi
-        
+
         TRIVY_VERSION=$(trivy --version 2>&1 | head -1)
         echo "✅ $TRIVY_VERSION"
     silent: false

--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@
 #
 # Workflow set ships in three conceptual layers:
 #   1. Static analysis  — work on any code (SAST, Secrets, Trivy, complexity, doc checks)
-#   2. Web-app dynamic  — need a URL (Smoke, Accessibility, CWV, Playwright)
+#   2. Web-app dynamic  — need a URL (Smoke, Accessibility, CWV, DAST, SEO, Broken Links)
 #   3. Agentic updater  — needs COPILOT_GITHUB_TOKEN (gh-aw doc-updater)
 # Deploy is intentionally not a layer: connect your repo in the Cloudflare
 # dash (Workers & Pages → Create → Connect to Git) and you get production
@@ -96,11 +96,32 @@ preflight
 # Resolve the directory that contains this script.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)" || true
 
-# When piped through curl, BASH_SOURCE is not set and we need to clone.
-# Taskfile.ss.yml is the marker file that proves we're in the SlopStopper repo.
-if [ -z "$SCRIPT_DIR" ] || [ ! -f "$SCRIPT_DIR/Taskfile.ss.yml" ]; then
+# Resolve the absolute target so we can compare against SCRIPT_DIR. If they
+# are the same directory, the user is running install.sh from inside an
+# adopter repo and we MUST clone — otherwise the cp Taskfile.ss.yml step
+# would copy the existing Taskfile.ss.yml to itself, never picking up
+# upstream changes. Using Taskfile.ss.yml as the slopstopper-source marker
+# (the previous behaviour) failed exactly this case because the adopter has
+# their own Taskfile.ss.yml from a prior install.
+TARGET_ABS="$(cd "$TARGET_DIR" 2>/dev/null && pwd || echo "$TARGET_DIR")"
+
+# Decide whether SCRIPT_DIR is the genuine slopstopper repo. Markers:
+#  - templates/  (only slopstopper has it; adopters get the templates
+#    expanded into .slopstopper.yml, public/_headers, etc.)
+#  - install.sh  (this script itself, sanity check)
+#  - SCRIPT_DIR != TARGET_ABS (running install.sh from inside a target
+#    that happens to ship its own templates/ dir would still trigger this).
+SCRIPT_IS_SOURCE=0
+if [ -n "$SCRIPT_DIR" ] \
+   && [ -d "$SCRIPT_DIR/templates" ] \
+   && [ -f "$SCRIPT_DIR/install.sh" ] \
+   && [ "$SCRIPT_DIR" != "$TARGET_ABS" ]; then
+  SCRIPT_IS_SOURCE=1
+fi
+
+if [ "$SCRIPT_IS_SOURCE" -eq 0 ]; then
   if ! command -v git &>/dev/null; then
-    error "git is required when running via curl. Please install git and try again."
+    error "git is required when running install.sh from outside the SlopStopper repo. Please install git and try again."
   fi
 
   TMP_DIR="$(mktemp -d)"
@@ -165,7 +186,8 @@ success ".ss/tests/ installed (refreshed)"
 cp "$SCRIPT_DIR/.ss/playwright.config.js" "$TARGET_DIR/.ss/playwright.config.js"
 cp "$SCRIPT_DIR/.ss/lighthouserc.json" "$TARGET_DIR/.ss/lighthouserc.json"
 cp "$SCRIPT_DIR/.ss/lighthouserc.prod.json" "$TARGET_DIR/.ss/lighthouserc.prod.json"
-success ".ss/ Playwright + Lighthouse configs installed (refreshed)"
+cp "$SCRIPT_DIR/.ss/server.js" "$TARGET_DIR/.ss/server.js"
+success ".ss/ Playwright + Lighthouse configs + server.js installed (refreshed)"
 
 # 4. .github/workflows/ — install ss- prefixed generic workflows.
 WORKFLOWS_SRC="$SCRIPT_DIR/.github/workflows"
@@ -394,7 +416,7 @@ echo "       Complexity · Doc Structure · Doc Accuracy · Doc Size"
 echo "       Auto-label PRs · Workflow-failure tracker"
 echo ""
 echo "  ⏳ Active once you point them at your app (edit .slopstopper.yml):"
-echo "       Smoke · Accessibility · Core Web Vitals · DAST · Playwright"
+echo "       Smoke · Accessibility · Core Web Vitals · DAST · SEO · Broken Links"
 echo ""
 echo "     # in .slopstopper.yml:"
 echo "     urls:"

--- a/templates/gitignore.block
+++ b/templates/gitignore.block
@@ -1,7 +1,11 @@
 # slopstopper begin
 # Generated outputs from slopstopper checks. Safe to delete locally.
+# .ss/.workflows-installed is the source of truth for what install.sh
+# deployed last; it MUST be committed so that re-runs (CI or fresh
+# checkout) can respect adopter deletions. Don't add it here.
 .ss/reports/
-.ss/.workflows-installed
+.ss/scripts/**/__pycache__/
+.ss/tests/**/__pycache__/
 playwright-report/
 test-results/
 .lighthouseci/


### PR DESCRIPTION
## Summary

Six installer-side follow-ups from the Phase 1.1 hungovercoders install, batched because they all touch `install.sh`, `templates/gitignore.block`, or the seeded `.ss/` scaffolding. None are CI-blocking on their own, but each one is a sharp edge the next adopter would hit.

- **#75 — Portable `.ss/server.js`.** Adopters needed to hand-roll a static server for the local-first dynamic check loop. Ship a small portable shim. Auto-detects `SERVE_ROOT` among `dist/client` → `dist` → `build` → `out` → `public` → `app`, honours `SERVE_ROOT` and `PORT` env vars, handles pretty URLs (`/foo` → `/foo.html` or `/foo/index.html`), 404s missing paths. No security headers — local dev convenience, run DAST against a deployed preview if you need headers asserted. Refreshed on re-install like the other `.ss/` configs.
- **#76 — Cross-platform Trivy installer.** Detects OS via `uname -s` (Linux/Darwin/FreeBSD) and arch via `uname -m` (x86_64/arm64/aarch64) and builds the GitHub release URL accordingly. Adds `brew install aquasecurity/trivy/trivy` as the macOS fast-path. Previously hardcoded `Linux-64bit` broke every non-x86_64-Linux adopter.
- **#80 — `install.sh` source detection.** Old logic treated `\$SCRIPT_DIR/Taskfile.ss.yml` existing as proof of being the slopstopper repo. False when the adopter already has a `Taskfile.ss.yml` from a prior install — installer would `cp` files to themselves and never refresh. Now requires `templates/` directory + `install.sh` itself + `SCRIPT_DIR != TARGET_ABS`. Falls through to clone-temp on mismatch.
- **#81 — Drop stale "Playwright" mention from `install.sh` stdout.** The Playwright umbrella workflow was removed in #178 but the post-install banner still advertised it as active-once-configured. Replaced with `SEO · Broken Links` to reflect what's actually shipping.
- **#85 — `templates/gitignore.block` ignores `__pycache__`.** The block didn't ignore `.ss/scripts/**/__pycache__` or `.ss/tests/**/__pycache__`, so Python bytecode got staged on first run. Fixed in the template, and also in slopstopper's own `.gitignore` which had the same gap.
- **#86 — Reconcile gitignore vs install manifest.** `.ss/.workflows-installed` was in `gitignore.block` but the install skill (and `install.sh` itself) treat it as the source of truth for which workflows were installed last time, used to respect adopter deletions on re-install. The manifest MUST be tracked. Removed from `gitignore.block`; added an inline comment explaining why.

## Test plan

- [x] `bash -n install.sh`: syntax clean.
- [x] Portable `.ss/server.js` smoke-tested locally on all three URL shapes (`/`, `/about/`, `/about` no-trailing-slash) and 404 path. Auto-detect resolved `dist/client` correctly.
- [x] `task --list` still parses cleanly with the new Trivy detection block.
- [x] `task ss:hygiene:complexity` still green on slopstopper itself (this branch doesn't include the wave-1 \`python3 -m lizard\` change, so this confirms the wave-2 Trivy edit didn't break the existing complexity path either).
- [ ] CI: confirm all checks pass on this branch.
- [ ] Manual: dry-run \`install.sh\` against a target dir that already has \`Taskfile.ss.yml\` to confirm \`SCRIPT_IS_SOURCE=0\` triggers the clone-temp path.
- [ ] Manual: \`uname -m\` on Apple Silicon → confirm the macOS-ARM64 release URL builds correctly (test in next install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)