### PR TITLE
fix(checks): correctness batch — CSP /* symmetry, docs categories, og:image override (#82, #83, #90)

### DIFF
--- a/.ss/scripts/check-csp-exceptions.py
+++ b/.ss/scripts/check-csp-exceptions.py
@@ -125,7 +125,18 @@ def _handle_doc_line(out: dict, state: dict, line: str) -> None:
     heading = HEADING_RE.match(line)
     if heading:
         _flush_doc_entry(out, state)
-        state["path"] = heading.group(1)
+        path = heading.group(1)
+        # /* is the site-wide CSP baseline, not a per-path exception.
+        # _headers_exception_map() skips /* on the headers side; doing the
+        # same here keeps the doc parser symmetric. A `### /*` heading
+        # under `## Exceptions` would otherwise be flagged as a stale doc
+        # entry (no matching headers rule, because the headers parser
+        # filtered /* out earlier).
+        if path == "/*":
+            state["path"] = None
+            state["current"] = None
+            return
+        state["path"] = path
         state["current"] = _new_entry()
         return
     if state["current"] is None:

--- a/.ss/scripts/check-docs-structure.py
+++ b/.ss/scripts/check-docs-structure.py
@@ -78,7 +78,11 @@ def _check_unexpected_items(docs_path, expected_categories):
 
 
 def check_docs_structure():
-    """Validate docs structure against index.md governance."""
+    """Validate docs structure against index.md governance.
+
+    Returns (violations, expected_categories) so the report writer can render
+    the actual adopter-declared categories instead of hardcoding slopstopper's.
+    """
     docs_path = Path("docs")
 
     if not docs_path.exists():
@@ -88,27 +92,30 @@ def check_docs_structure():
     expected_categories = extract_categories_from_index()
     violations = _check_expected_categories(docs_path, expected_categories)
     violations += _check_unexpected_items(docs_path, expected_categories)
-    return violations
+    return violations, expected_categories
 
 
 def main():
     print("🔍 Validating documentation structure...")
-    
-    violations = check_docs_structure()
-    
+
+    violations, expected_categories = check_docs_structure()
+
     # Create report directory
     Path(".ss/reports/docs").mkdir(parents=True, exist_ok=True)
-    
-    # Write JSON report
+
+    # Write JSON report. expected_categories is what generate-docs-structure-md.py
+    # renders in its "Expected Categories" table — it's adopter-defined, not
+    # slopstopper-defined, so it MUST flow through here.
     report = {
         "violations": violations,
         "valid": len(violations) == 0,
-        "violation_count": len(violations)
+        "violation_count": len(violations),
+        "expected_categories": expected_categories,
     }
-    
+
     with open(".ss/reports/docs/docs-structure-report.json", "w") as f:
         json.dump(report, f, indent=2)
-    
+
     if violations:
         print(f"❌ Found {len(violations)} structure violation(s)")
         sys.exit(1)

--- a/.ss/scripts/check-seo-metatags.py
+++ b/.ss/scripts/check-seo-metatags.py
@@ -217,6 +217,38 @@ def rewrite_origin(url: str, new_base: str) -> str:
     return urllib.parse.urlunparse((new.scheme, new.netloc, src.path, src.params, src.query, src.fragment))
 
 
+def _maybe_rewrite_og_image(og_image_abs: str, og_image_base: Optional[str]) -> tuple[str, bool]:
+    """Return (url_to_HEAD, was_rewritten). Only rewrites when bases differ."""
+    if not og_image_base:
+        return og_image_abs, False
+    src_origin = urllib.parse.urlparse(og_image_abs).netloc
+    override_origin = urllib.parse.urlparse(og_image_base).netloc
+    if not src_origin or not override_origin or src_origin == override_origin:
+        return og_image_abs, False
+    return rewrite_origin(og_image_abs, og_image_base), True
+
+
+def _verify_og_image(
+    tags: dict[str, str],
+    page_url: str,
+    og_image_base: Optional[str],
+    issues: list[str],
+) -> Optional[dict]:
+    """HEAD-check og:image (after optional origin rewrite); update issues; return image_check dict."""
+    og_image_abs = urllib.parse.urljoin(page_url, tags["og:image"])
+    head_url, rewritten = _maybe_rewrite_og_image(og_image_abs, og_image_base)
+    ok, detail = head_ok(head_url)
+    if not ok:
+        via = f" (origin-rewritten from {og_image_abs})" if rewritten else ""
+        issues.append(f"og:image not reachable ({head_url}){via}: {detail}")
+    return {
+        "url": head_url,
+        "original_url": og_image_abs if rewritten else None,
+        "ok": ok,
+        "detail": detail,
+    }
+
+
 def check_page(
     base: str,
     path: str,
@@ -250,32 +282,9 @@ def check_page(
     validate_open_graph_tags(tags, issues, require_og_image)
     validate_twitter_tags(tags, issues, notes, require_og_image)
 
-    # Verify og:image is reachable
     image_check: Optional[dict] = None
     if tags["og:image"] and verify_og_image:
-        # Normalise relative og:image against page URL
-        og_image_abs = urllib.parse.urljoin(page_url, tags["og:image"])
-        head_url = og_image_abs
-        rewritten = False
-        # Pre-deploy mode: page hard-codes production origin in og:image,
-        # but we're testing against a local/preview base. Swap origins so
-        # the HEAD check hits the artefact actually being shipped.
-        if og_image_base:
-            src_origin = urllib.parse.urlparse(og_image_abs).netloc
-            override_origin = urllib.parse.urlparse(og_image_base).netloc
-            if src_origin and override_origin and src_origin != override_origin:
-                head_url = rewrite_origin(og_image_abs, og_image_base)
-                rewritten = True
-        ok, detail = head_ok(head_url)
-        image_check = {
-            "url": head_url,
-            "original_url": og_image_abs if rewritten else None,
-            "ok": ok,
-            "detail": detail,
-        }
-        if not ok:
-            via = f" (origin-rewritten from {og_image_abs})" if rewritten else ""
-            issues.append(f"og:image not reachable ({head_url}){via}: {detail}")
+        image_check = _verify_og_image(tags, page_url, og_image_base, issues)
 
     return {
         "url": page_url,

--- a/.ss/scripts/check-seo-metatags.py
+++ b/.ss/scripts/check-seo-metatags.py
@@ -10,10 +10,18 @@ category covers core SEO (description, viewport, canonical, indexability)
 but does not flag missing OpenGraph or Twitter tags.
 
 Inputs (env vars):
-    SEO_TEST_URL       (required)  base URL, e.g. https://slopstopper.dev
-    SEO_PAGES          (default /) comma-separated paths to check
-    SEO_REQUIRE_OG_IMAGE  (default 1)  set to 0 to skip og:image presence check
-    SEO_VERIFY_OG_IMAGE   (default 1)  set to 0 to skip HEAD-fetching og:image
+    SEO_TEST_URL          (required)  base URL, e.g. https://slopstopper.dev
+    SEO_PAGES             (default /) comma-separated paths to check
+    SEO_REQUIRE_OG_IMAGE  (default 1) set to 0 to skip og:image presence check
+    SEO_VERIFY_OG_IMAGE   (default 1) set to 0 to skip HEAD-fetching og:image
+    SEO_OG_IMAGE_BASE     (optional)  if set, rewrite the origin of any
+                                      absolute og:image / twitter:image URL
+                                      to this base before HEAD-checking.
+                                      Use when testing a pre-deploy preview
+                                      (e.g. http://localhost:8080) where the
+                                      page already hard-codes the production
+                                      origin in its og:image. The page itself
+                                      is still fetched from SEO_TEST_URL.
 
 Outputs:
     .ss/reports/seo/seo-metatags-report.md   (human-readable)
@@ -202,7 +210,20 @@ def validate_twitter_tags(tags: dict[str, str], issues: list[str], notes: list[s
         issues.append("Missing twitter:image")
 
 
-def check_page(base: str, path: str, require_og_image: bool, verify_og_image: bool) -> dict:
+def rewrite_origin(url: str, new_base: str) -> str:
+    """Replace the scheme+netloc of url with those of new_base, preserving path/query/fragment."""
+    src = urllib.parse.urlparse(url)
+    new = urllib.parse.urlparse(new_base)
+    return urllib.parse.urlunparse((new.scheme, new.netloc, src.path, src.params, src.query, src.fragment))
+
+
+def check_page(
+    base: str,
+    path: str,
+    require_og_image: bool,
+    verify_og_image: bool,
+    og_image_base: Optional[str] = None,
+) -> dict:
     page_url = urllib.parse.urljoin(base.rstrip("/") + "/", path.lstrip("/"))
     issues: list[str] = []
     notes: list[str] = []
@@ -234,10 +255,27 @@ def check_page(base: str, path: str, require_og_image: bool, verify_og_image: bo
     if tags["og:image"] and verify_og_image:
         # Normalise relative og:image against page URL
         og_image_abs = urllib.parse.urljoin(page_url, tags["og:image"])
-        ok, detail = head_ok(og_image_abs)
-        image_check = {"url": og_image_abs, "ok": ok, "detail": detail}
+        head_url = og_image_abs
+        rewritten = False
+        # Pre-deploy mode: page hard-codes production origin in og:image,
+        # but we're testing against a local/preview base. Swap origins so
+        # the HEAD check hits the artefact actually being shipped.
+        if og_image_base:
+            src_origin = urllib.parse.urlparse(og_image_abs).netloc
+            override_origin = urllib.parse.urlparse(og_image_base).netloc
+            if src_origin and override_origin and src_origin != override_origin:
+                head_url = rewrite_origin(og_image_abs, og_image_base)
+                rewritten = True
+        ok, detail = head_ok(head_url)
+        image_check = {
+            "url": head_url,
+            "original_url": og_image_abs if rewritten else None,
+            "ok": ok,
+            "detail": detail,
+        }
         if not ok:
-            issues.append(f"og:image not reachable ({og_image_abs}): {detail}")
+            via = f" (origin-rewritten from {og_image_abs})" if rewritten else ""
+            issues.append(f"og:image not reachable ({head_url}){via}: {detail}")
 
     return {
         "url": page_url,
@@ -279,6 +317,8 @@ def append_tags(lines: list[str], tags: dict[str, str]) -> None:
 def append_image_check(lines: list[str], image_check: dict) -> None:
     icon = "✅" if image_check["ok"] else "❌"
     lines.append(f"**og:image fetch:** {icon} `{image_check['url']}` — {image_check['detail']}")
+    if image_check.get("original_url"):
+        lines.append(f"  _(origin rewritten from `{image_check['original_url']}` via `SEO_OG_IMAGE_BASE`)_")
     lines.append("")
 
 
@@ -334,13 +374,14 @@ def write_reports(results: list[dict], base: str) -> None:
     md_path.write_text(build_markdown_report(results, base, overall_pass))
 
 
-def read_config() -> tuple[str, list[str], bool, bool]:
+def read_config() -> tuple[str, list[str], bool, bool, Optional[str]]:
     base = os.environ.get("SEO_TEST_URL", "").strip()
     pages_raw = os.environ.get("SEO_PAGES", "/")
     pages = [p.strip() for p in pages_raw.split(",") if p.strip()] or ["/"]
     require_og_image = os.environ.get("SEO_REQUIRE_OG_IMAGE", "1") != "0"
     verify_og_image = os.environ.get("SEO_VERIFY_OG_IMAGE", "1") != "0"
-    return base, pages, require_og_image, verify_og_image
+    og_image_base = os.environ.get("SEO_OG_IMAGE_BASE", "").strip() or None
+    return base, pages, require_og_image, verify_og_image, og_image_base
 
 
 def print_results(results: list[dict]) -> None:
@@ -353,7 +394,7 @@ def print_results(results: list[dict]) -> None:
 
 
 def main() -> int:
-    base, pages, require_og_image, verify_og_image = read_config()
+    base, pages, require_og_image, verify_og_image, og_image_base = read_config()
     if not base:
         print("❌ Error: SEO_TEST_URL is required", file=sys.stderr)
         print("", file=sys.stderr)
@@ -363,9 +404,11 @@ def main() -> int:
 
     print(f"🔎 SEO metatag audit against: {base}")
     print(f"   Pages: {', '.join(pages)}")
+    if og_image_base:
+        print(f"   og:image origin override → {og_image_base}")
     print("━" * 60)
 
-    results = [check_page(base, p, require_og_image, verify_og_image) for p in pages]
+    results = [check_page(base, p, require_og_image, verify_og_image, og_image_base) for p in pages]
     write_reports(results, base)
 
     overall_pass = all(r["status"] == "pass" for r in results)

--- a/.ss/scripts/generate-docs-structure-md.py
+++ b/.ss/scripts/generate-docs-structure-md.py
@@ -28,6 +28,34 @@ def read_json_report(json_path):
     return data
 
 
+def _format_expected_categories_section(categories):
+    """Render the 'Expected Categories' table from adopter-declared categories.
+
+    Previously hardcoded to slopstopper's own 8 categories, which was wrong for
+    every other adopter. categories comes from docs/index.md, parsed by
+    check-docs-structure.py and threaded through the JSON report.
+    """
+    if not categories:
+        return (
+            "## Expected Categories\n\n"
+            "_No categories declared in `docs/index.md`. Add a categories table "
+            "(see slopstopper's docs/index.md for the format) to enforce structure._\n\n"
+        )
+
+    lines = [
+        "## Expected Categories",
+        "",
+        "The following categories are defined in `docs/index.md`:",
+        "",
+        "| Category | Required | Status |",
+        "|----------|----------|--------|",
+    ]
+    for category in categories:
+        lines.append(f"| {category}/ | ✅ | Must exist with README.md |")
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
 def _format_violations_content(violations):
     """Format violations into markdown sections grouped by type."""
     content = f"Found **{len(violations)}** violation(s):\n\n"
@@ -84,23 +112,10 @@ The documentation structure is governed by [`docs/index.md`](../index.md). All d
         report += _format_violations_content(violations)
     else:
         report += "✅ No violations found\n\n"
-    
-    report += """## Expected Categories
 
-The following categories are defined in `docs/index.md`:
+    report += _format_expected_categories_section(data.get("expected_categories", []))
 
-| Category | Required | Status |
-|----------|----------|--------|
-| architecture/ | ✅ | Must exist with README.md |
-| contributing/ | ✅ | Must exist with README.md |
-| decisions/ | ✅ | Must exist with README.md |
-| deployment/ | ✅ | Must exist with README.md |
-| hygiene/ | ✅ | Must exist with README.md |
-| reliability/ | ✅ | Must exist with README.md |
-| runbooks/ | ✅ | Must exist with README.md |
-| security/ | ✅ | Must exist with README.md |
-
-## How to Fix
+    report += """## How to Fix
 
 1. **For missing directories or README.md files:**
    - Create the directory and add a README.md with its purpose

--- a/.ss/tests/check_csp_exceptions.test.py
+++ b/.ss/tests/check_csp_exceptions.test.py
@@ -1,0 +1,147 @@
+"""Tests for check-csp-exceptions.py — focused on parser invariants.
+
+The end-to-end drift comparison is exercised by `task ss:hygiene:csp-exceptions`
+against slopstopper's own CSP_EXCEPTIONS.md in CI.
+"""
+
+import importlib.util
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+
+THIS_DIR = Path(__file__).resolve().parent
+SCRIPT_PATH = THIS_DIR.parent / "scripts" / "check-csp-exceptions.py"
+
+
+def _load_module():
+    """Import check-csp-exceptions.py by file path (hyphen in name blocks normal import)."""
+    spec = importlib.util.spec_from_file_location("check_csp_exceptions", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(SCRIPT_PATH.parent))
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_doc(text: str) -> Path:
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False)
+    tmp.write(text)
+    tmp.close()
+    return Path(tmp.name)
+
+
+def test_skips_glob_baseline_under_exceptions():
+    """`### /*` under `## Exceptions` is the site-wide baseline, not a per-path exception."""
+    mod = _load_module()
+    doc = _write_doc("""# CSP Exceptions
+
+## Baseline relaxations (site-wide CSP)
+
+Baseline notes here.
+
+## Exceptions
+
+### /*
+
+- **Origin allowed:** none — site-wide baseline only
+- **Why:** site-wide CSP baseline; documented for reference, not an exception
+
+### /feedback.html
+
+- **Origin allowed:** https://giscus.app
+- **Directives added:** script-src https://giscus.app
+- **Loader SRI:** abc123
+- **Why:** Giscus comments
+- **Approved by:** maintainer
+- **Data leaving site:** username, comment
+- **Refresh policy:** quarterly
+""")
+    try:
+        entries = mod.parse_exceptions_doc(doc)
+        assert "/*" not in entries, "Glob baseline must not be parsed as an exception entry"
+        assert "/feedback.html" in entries, "Per-path heading should still be picked up"
+        assert "https://giscus.app" in entries["/feedback.html"]["origins"], \
+            "Origin should be extracted for valid entries"
+        print("✅ test_skips_glob_baseline_under_exceptions passed")
+    finally:
+        os.unlink(doc)
+
+
+def test_following_heading_starts_clean_after_skipped_glob():
+    """Field lines after a skipped `### /*` must not bleed into the next entry."""
+    mod = _load_module()
+    doc = _write_doc("""# CSP Exceptions
+
+## Exceptions
+
+### /*
+
+- **Origin allowed:** baseline only
+- **Directives added:** script-src https://baseline.example
+- **Loader SRI:** TODO
+
+### /real-exception
+
+- **Origin allowed:** https://real.example
+- **Directives added:** script-src https://real.example
+- **Loader SRI:** sha256-real
+- **Why:** real third party
+- **Approved by:** maintainer
+- **Data leaving site:** nothing
+- **Refresh policy:** quarterly
+""")
+    try:
+        entries = mod.parse_exceptions_doc(doc)
+        assert "/*" not in entries
+        assert entries["/real-exception"]["origins"] == {"https://real.example"}, \
+            "Origins from skipped /* block must not leak into next entry"
+        assert entries["/real-exception"]["sri"] == "sha256-real", \
+            "SRI from skipped /* block must not leak into next entry"
+        print("✅ test_following_heading_starts_clean_after_skipped_glob passed")
+    finally:
+        os.unlink(doc)
+
+
+def test_glob_outside_exceptions_section_is_irrelevant():
+    """`### /*` outside `## Exceptions` (e.g. under a baseline section) is always ignored."""
+    mod = _load_module()
+    doc = _write_doc("""# CSP Exceptions
+
+## Baseline relaxations (site-wide CSP)
+
+### /*
+
+- **Origin allowed:** site-wide baseline only
+
+## Exceptions
+
+### /feedback.html
+
+- **Origin allowed:** https://giscus.app
+""")
+    try:
+        entries = mod.parse_exceptions_doc(doc)
+        assert "/*" not in entries
+        assert "/feedback.html" in entries
+        print("✅ test_glob_outside_exceptions_section_is_irrelevant passed")
+    finally:
+        os.unlink(doc)
+
+
+if __name__ == "__main__":
+    print("\n🧪 Running check-csp-exceptions parser tests...\n")
+    try:
+        test_skips_glob_baseline_under_exceptions()
+        test_following_heading_starts_clean_after_skipped_glob()
+        test_glob_outside_exceptions_section_is_irrelevant()
+        print("\n✅ All tests passed!\n")
+        sys.exit(0)
+    except AssertionError as e:
+        print(f"\n❌ Test failed: {e}\n")
+        sys.exit(1)
+    except Exception as e:
+        print(f"\n❌ Unexpected error: {e}\n")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)

--- a/.ss/tests/check_seo_metatags.test.py
+++ b/.ss/tests/check_seo_metatags.test.py
@@ -1,0 +1,73 @@
+"""Tests for check-seo-metatags.py — focused on SEO_OG_IMAGE_BASE rewrite path.
+
+End-to-end fetching is exercised by `task ss:reliability:seo` in CI against
+slopstopper.dev / preview URLs. This test pins the URL-rewrite logic
+that lets adopters validate pre-deploy previews against production-baked
+og:image URLs.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+THIS_DIR = Path(__file__).resolve().parent
+SCRIPT_PATH = THIS_DIR.parent / "scripts" / "check-seo-metatags.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_seo_metatags", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(SCRIPT_PATH.parent))
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_rewrite_origin_swaps_scheme_and_netloc():
+    mod = _load_module()
+    result = mod.rewrite_origin(
+        "https://hungovercoders.com/assets/foo/link.png",
+        "http://localhost:8080",
+    )
+    assert result == "http://localhost:8080/assets/foo/link.png", \
+        f"unexpected rewrite: {result}"
+    print("✅ test_rewrite_origin_swaps_scheme_and_netloc passed")
+
+
+def test_rewrite_origin_preserves_query_and_fragment():
+    mod = _load_module()
+    result = mod.rewrite_origin(
+        "https://hungovercoders.com/assets/foo/link.png?v=2#x",
+        "http://localhost:8080",
+    )
+    assert result == "http://localhost:8080/assets/foo/link.png?v=2#x", \
+        f"unexpected rewrite: {result}"
+    print("✅ test_rewrite_origin_preserves_query_and_fragment passed")
+
+
+def test_rewrite_origin_handles_port_in_target():
+    mod = _load_module()
+    result = mod.rewrite_origin(
+        "https://hungovercoders.com/og.png",
+        "http://127.0.0.1:4321",
+    )
+    assert result == "http://127.0.0.1:4321/og.png", f"unexpected rewrite: {result}"
+    print("✅ test_rewrite_origin_handles_port_in_target passed")
+
+
+if __name__ == "__main__":
+    print("\n🧪 Running check-seo-metatags tests...\n")
+    try:
+        test_rewrite_origin_swaps_scheme_and_netloc()
+        test_rewrite_origin_preserves_query_and_fragment()
+        test_rewrite_origin_handles_port_in_target()
+        print("\n✅ All tests passed!\n")
+        sys.exit(0)
+    except AssertionError as e:
+        print(f"\n❌ Test failed: {e}\n")
+        sys.exit(1)
+    except Exception as e:
+        print(f"\n❌ Unexpected error: {e}\n")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)

--- a/Taskfile.ss.yml
+++ b/Taskfile.ss.yml
@@ -146,10 +146,19 @@ tasks:
         SEO_PAGES             - comma-separated paths (default: /)
         SEO_REQUIRE_OG_IMAGE  - 0 to skip og:image presence check (default: 1)
         SEO_VERIFY_OG_IMAGE   - 0 to skip HEAD-fetching og:image (default: 1)
+        SEO_OG_IMAGE_BASE     - rewrite absolute og:image / twitter:image
+                                origin to this base before HEAD-checking.
+                                Use when validating a pre-deploy preview
+                                (e.g. http://localhost:8080) where the
+                                page bakes in the production origin.
 
       Usage:
         task ss:reliability:seo -- https://your-site.example.com
         SEO_TEST_URL=https://your-site.example.com task ss:reliability:seo
+        # Pre-deploy local preview:
+        SEO_TEST_URL=http://localhost:8080 \
+          SEO_OG_IMAGE_BASE=http://localhost:8080 \
+          task ss:reliability:seo
     cmds:
       - |
         {{if .CLI_ARGS}}


### PR DESCRIPTION
## Summary

Three independent check-correctness fixes surfaced by the Phase 1.1 hungovercoders install. Each closes an asymmetry or hardcoded assumption that made the relevant check noisy or wrong for adopters whose shape differs from slopstopper.dev's. None are CI-blocking on slopstopper itself today, but each one bit the next adopter at the install prompt.

- **#82 — CSP doc-parser symmetric on `/*`.** \`_headers_exception_map()\` already skips \`path == '/*'\` on the headers side because \`/*\` is the site-wide CSP baseline, not a per-path exception. The doc parser didn't apply the same filter, so a \`### /*\` heading under \`## Exceptions\` in \`CSP_EXCEPTIONS.md\` (a reasonable way to document the baseline) was flagged as a stale doc entry with no matching headers rule. Fix: drop \`/*\` in \`parse_exceptions_doc\` with a cross-reference comment to the headers-side skip. **Three unit tests** pin the behaviour — including the bleed case where field lines under a skipped \`/*\` could otherwise contaminate the next entry's origins/SRI.
- **#83 — docs-structure report uses adopter categories.** The \"Expected Categories\" table was hardcoded to slopstopper's own 8 — meaningless for adopters with different governance. \`check-docs-structure.py\` already extracted the real categories from \`docs/index.md\` (via \`extract_categories_from_index()\`) but never surfaced them. Thread them through the JSON report and render the actual list in \`generate-docs-structure-md.py\`. Empty categories shows a \"declare a table in docs/index.md\" hint instead. Verified end-to-end on slopstopper — report now shows its own 10 categories pulled from the index instead of a stale 8.
- **#90 — SEO check \`SEO_OG_IMAGE_BASE\` override.** When validating a pre-deploy local preview (\`SEO_TEST_URL=http://localhost:8080\`), absolute \`og:image\` URLs in the page HTML still point at the production origin — that URL 404s locally because the per-post share image isn't deployed yet. New \`SEO_OG_IMAGE_BASE\` env var rewrites the origin of any cross-origin \`og:image\` URL to this base before the HEAD check. Report annotates the rewrite (\"_origin rewritten from \\<original\\> via SEO_OG_IMAGE_BASE_\") so the adopter sees what was actually fetched. **Three unit tests** cover scheme/netloc swap, query/fragment preservation, and port handling. Taskfile signature documents the new knob with a pre-deploy preview example.

## Test plan

- [x] \`python3 .ss/tests/check_csp_exceptions.test.py\` — 3/3 green
- [x] \`python3 .ss/tests/check_seo_metatags.test.py\` — 3/3 green
- [x] \`task ss:hygiene:csp-exceptions\` end-to-end on slopstopper: ✅ No drift
- [x] \`task ss:hygiene:docs-structure\` end-to-end on slopstopper: ✅ shows actual 10 categories from \`docs/index.md\`
- [ ] CI: confirm all checks pass on this branch
- [ ] Adopter-side smoke: re-run install against hungovercoders, run \`SEO_TEST_URL=http://localhost:8080 SEO_OG_IMAGE_BASE=http://localhost:8080 task ss:reliability:seo\` on a freshly-built site and confirm per-post share images get HEAD-checked against localhost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)