### PR TITLE
fix(dast): use host.docker.internal on macOS, preserve original port (#84)

### DIFF
--- a/Taskfile.ss.yml
+++ b/Taskfile.ss.yml
@@ -846,8 +846,21 @@ tasks:
             exit 1
           fi
 
-          # Replace localhost with Docker gateway IP for access from container
-          TARGET="http://172.17.0.1:8080"
+          # Replace localhost with a host-routable address from inside the ZAP
+          # container. The bridge gateway 172.17.0.1 works on Linux Docker
+          # (including ubuntu-latest runners in CI), but Docker Desktop on
+          # macOS does not route to it. Detect Darwin and use the magic
+          # host.docker.internal hostname instead — Docker Desktop wires it
+          # automatically. Same trick works on Windows.
+          DOCKER_HOST_TARGET="172.17.0.1"
+          if [ "$(uname -s)" = "Darwin" ]; then
+            DOCKER_HOST_TARGET="host.docker.internal"
+          fi
+          # Extract the original port so adopters running on a non-8080 port
+          # still hit the right place.
+          ORIGINAL_PORT="$(echo "$TARGET" | sed -E 's|https?://[^:/]+:?([0-9]+)?.*|\1|')"
+          ORIGINAL_PORT="${ORIGINAL_PORT:-8080}"
+          TARGET="http://${DOCKER_HOST_TARGET}:${ORIGINAL_PORT}"
           echo "📍 Using Docker-compatible target: $TARGET"
         fi
         


### PR DESCRIPTION
## Summary

\`ss:security:dast\` against \`localhost\` substitutes a host-routable address so the ZAP container can reach the dev server. The previous hardcoded \`http://172.17.0.1:8080\` works on Linux Docker (including \`ubuntu-latest\` in CI) but Docker Desktop on macOS does not route to that bridge gateway — the local loop fails with \"ZAP could not access the target.\"

- Detect Darwin via \`uname -s\` and swap in \`host.docker.internal\`, which Docker Desktop wires automatically on macOS (and Windows). Linux keeps \`172.17.0.1\` so CI behaviour is unchanged.
- Extract the original port from the input \`TARGET\` instead of hardcoding \`8080\`. Adopters running on a non-default port (e.g. Astro on \`:4321\`) no longer get silently redirected to \`:8080\`. Fallback is \`8080\` when the input omits a port.

## Test plan

- [x] Bash logic verified on macOS: \`http://localhost:8080\` → \`http://host.docker.internal:8080\`; non-8080 port preserved; missing port falls back to 8080.
- [ ] CI: confirm DAST workflow still passes on \`ubuntu-latest\` (where \`uname -s\` is \`Linux\` and \`172.17.0.1\` path stays in effect).
- [ ] Adopter-side smoke: re-run \`task ss:security:dast\` on hungovercoders/site from macOS — should now complete locally instead of failing on container-to-host networking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)