### PR TITLE
feat(reliability): sitemap + changed-pages coverage (#87, #88, #89)

### DIFF
--- a/.github/workflows/ss-reliability-accessibility-check.yml
+++ b/.github/workflows/ss-reliability-accessibility-check.yml
@@ -34,6 +34,12 @@ on:
         required: false
         default: '0'
         type: string
+      coverage_mode:
+        description: 'Force discovery mode (overrides .slopstopper.yml)'
+        required: false
+        default: ''
+        type: choice
+        options: ['', 'sitemap', 'changed']
 
 permissions:
   contents: read
@@ -52,6 +58,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # discover-pages.py changed-mode needs git history vs the base branch.
+          # 0 = full history. Adds a couple of seconds; cost is negligible.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -128,12 +138,22 @@ jobs:
 
       - name: Pages to audit
         if: steps.url.outputs.use_local == 'true'
-        # Reads pages.accessibility from .slopstopper.yml. Falls back to '/'
-        # if not configured. Override per-repo in .slopstopper.yml, e.g.:
-        #   pages:
-        #     accessibility: /,/blog,/about
+        env:
+          DISPATCH_MODE: ${{ github.event.inputs.coverage_mode }}
+          GITHUB_BASE_REF: ${{ github.base_ref || 'main' }}
+        # Calls discover-pages.py with the event-mapped mode. Falls through
+        # to pages.accessibility when reliability.coverage.* is unset, so
+        # existing adopters see no behaviour change.
         run: |
-          PAGES=$(python3 .ss/scripts/load_config.py pages.accessibility /)
+          case "${{ github.event_name }}" in
+            pull_request|pull_request_target) EVENT=pr ;;
+            push)              EVENT=main ;;
+            schedule)          EVENT=cron ;;
+            deployment_status) EVENT=main ;;
+            workflow_dispatch) EVENT="${DISPATCH_MODE:-main}" ;;
+            *)                 EVENT=main ;;
+          esac
+          PAGES=$(python3 .ss/scripts/discover-pages.py accessibility --event="$EVENT")
           echo "ACCESSIBILITY_PAGES=$PAGES" >> "$GITHUB_ENV"
 
       - name: Run accessibility audit

--- a/.github/workflows/ss-reliability-broken-links-check.yml
+++ b/.github/workflows/ss-reliability-broken-links-check.yml
@@ -16,6 +16,12 @@ on:
         required: false
         default: ''
         type: string
+      coverage_mode:
+        description: 'Force discovery mode (overrides .slopstopper.yml)'
+        required: false
+        default: ''
+        type: choice
+        options: ['', 'sitemap', 'changed']
 
 permissions:
   contents: read
@@ -32,6 +38,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # discover-pages.py changed-mode needs git history vs the base branch.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -98,12 +107,22 @@ jobs:
 
       - name: Pages to audit
         if: steps.url.outputs.use_local == 'true'
-        # Reads pages.broken_links from .slopstopper.yml. Falls back to '/'
-        # if not configured. Override per-repo in .slopstopper.yml:
-        #   pages:
-        #     broken_links: /,/blog,/about
+        env:
+          DISPATCH_MODE: ${{ github.event.inputs.coverage_mode }}
+          GITHUB_BASE_REF: ${{ github.base_ref || 'main' }}
+        # Calls discover-pages.py with the event-mapped mode. Falls through
+        # to pages.broken_links when reliability.coverage.* is unset, so
+        # existing adopters see no behaviour change.
         run: |
-          PAGES=$(python3 .ss/scripts/load_config.py pages.broken_links /)
+          case "${{ github.event_name }}" in
+            pull_request|pull_request_target) EVENT=pr ;;
+            push)              EVENT=main ;;
+            schedule)          EVENT=cron ;;
+            deployment_status) EVENT=main ;;
+            workflow_dispatch) EVENT="${DISPATCH_MODE:-main}" ;;
+            *)                 EVENT=main ;;
+          esac
+          PAGES=$(python3 .ss/scripts/discover-pages.py broken_links --event="$EVENT")
           echo "BROKEN_LINKS_PAGES=$PAGES" >> "$GITHUB_ENV"
 
       - name: Run broken-link checks

--- a/.github/workflows/ss-reliability-seo-check.yml
+++ b/.github/workflows/ss-reliability-seo-check.yml
@@ -19,6 +19,12 @@ on:
         required: false
         default: ''
         type: string
+      coverage_mode:
+        description: 'Force discovery mode (overrides .slopstopper.yml)'
+        required: false
+        default: ''
+        type: choice
+        options: ['', 'sitemap', 'changed']
 
 permissions:
   contents: read
@@ -36,6 +42,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # discover-pages.py changed-mode needs git history vs the base branch.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -114,12 +123,22 @@ jobs:
 
       - name: Pages to audit
         if: steps.url.outputs.use_local == 'true'
-        # Reads pages.seo from .slopstopper.yml. Falls back to '/' if not
-        # configured. Override per-repo in .slopstopper.yml:
-        #   pages:
-        #     seo: /,/blog,/about
+        env:
+          DISPATCH_MODE: ${{ github.event.inputs.coverage_mode }}
+          GITHUB_BASE_REF: ${{ github.base_ref || 'main' }}
+        # Calls discover-pages.py with the event-mapped mode. Falls through
+        # to pages.seo when reliability.coverage.* is unset, so existing
+        # adopters see no behaviour change.
         run: |
-          PAGES=$(python3 .ss/scripts/load_config.py pages.seo /)
+          case "${{ github.event_name }}" in
+            pull_request|pull_request_target) EVENT=pr ;;
+            push)              EVENT=main ;;
+            schedule)          EVENT=cron ;;
+            deployment_status) EVENT=main ;;
+            workflow_dispatch) EVENT="${DISPATCH_MODE:-main}" ;;
+            *)                 EVENT=main ;;
+          esac
+          PAGES=$(python3 .ss/scripts/discover-pages.py seo --event="$EVENT")
           echo "SEO_PAGES=$PAGES" >> "$GITHUB_ENV"
 
       - name: Run SEO metatag audit

--- a/.ss/scripts/discover-pages.py
+++ b/.ss/scripts/discover-pages.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+
+"""Page-discovery orchestrator for the reliability gates.
+
+Resolves "which paths should I audit?" for a given check (accessibility, SEO,
+broken-links, smoke) and CI event (pr, main, cron, local). Prints a
+comma-separated list of paths to stdout — the CI workflow "Pages to audit"
+step and the local Taskfile reliability tasks both consume that output.
+
+Resolution order (first hit wins):
+    1. Env-var override — if <CHECK>_PAGES is set in the environment, pass through.
+    2. reliability.coverage.<event> in .slopstopper.yml:
+         - "sitemap" → parse dist/client/sitemap-index.xml (or sibling
+           fallbacks), return every <loc> URL's path.
+         - "changed" (PR only) → git diff origin/main...HEAD, map each
+           changed source file to its output URL via framework-specific
+           rules (Astro / Next / SvelteKit auto-detected). Any changed file
+           matching reliability.coverage.cross_cutting_paths auto-escalates
+           the run to a sitemap sweep.
+         - "<path,path>" → comma-separated explicit list.
+    3. pages.<check> in .slopstopper.yml — existing hand-list behaviour.
+    4. Default → "/".
+
+The source_to_url mapper is baked into the script (not config-driven)
+because the stdlib YAML subset .ss/scripts/load_config.py supports doesn't
+handle list-of-mappings cleanly, and the three common framework shapes are
+predictable enough that adopters shouldn't need to author regex rules
+themselves. Custom routing falls back to sitemap mode on cross-cutting or
+unmapped files.
+
+Exit codes:
+    0 — paths resolved
+    1 — internal error
+    2 — discovery configured but inputs missing (no sitemap, no git history)
+
+Stdlib only — keeps the no-deps invariant the rest of .ss/scripts/ holds.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import os
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Optional, Sequence
+from urllib.parse import urlparse
+
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(THIS_DIR))
+import load_config  # noqa: E402  pylint: disable=wrong-import-position
+
+
+CHECKS = ("smoke", "accessibility", "seo", "broken_links")
+EVENTS = ("pr", "main", "cron", "local")
+
+ENV_VAR_BY_CHECK = {
+    "smoke": "SMOKE_PAGES",
+    "accessibility": "ACCESSIBILITY_PAGES",
+    "seo": "SEO_PAGES",
+    "broken_links": "BROKEN_LINKS_PAGES",
+}
+
+SITEMAP_CANDIDATES = (
+    "dist/client/sitemap-index.xml",
+    "dist/sitemap-index.xml",
+    "dist/sitemap.xml",
+    "dist/sitemap-0.xml",
+    "build/sitemap.xml",
+    "out/sitemap.xml",
+    "public/sitemap.xml",
+)
+
+SITEMAP_NS = "{http://www.sitemaps.org/schemas/sitemap/0.9}"
+
+
+# ── Per-framework source-to-URL rules ─────────────────────────────────
+#
+# Each rule = (regex, template). Capture groups in the regex feed into the
+# template via $name. Astro is the default; Next.js Pages Router and App
+# Router and SvelteKit are also supported. Adopters with custom routing
+# (i18n, catch-all routes, generated slugs) rely on cross_cutting_paths
+# escalation or unmapped→sitemap fallback to keep coverage honest.
+
+ASTRO_RULES: tuple[tuple[str, str], ...] = (
+    (r"^src/content/blog/(?P<slug>[^/]+)\.md$", "/blog/$slug/"),
+    (r"^src/content/blog/(?P<slug>[^/]+)\.mdx$", "/blog/$slug/"),
+    (r"^src/content/(?P<col>[^/]+)/(?P<slug>[^/]+)\.md$", "/$col/$slug/"),
+    (r"^src/content/(?P<col>[^/]+)/(?P<slug>[^/]+)\.mdx$", "/$col/$slug/"),
+    (r"^src/pages/index\.astro$", "/"),
+    (r"^src/pages/(?P<page>[^/]+)/index\.astro$", "/$page/"),
+    (r"^src/pages/(?P<page>[^/]+)\.astro$", "/$page/"),
+)
+
+NEXT_PAGES_RULES: tuple[tuple[str, str], ...] = (
+    (r"^pages/index\.tsx?$", "/"),
+    (r"^pages/index\.jsx?$", "/"),
+    (r"^pages/(?P<page>[^/]+)/index\.tsx?$", "/$page/"),
+    (r"^pages/(?P<page>[^/]+)/index\.jsx?$", "/$page/"),
+    (r"^pages/(?P<page>[^/]+)\.tsx?$", "/$page/"),
+    (r"^pages/(?P<page>[^/]+)\.jsx?$", "/$page/"),
+)
+
+NEXT_APP_RULES: tuple[tuple[str, str], ...] = (
+    (r"^app/page\.tsx?$", "/"),
+    (r"^app/page\.jsx?$", "/"),
+    (r"^app/(?P<route>[^/]+)/page\.tsx?$", "/$route/"),
+    (r"^app/(?P<route>[^/]+)/page\.jsx?$", "/$route/"),
+)
+
+SVELTEKIT_RULES: tuple[tuple[str, str], ...] = (
+    (r"^src/routes/\+page\.svelte$", "/"),
+    (r"^src/routes/(?P<route>[^/]+)/\+page\.svelte$", "/$route/"),
+)
+
+
+def _detect_framework_rules() -> tuple[tuple[str, str], ...]:
+    """Detect framework by config-file presence; return source_to_url rule set."""
+    if any(Path(f).exists() for f in ("astro.config.mjs", "astro.config.js", "astro.config.ts")):
+        return ASTRO_RULES
+    if any(Path(f).exists() for f in ("next.config.mjs", "next.config.js", "next.config.ts")):
+        return NEXT_PAGES_RULES + NEXT_APP_RULES
+    if any(Path(f).exists() for f in ("svelte.config.js", "svelte.config.mjs")):
+        return SVELTEKIT_RULES
+    return ASTRO_RULES
+
+
+def log(msg: str) -> None:
+    """Stderr log — never pollutes the stdout payload the caller consumes."""
+    print(msg, file=sys.stderr)
+
+
+# ── Sitemap parsing ─────────────────────────────────────────────────
+
+
+def _find_sitemap_path() -> Optional[Path]:
+    for candidate in SITEMAP_CANDIDATES:
+        path = Path(candidate)
+        if path.exists():
+            return path
+    return None
+
+
+def _resolve_child_sitemap(parent: Path, loc: str) -> Optional[Path]:
+    """A sitemapindex <loc> is usually an absolute URL like
+    https://example.com/sitemap-0.xml; map back to a sibling file path so
+    we can keep reading from disk without spinning up a fetcher."""
+    candidate = parent.parent / Path(urlparse(loc).path).name
+    if candidate.exists():
+        return candidate
+    return None
+
+
+def _extract_paths_from_sitemap_xml(path: Path, seen: set[Path]) -> list[str]:
+    """Read a sitemap XML file; recurse into sitemap-index files."""
+    if path in seen:
+        return []
+    seen.add(path)
+    try:
+        tree = ET.parse(path)
+    except ET.ParseError as e:
+        log(f"⚠️  Failed to parse sitemap {path}: {e}")
+        return []
+    root = tree.getroot()
+    if root.tag == f"{SITEMAP_NS}sitemapindex":
+        return _collect_from_index(root, path, seen)
+    if root.tag == f"{SITEMAP_NS}urlset":
+        return _collect_from_urlset(root)
+    return []
+
+
+def _collect_from_index(root: ET.Element, path: Path, seen: set[Path]) -> list[str]:
+    paths: list[str] = []
+    for sitemap_el in root.findall(f"{SITEMAP_NS}sitemap"):
+        loc = sitemap_el.find(f"{SITEMAP_NS}loc")
+        if loc is None or not loc.text:
+            continue
+        child = _resolve_child_sitemap(path, loc.text.strip())
+        if child is not None:
+            paths.extend(_extract_paths_from_sitemap_xml(child, seen))
+    return paths
+
+
+def _collect_from_urlset(root: ET.Element) -> list[str]:
+    paths: list[str] = []
+    for url_el in root.findall(f"{SITEMAP_NS}url"):
+        loc = url_el.find(f"{SITEMAP_NS}loc")
+        if loc is None or not loc.text:
+            continue
+        parsed = urlparse(loc.text.strip())
+        paths.append(parsed.path or "/")
+    return paths
+
+
+def _dedupe(paths: list[str]) -> list[str]:
+    seen: set[str] = set()
+    return [p for p in paths if not (p in seen or seen.add(p))]
+
+
+def _from_sitemap() -> list[str]:
+    path = _find_sitemap_path()
+    if path is None:
+        log(
+            "❌ sitemap mode: no sitemap found at any of: "
+            + ", ".join(SITEMAP_CANDIDATES)
+        )
+        log("   Run `npm run build` (or your build command) first.")
+        return []
+    log(f"📄 Sitemap discovered: {path}")
+    unique = _dedupe(_extract_paths_from_sitemap_xml(path, set()))
+    log(f"   → {len(unique)} unique paths")
+    return unique
+
+
+# ── Changed-pages mode ───────────────────────────────────────────────
+
+
+def _git_diff_files(base_ref: str) -> Optional[list[str]]:
+    """Return file paths changed in the current PR. None on git failure."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        log(f"⚠️  git diff failed: {e}")
+        log(
+            "   Hint: set `fetch-depth: 0` on actions/checkout for this workflow."
+        )
+        return None
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _file_matches_any_glob(file_path: str, patterns: Sequence[str]) -> bool:
+    return any(fnmatch.fnmatchcase(file_path, p) for p in patterns)
+
+
+def _expand_url_template(template: str, match: re.Match) -> str:
+    """Substitute $name and ${name} for re named groups in the template."""
+
+    def replace(m: re.Match) -> str:
+        name = m.group(1) or m.group(2)
+        return match.groupdict().get(name, "") or ""
+
+    return re.sub(r"\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}|\$([a-zA-Z_][a-zA-Z0-9_]*)", replace, template)
+
+
+def _map_file_to_urls(file_path: str, rules: Sequence[tuple[str, str]]) -> list[str]:
+    urls: list[str] = []
+    for pattern, template in rules:
+        try:
+            match = re.match(pattern, file_path)
+        except re.error as e:
+            log(f"⚠️  bad framework regex {pattern!r}: {e}")
+            continue
+        if match:
+            urls.append(_expand_url_template(template, match))
+    return urls
+
+
+def _resolve_base_ref() -> str:
+    base_ref = os.environ.get("GITHUB_BASE_REF") or "origin/main"
+    if not base_ref.startswith("origin/") and "/" not in base_ref:
+        base_ref = f"origin/{base_ref}"
+    return base_ref
+
+
+def _any_cross_cutting_change(files: list[str]) -> Optional[str]:
+    """Return the first file matching cross_cutting_paths, or None."""
+    cross_cutting = list(load_config.get("reliability.coverage.cross_cutting_paths", []) or [])
+    for file_path in files:
+        if _file_matches_any_glob(file_path, cross_cutting):
+            return file_path
+    return None
+
+
+def _map_changed_files(files: list[str]) -> tuple[list[str], list[str]]:
+    """Map each file to its URL(s) using framework defaults; return (urls, unmapped)."""
+    rules = _detect_framework_rules()
+    urls: list[str] = []
+    unmapped: list[str] = []
+    for file_path in files:
+        mapped = _map_file_to_urls(file_path, rules)
+        if mapped:
+            urls.extend(mapped)
+        else:
+            unmapped.append(file_path)
+    return urls, unmapped
+
+
+def _from_changed_pages() -> list[str]:
+    files = _git_diff_files(_resolve_base_ref())
+    if files is None:
+        log("   → falling back to sitemap mode")
+        return _from_sitemap()
+
+    trigger = _any_cross_cutting_change(files)
+    if trigger:
+        log(f"🎯 Cross-cutting change detected: {trigger} matches cross_cutting_paths")
+        log("   → escalating to sitemap sweep")
+        return _from_sitemap()
+
+    urls, unmapped = _map_changed_files(files)
+    if unmapped:
+        log(f"ℹ️  {len(unmapped)} changed file(s) had no source_to_url match (permissive)")
+
+    unique = _dedupe(urls)
+    if not unique:
+        log("   → changed-pages produced empty set, falling through to sitemap")
+        return _from_sitemap()
+    log(f"   → {len(unique)} changed page(s) selected from {len(files)} file(s)")
+    return unique
+
+
+# ── Resolution orchestrator ───────────────────────────────────────────
+
+
+def _from_env(check: str) -> Optional[list[str]]:
+    env_name = ENV_VAR_BY_CHECK[check]
+    raw = os.environ.get(env_name)
+    if raw is None:
+        return None
+    paths = [p.strip() for p in raw.split(",") if p.strip()]
+    if paths:
+        log(f"🔁 {env_name} preset in environment ({len(paths)} path(s))")
+        return paths
+    return None
+
+
+def _coverage_mode_str(event: str) -> Optional[str]:
+    raw = load_config.get(f"reliability.coverage.{event}")
+    if isinstance(raw, str):
+        return raw.strip() or None
+    if isinstance(raw, list):
+        items = [str(p).strip() for p in raw if str(p).strip()]
+        if items:
+            return ",".join(items)
+    return None
+
+
+def _from_coverage_mode(event: str) -> Optional[list[str]]:
+    mode = _coverage_mode_str(event)
+    if mode is None:
+        return None
+    if mode == "sitemap":
+        return _from_sitemap()
+    if mode == "changed":
+        if event != "pr":
+            log(f"⚠️  changed mode only valid for --event=pr (got {event}); skipping")
+            return None
+        return _from_changed_pages()
+    paths = [p.strip() for p in mode.split(",") if p.strip()]
+    if paths:
+        log(f"📋 explicit list from reliability.coverage.{event} ({len(paths)} path(s))")
+        return paths
+    return None
+
+
+def _from_pages_list(check: str) -> Optional[list[str]]:
+    raw = load_config.get(f"pages.{check}")
+    if raw is None:
+        return None
+    if isinstance(raw, list):
+        paths = [str(p).strip() for p in raw if str(p).strip()]
+    else:
+        paths = [p.strip() for p in str(raw).split(",") if p.strip()]
+    if paths:
+        log(f"📜 pages.{check} ({len(paths)} path(s))")
+        return paths
+    return None
+
+
+def discover(check: str, event: str) -> list[str]:
+    env_paths = _from_env(check)
+    if env_paths:
+        return env_paths
+    if event in {"pr", "main", "cron"}:
+        coverage_paths = _from_coverage_mode(event)
+        if coverage_paths:
+            return coverage_paths
+    pages_paths = _from_pages_list(check)
+    if pages_paths:
+        return pages_paths
+    log("ℹ️  no discovery hit; defaulting to /")
+    return ["/"]
+
+
+# ── CLI ──────────────────────────────────────────────────────────────
+
+
+def main(argv: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(description="Resolve pages to audit for a reliability check.")
+    parser.add_argument("check", choices=CHECKS)
+    parser.add_argument("--event", choices=EVENTS, default="local")
+    args = parser.parse_args(argv)
+
+    try:
+        paths = discover(args.check, args.event)
+    except Exception as e:  # noqa: BLE001
+        log(f"❌ internal error: {e}")
+        return 1
+
+    if not paths:
+        return 2
+
+    print(",".join(paths))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.ss/scripts/discover-pages.py
+++ b/.ss/scripts/discover-pages.py
@@ -155,12 +155,20 @@ def _resolve_child_sitemap(parent: Path, loc: str) -> Optional[Path]:
 
 
 def _extract_paths_from_sitemap_xml(path: Path, seen: set[Path]) -> list[str]:
-    """Read a sitemap XML file; recurse into sitemap-index files."""
+    """Read a sitemap XML file; recurse into sitemap-index files.
+
+    The sitemap is local trusted build output (dist/client/sitemap-index.xml
+    or sibling fallbacks) produced by the adopter's own build process —
+    never adversary-controlled. Stdlib ElementTree's default parser since
+    Python 3.7.1 does not resolve external entities, so XXE is moot.
+    Defusedxml is avoided to keep the no-deps invariant of .ss/scripts/.
+    """
     if path in seen:
         return []
     seen.add(path)
     try:
-        tree = ET.parse(path)
+        # nosemgrep: python.lang.security.use-defused-xml-parse.use-defused-xml-parse
+        tree = ET.parse(path)  # nosec B314
     except ET.ParseError as e:
         log(f"⚠️  Failed to parse sitemap {path}: {e}")
         return []

--- a/.ss/tests/discover_pages.test.py
+++ b/.ss/tests/discover_pages.test.py
@@ -1,0 +1,360 @@
+"""Tests for .ss/scripts/discover-pages.py.
+
+Covers: env-var override, sitemap parsing (incl. sitemap-index recursion),
+source-to-URL mapping, cross-cutting auto-escalation, unmapped modes,
+resolution-order precedence, and the CLI shim.
+
+Uses tempdir + chdir so the relative-path lookups (sitemap candidates,
+.slopstopper.yml) resolve to fixtures. load_config caches; reload between
+fixtures.
+"""
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+THIS_DIR = Path(__file__).resolve().parent
+SCRIPT_PATH = THIS_DIR.parent / "scripts" / "discover-pages.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("discover_pages", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(SCRIPT_PATH.parent))
+    spec.loader.exec_module(module)
+    return module
+
+
+def _enter_tmpdir() -> str:
+    tmp = tempfile.mkdtemp()
+    os.chdir(tmp)
+    return tmp
+
+
+def _leave_tmpdir(tmp: str) -> None:
+    os.chdir("/")
+    shutil.rmtree(tmp, ignore_errors=True)
+
+
+def _write_yml(text: str) -> None:
+    Path(".slopstopper.yml").write_text(text)
+
+
+def _reload_config(mod):
+    """discover-pages.py uses load_config's module-level cache; reset between fixtures."""
+    mod.load_config.reload()
+
+
+def _clear_check_env():
+    for var in ("SMOKE_PAGES", "ACCESSIBILITY_PAGES", "SEO_PAGES", "BROKEN_LINKS_PAGES"):
+        os.environ.pop(var, None)
+
+
+def test_env_var_override_short_circuits_everything():
+    tmp = _enter_tmpdir()
+    try:
+        mod = _load_module()
+        _clear_check_env()
+        os.environ["SEO_PAGES"] = "/from-env,/also-from-env"
+        try:
+            paths = mod.discover("seo", "pr")
+            assert paths == ["/from-env", "/also-from-env"], paths
+            print("✅ test_env_var_override_short_circuits_everything passed")
+        finally:
+            _clear_check_env()
+    finally:
+        _leave_tmpdir(tmp)
+
+
+def test_falls_back_to_pages_list_when_no_coverage_mode():
+    tmp = _enter_tmpdir()
+    try:
+        mod = _load_module()
+        _clear_check_env()
+        _write_yml("pages:\n  seo: /,/about,/contact\n")
+        _reload_config(mod)
+        paths = mod.discover("seo", "pr")
+        assert paths == ["/", "/about", "/contact"], paths
+        print("✅ test_falls_back_to_pages_list_when_no_coverage_mode passed")
+    finally:
+        _leave_tmpdir(tmp)
+
+
+def test_defaults_to_slash_when_nothing_configured():
+    tmp = _enter_tmpdir()
+    try:
+        mod = _load_module()
+        _clear_check_env()
+        _reload_config(mod)
+        paths = mod.discover("accessibility", "main")
+        assert paths == ["/"], paths
+        print("✅ test_defaults_to_slash_when_nothing_configured passed")
+    finally:
+        _leave_tmpdir(tmp)
+
+
+def test_sitemap_mode_extracts_paths_from_urlset():
+    tmp = _enter_tmpdir()
+    try:
+        mod = _load_module()
+        _clear_check_env()
+        Path("dist").mkdir()
+        Path("dist/sitemap.xml").write_text(
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+            '  <url><loc>https://example.com/</loc></url>\n'
+            '  <url><loc>https://example.com/blog/</loc></url>\n'
+            '  <url><loc>https://example.com/blog/post-a/</loc></url>\n'
+            '</urlset>\n'
+        )
+        _write_yml("reliability:\n  coverage:\n    main: sitemap\n")
+        _reload_config(mod)
+        paths = mod.discover("seo", "main")
+        assert paths == ["/", "/blog/", "/blog/post-a/"], paths
+        print("✅ test_sitemap_mode_extracts_paths_from_urlset passed")
+    finally:
+        _leave_tmpdir(tmp)
+
+
+def test_sitemap_mode_recurses_through_sitemap_index():
+    tmp = _enter_tmpdir()
+    try:
+        mod = _load_module()
+        _clear_check_env()
+        Path("dist/client").mkdir(parents=True)
+        Path("dist/client/sitemap-index.xml").write_text(
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+            '  <sitemap><loc>https://example.com/sitemap-0.xml</loc></sitemap>\n'
+            '</sitemapindex>\n'
+        )
+        Path("dist/client/sitemap-0.xml").write_text(
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+            '  <url><loc>https://example.com/blog/a/</loc></url>\n'
+            '  <url><loc>https://example.com/blog/b/</loc></url>\n'
+            '</urlset>\n'
+        )
+        _write_yml("reliability:\n  coverage:\n    main: sitemap\n")
+        _reload_config(mod)
+        paths = mod.discover("seo", "main")
+        assert paths == ["/blog/a/", "/blog/b/"], paths
+        print("✅ test_sitemap_mode_recurses_through_sitemap_index passed")
+    finally:
+        _leave_tmpdir(tmp)
+
+
+def test_explicit_list_mode_returns_verbatim():
+    tmp = _enter_tmpdir()
+    try:
+        mod = _load_module()
+        _clear_check_env()
+        _write_yml(
+            "reliability:\n"
+            "  coverage:\n"
+            "    main: /,/pricing,/about\n"
+            "pages:\n"
+            "  seo: /should-be-shadowed\n"
+        )
+        _reload_config(mod)
+        paths = mod.discover("seo", "main")
+        assert paths == ["/", "/pricing", "/about"], paths
+        print("✅ test_explicit_list_mode_returns_verbatim passed")
+    finally:
+        _leave_tmpdir(tmp)
+
+
+def test_changed_mode_uses_astro_defaults(monkey):
+    tmp = _enter_tmpdir()
+    try:
+        mod = _load_module()
+        _clear_check_env()
+        Path("astro.config.mjs").write_text("export default {};\n")
+        _write_yml("reliability:\n  coverage:\n    pr: changed\n")
+        _reload_config(mod)
+        monkey(
+            mod,
+            "_git_diff_files",
+            lambda base_ref: [
+                "src/content/blog/2026-06-12-hello.md",
+                "src/pages/about.astro",
+            ],
+        )
+        paths = mod.discover("accessibility", "pr")
+        assert paths == ["/blog/2026-06-12-hello/", "/about/"], paths
+        print("✅ test_changed_mode_uses_astro_defaults passed")
+    finally:
+        _leave_tmpdir(tmp)
+
+
+def test_changed_mode_detects_nextjs_app_router(monkey):
+    tmp = _enter_tmpdir()
+    try:
+        mod = _load_module()
+        _clear_check_env()
+        Path("next.config.js").write_text("module.exports = {};\n")
+        _write_yml("reliability:\n  coverage:\n    pr: changed\n")
+        _reload_config(mod)
+        monkey(
+            mod,
+            "_git_diff_files",
+            lambda base_ref: ["app/about/page.tsx", "app/page.tsx"],
+        )
+        paths = mod.discover("seo", "pr")
+        assert paths == ["/about/", "/"], paths
+        print("✅ test_changed_mode_detects_nextjs_app_router passed")
+    finally:
+        _leave_tmpdir(tmp)
+
+
+def test_cross_cutting_escalates_to_sitemap(monkey):
+    tmp = _enter_tmpdir()
+    try:
+        mod = _load_module()
+        _clear_check_env()
+        Path("dist").mkdir()
+        Path("dist/sitemap.xml").write_text(
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+            '  <url><loc>https://x.example/</loc></url>\n'
+            '  <url><loc>https://x.example/a/</loc></url>\n'
+            '</urlset>\n'
+        )
+        _write_yml(
+            "reliability:\n"
+            "  coverage:\n"
+            "    pr: changed\n"
+            "    cross_cutting_paths: ['src/styles/*']\n"
+        )
+        _reload_config(mod)
+        monkey(
+            mod,
+            "_git_diff_files",
+            lambda base_ref: [
+                "src/content/blog/foo.md",
+                "src/styles/global.css",
+            ],
+        )
+        paths = mod.discover("seo", "pr")
+        assert paths == ["/", "/a/"], paths
+        print("✅ test_cross_cutting_escalates_to_sitemap passed")
+    finally:
+        _leave_tmpdir(tmp)
+
+
+def test_unmapped_changed_file_falls_back_to_sitemap(monkey):
+    """When every changed file is unmapped (e.g. infra changes), discovery
+    should fall through to a sitemap sweep rather than silently no-op."""
+    tmp = _enter_tmpdir()
+    try:
+        mod = _load_module()
+        _clear_check_env()
+        Path("astro.config.mjs").write_text("{}\n")
+        Path("dist").mkdir()
+        Path("dist/sitemap.xml").write_text(
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+            '  <url><loc>https://x.example/fallback/</loc></url>\n'
+            '</urlset>\n'
+        )
+        _write_yml("reliability:\n  coverage:\n    pr: changed\n")
+        _reload_config(mod)
+        monkey(mod, "_git_diff_files", lambda base_ref: ["infra/Dockerfile"])
+        paths = mod.discover("seo", "pr")
+        assert paths == ["/fallback/"], paths
+        print("✅ test_unmapped_changed_file_falls_back_to_sitemap passed")
+    finally:
+        _leave_tmpdir(tmp)
+
+
+def test_cli_shim_prints_comma_separated(monkey):
+    tmp = _enter_tmpdir()
+    try:
+        Path("dist").mkdir()
+        Path("dist/sitemap.xml").write_text(
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+            '  <url><loc>https://x.example/</loc></url>\n'
+            '  <url><loc>https://x.example/about/</loc></url>\n'
+            '</urlset>\n'
+        )
+        _write_yml("reliability:\n  coverage:\n    cron: sitemap\n")
+        env = {**os.environ}
+        for var in ("SMOKE_PAGES", "ACCESSIBILITY_PAGES", "SEO_PAGES", "BROKEN_LINKS_PAGES"):
+            env.pop(var, None)
+        result = subprocess.run(
+            ["python3", str(SCRIPT_PATH), "seo", "--event=cron"],
+            capture_output=True,
+            text=True,
+            cwd=tmp,
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "/,/about/", result.stdout
+        print("✅ test_cli_shim_prints_comma_separated passed")
+    finally:
+        _leave_tmpdir(tmp)
+
+
+# ── Lightweight monkeypatch — no pytest dependency ──
+
+class _Monkey:
+    def __init__(self):
+        self._restore = []
+
+    def __call__(self, mod, attr, value):
+        original = getattr(mod, attr)
+        setattr(mod, attr, value)
+        self._restore.append((mod, attr, original))
+
+    def undo(self):
+        for mod, attr, original in self._restore:
+            setattr(mod, attr, original)
+        self._restore.clear()
+
+
+def run_test(fn):
+    """Invoke a test, supplying _Monkey() if the test wants one."""
+    monkey = _Monkey()
+    try:
+        if fn.__code__.co_argcount == 0:
+            fn()
+        else:
+            fn(monkey)
+    finally:
+        monkey.undo()
+
+
+if __name__ == "__main__":
+    print("\n🧪 Running discover-pages tests...\n")
+    tests = [
+        test_env_var_override_short_circuits_everything,
+        test_falls_back_to_pages_list_when_no_coverage_mode,
+        test_defaults_to_slash_when_nothing_configured,
+        test_sitemap_mode_extracts_paths_from_urlset,
+        test_sitemap_mode_recurses_through_sitemap_index,
+        test_explicit_list_mode_returns_verbatim,
+        test_changed_mode_uses_astro_defaults,
+        test_changed_mode_detects_nextjs_app_router,
+        test_cross_cutting_escalates_to_sitemap,
+        test_unmapped_changed_file_falls_back_to_sitemap,
+        test_cli_shim_prints_comma_separated,
+    ]
+    try:
+        for test in tests:
+            run_test(test)
+        print("\n✅ All tests passed!\n")
+        sys.exit(0)
+    except AssertionError as e:
+        print(f"\n❌ Test failed: {e}\n")
+        sys.exit(1)
+    except Exception as e:
+        print(f"\n❌ Unexpected error: {e}\n")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)

--- a/Taskfile.ss.yml
+++ b/Taskfile.ss.yml
@@ -174,6 +174,13 @@ tasks:
           exit 1
         fi
 
+        # Resolve SEO_PAGES from .slopstopper.yml the same way CI does, so local
+        # runs aren't asymmetric. --event=local skips reliability.coverage.*
+        # modes (those are CI-event-shaped) and falls through to pages.seo or /.
+        if [ -z "${SEO_PAGES+x}" ] && [ -f .slopstopper.yml ]; then
+          export SEO_PAGES="$(python3 .ss/scripts/discover-pages.py seo --event=local)"
+        fi
+
         python3 .ss/scripts/check-seo-metatags.py
     silent: false
 
@@ -228,6 +235,11 @@ tasks:
 
         echo "♿ Running accessibility audit against: $TARGET"
         echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+        # Resolve ACCESSIBILITY_PAGES from .slopstopper.yml the same way CI does.
+        if [ -z "${ACCESSIBILITY_PAGES+x}" ] && [ -f .slopstopper.yml ]; then
+          export ACCESSIBILITY_PAGES="$(python3 .ss/scripts/discover-pages.py accessibility --event=local)"
+        fi
 
         ACCESSIBILITY_TEST_URL="$TARGET" npx playwright test --config=.ss/playwright.config.js .ss/tests/accessibility.spec.ts --reporter=list
     silent: false
@@ -284,6 +296,11 @@ tasks:
 
         echo "🔗 Running broken-link checks against: $TARGET"
         echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+        # Resolve BROKEN_LINKS_PAGES from .slopstopper.yml the same way CI does.
+        if [ -z "${BROKEN_LINKS_PAGES+x}" ] && [ -f .slopstopper.yml ]; then
+          export BROKEN_LINKS_PAGES="$(python3 .ss/scripts/discover-pages.py broken_links --event=local)"
+        fi
 
         BROKEN_LINKS_TEST_URL="$TARGET" npx playwright test --config=.ss/playwright.config.js .ss/tests/broken-links.spec.ts --reporter=list
     silent: false

--- a/templates/slopstopper.yml.example
+++ b/templates/slopstopper.yml.example
@@ -40,11 +40,52 @@ urls:
   preview:
 
 # Pages to exercise on each dynamic check (comma-separated paths).
+# This is the hand-list path: simple, predictable, easy to skim. For
+# real adopters, prefer the `reliability:` block below to stop the list
+# going stale every time a new page or content type lands.
 pages:
   smoke:         /
   accessibility: /
   seo:           /
   broken_links:  /
+
+# ── Reliability coverage (sitemap + changed-pages) ───────────────────
+# Opt-in alternative to the hand-list above. When set, the accessibility
+# / SEO / broken-links checks resolve which paths to audit via:
+#
+#   sitemap   → every URL in dist/client/sitemap-index.xml (or fallback
+#               candidates like dist/sitemap.xml). Run `npm run build`
+#               first; CI workflows do this automatically.
+#   changed   → on PRs only: git diff origin/main...HEAD → map source
+#               files to URLs via the framework's source_to_url rules
+#               (Astro / Next.js / SvelteKit are auto-detected from
+#               their config files). Auto-escalates to sitemap when any
+#               changed file matches cross_cutting_paths.
+#   /a,/b     → explicit hand-list, same shape as pages.* above.
+#
+# When the resolved set is empty (no sitemap, no matched changed files,
+# git history missing), discovery falls through to sitemap, then to
+# pages.<check>, then to "/". Better to over-test than to silently
+# no-op a quality gate.
+#
+# cross_cutting_paths MUST use the inline-list form ([a, b]) — the
+# stdlib YAML subset in .ss/scripts/load_config.py doesn't parse the
+# multi-line "- item" form under nested keys. Tracked as a follow-up.
+#
+# reliability:
+#   coverage:
+#     pr:   changed
+#     main: sitemap
+#     cron: sitemap
+#     cross_cutting_paths: [
+#       'src/layouts/*',
+#       'src/components/Base*.astro',
+#       'src/components/Header.astro',
+#       'src/components/Footer.astro',
+#       'src/styles/*',
+#       'astro.config.*',
+#       'tailwind.config.*',
+#     ]
 
 # ── Smoke test customizations ────────────────────────────────────────
 smoke:


### PR DESCRIPTION
## Summary

Closes the architecture wave for reliability gates. The accessibility, SEO, and broken-links checks previously audited a hand-curated \`pages.*\` list in \`.slopstopper.yml\` — exemplar coverage that hid per-page content regressions and went stale every time a new section landed.

This PR adds a new orchestrator (\`.ss/scripts/discover-pages.py\`) and a backwards-compatible config schema. Adopters opt in to richer coverage; current adopters see bit-for-bit identical behaviour until they change their config.

## What ships

- **\`.ss/scripts/discover-pages.py\` (#88)** — single entry point. Resolves the audit set from \`{env-var override, reliability.coverage.<event>, pages.<check>, "/"}\` in that order. New modes:
  - \`sitemap\` → parse \`dist/client/sitemap-index.xml\` (recurses through sitemapindex children) or sibling fallbacks; every \`<loc>\` URL's path enters the set.
  - \`changed\` (PR only) → \`git diff origin/main...HEAD\`, map source files to URLs via baked-in framework rules (Astro / Next.js Pages and App routers / SvelteKit auto-detected from config-file presence). Cross-cutting changes (layouts, shared components, global CSS — configurable via \`reliability.coverage.cross_cutting_paths\`) auto-escalate to a sitemap sweep. Empty changed set or git failure also falls through to sitemap.
  - \`"/a,/b,/c"\` → explicit list, same shape as \`pages.*\`.

  Stdlib only — matches the no-deps invariant of the rest of \`.ss/scripts/\`. 11 unit tests pass; all complexity ≤ CCN 10.

- **3 CI workflows wired (#88)** — \`ss-reliability-accessibility-check.yml\`, \`ss-reliability-seo-check.yml\`, \`ss-reliability-broken-links-check.yml\` now:
  - Check out with \`fetch-depth: 0\` so changed-mode can diff against the base branch.
  - Gain a \`workflow_dispatch\` \`coverage_mode\` input (\`sitemap | changed\`).
  - Replace their \"Pages to audit\" body with a case-mapped event + \`discover-pages.py\` call.

  Existing \`pages.*\` lists keep working because the resolution order falls through when \`reliability.coverage.*\` is unset.

- **Local Taskfile reliability tasks (#89)** — \`reliability:seo\`, \`reliability:accessibility\`, \`reliability:links\` now read their \`*_PAGES\` env var from \`discover-pages.py --event=local\` in the same shape as the CI \"Pages to audit\" step. Closes the asymmetry where CI honoured \`pages.*\` but local runs required manual env-var passing.

- **\`slopstopper-install\` skill (#87)** — Step 4 gains a coverage-mode prompt walking adopters through the sitemap + changed choice with per-framework \`cross_cutting_paths\` defaults. \`templates/slopstopper.yml.example\` documents the new schema in commented form (not seeded by default — backwards-compatibility preserved per the locked decision).

## User decisions locked in (from /plan)

- **Default behaviour unchanged.** \`reliability.coverage.*\` unset → fall through to existing \`pages.*\` → \`/\`. Adopters opt in explicitly.
- **One bundled PR.** Three follow-ups share the new plumbing.

## Known limitation (follow-up #92)

\`load_config.py\`'s stdlib YAML subset parses inline-list form (\`[a, b]\`) but not multi-line \`- item\` under nested keys. \`cross_cutting_paths\` uses inline form in v1. Tracked separately.

## Test plan

- [x] \`python3 .ss/tests/discover_pages.test.py\` — 11/11 green
- [x] \`task ss:hygiene:complexity\` — green, all CCN ≤ 10
- [x] \`task ss:hygiene:csp-exceptions\` — green
- [x] \`python3 .ss/scripts/discover-pages.py seo --event=main\` on slopstopper main returns \`/,/features.html,/tools.html,/feedback.html\` (back-compat — falls through to existing \`pages.seo\`)
- [x] \`task --list\` parses the modified Taskfile
- [ ] CI: confirm all reliability checks pass on this branch (slopstopper.dev's existing \`pages.seo\` etc. should remain authoritative — bit-for-bit identical to current main)
- [ ] Adopter end-to-end: on hungovercoders, add \`reliability.coverage.main: sitemap\` to \`.slopstopper.yml\` on a test branch; confirm the workflow reads \`dist/client/sitemap-index.xml\` and audits every URL. Edit one blog post markdown file; push as a PR; confirm only \`/blog/<slug>/\` is in the audit set. Edit \`src/styles/global.css\` separately; confirm the workflow logs \"Cross-cutting change detected\" and escalates to a sitemap sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)