### PR TITLE
feat(cli): port hygiene:docs-structure as third CLI check

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -33,6 +33,8 @@ on:
       - '.ss/scripts/check-docs-size.sh'
       - '.ss/scripts/generate-docs-size-report.py'
       - '.ss/scripts/check-entry-file-size.py'
+      - '.ss/scripts/check-docs-structure.py'
+      - '.ss/scripts/generate-docs-structure-md.py'
   push:
     branches: [ main ]
     paths:
@@ -41,6 +43,8 @@ on:
       - '.ss/scripts/check-docs-size.sh'
       - '.ss/scripts/generate-docs-size-report.py'
       - '.ss/scripts/check-entry-file-size.py'
+      - '.ss/scripts/check-docs-structure.py'
+      - '.ss/scripts/generate-docs-structure-md.py'
   workflow_dispatch:
 
 permissions:

--- a/cli/Taskfile.yml
+++ b/cli/Taskfile.yml
@@ -138,6 +138,16 @@ tasks:
           ".ss/reports/entry-files/entry-file-size-report.md" \
           ".ss/reports/entry-files/entry-file-size-report.json"
 
+        # docs-structure is a two-script bash flow: check writes JSON,
+        # generate reads JSON and writes MD. Chain them so the parity
+        # snapshot captures both outputs.
+        check_parity \
+          "hygiene-docs-structure" \
+          "python3 .ss/scripts/check-docs-structure.py; python3 .ss/scripts/generate-docs-structure-md.py" \
+          "cli/.venv/bin/slopstopper run hygiene:docs-structure" \
+          ".ss/reports/docs/docs-structure-report.json" \
+          ".ss/reports/docs/docs-structure-report.md"
+
         echo ""
         if [ "$FAILED" -eq 0 ]; then
           echo "All parity checks passed."

--- a/cli/slopstopper/checks/__init__.py
+++ b/cli/slopstopper/checks/__init__.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from typing import Callable
 
-from slopstopper.checks import docs_size, entry_files
+from slopstopper.checks import docs_size, docs_structure, entry_files
 
 REGISTRY: dict[str, Callable[[], int]] = {
     "hygiene:docs-size": docs_size.run,
+    "hygiene:docs-structure": docs_structure.run,
     "hygiene:entry-files": entry_files.run,
 }

--- a/cli/slopstopper/checks/docs_structure.py
+++ b/cli/slopstopper/checks/docs_structure.py
@@ -1,0 +1,241 @@
+"""Documentation structure validator.
+
+Ports .ss/scripts/check-docs-structure.py + generate-docs-structure-md.py.
+Validates that the docs/ tree matches the governance model declared
+in docs/index.md (each category named in the index must exist with a
+README.md; nothing in docs/ should exist that the index doesn't sanction).
+
+Writes a JSON report (machine-readable, drives downstream tooling) and a
+markdown report (human-readable). Exit codes mirror the bash:
+
+  0 — clean
+  1 — violations OR docs/ / docs/index.md missing
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+DOCS_DIR = Path("docs")
+INDEX_PATH = DOCS_DIR / "index.md"
+REPORT_DIR = Path(".ss/reports/docs")
+REPORT_JSON = REPORT_DIR / "docs-structure-report.json"
+REPORT_MD = REPORT_DIR / "docs-structure-report.md"
+
+# Files allowed at the top level of docs/ without being declared in
+# the categories table. Mirrors the bash check exactly.
+ALLOWED_TOP_FILES = {"index.md", "README.md", "AGENTS.md", "CONTRIBUTING.md"}
+
+_CATEGORY_RE = re.compile(r"\|\s*\[([a-z_]+)/\]\(([a-z_]+)/\)\s*\|")
+
+
+def _extract_categories(index_text: str) -> list[str]:
+    matches = _CATEGORY_RE.findall(index_text)
+    return sorted({m[0] for m in matches})
+
+
+def _check_expected_categories(docs_dir: Path, expected: list[str]) -> list[dict]:
+    violations: list[dict] = []
+    for category in expected:
+        category_path = docs_dir / category
+        if not category_path.exists():
+            violations.append({
+                "type": "missing_directory",
+                "path": f"docs/{category}/",
+                "message": f"Missing directory: docs/{category}/",
+            })
+        elif not (category_path / "README.md").exists():
+            violations.append({
+                "type": "missing_readme",
+                "path": f"docs/{category}/README.md",
+                "message": f"Missing README.md: docs/{category}/README.md",
+            })
+    return violations
+
+
+def _check_unexpected_items(docs_dir: Path, expected: list[str]) -> list[dict]:
+    violations: list[dict] = []
+    expected_dirs = set(expected)
+
+    actual_files = {f.name for f in docs_dir.iterdir() if f.is_file()}
+    for filename in sorted(actual_files - ALLOWED_TOP_FILES):
+        violations.append({
+            "type": "unexpected_file",
+            "path": f"docs/{filename}",
+            "message": f"Unexpected file (not in index): docs/{filename}",
+        })
+
+    actual_dirs = sorted(d.name for d in docs_dir.iterdir() if d.is_dir())
+    for dirname in sorted(set(actual_dirs) - expected_dirs):
+        violations.append({
+            "type": "unexpected_directory",
+            "path": f"docs/{dirname}/",
+            "message": f"Unexpected directory (not in index): docs/{dirname}/",
+        })
+
+    return violations
+
+
+def _generated_at() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def _format_expected_categories_section(categories: list[str]) -> str:
+    if not categories:
+        return (
+            "## Expected Categories\n\n"
+            "_No categories declared in `docs/index.md`. Add a categories table "
+            "(see slopstopper's docs/index.md for the format) to enforce structure._\n\n"
+        )
+    lines = [
+        "## Expected Categories",
+        "",
+        "The following categories are defined in `docs/index.md`:",
+        "",
+        "| Category | Required | Status |",
+        "|----------|----------|--------|",
+    ]
+    for category in categories:
+        lines.append(f"| {category}/ | ✅ | Must exist with README.md |")
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def _format_violations_content(violations: list[dict]) -> str:
+    content = f"Found **{len(violations)}** violation(s):\n\n"
+    by_type: dict[str, list[dict]] = {}
+    for v in violations:
+        by_type.setdefault(v.get("type", "unknown"), []).append(v)
+
+    sections = [
+        ("missing_directory", "### Missing Directories\n\n", None),
+        ("missing_readme", "### Missing README.md Files\n\n", None),
+        (
+            "unexpected_file",
+            "### Unexpected Files\n\n",
+            "  *Either add to `docs/index.md` or remove the file*\n",
+        ),
+        (
+            "unexpected_directory",
+            "### Unexpected Directories\n\n",
+            "  *Either add to `docs/index.md` or remove the directory*\n",
+        ),
+    ]
+
+    for vtype, header, note in sections:
+        if vtype not in by_type:
+            continue
+        content += header
+        for v in by_type[vtype]:
+            content += f"- {v['message']}\n"
+            if note:
+                content += note
+        content += "\n"
+
+    return content
+
+
+def _build_md_report(data: dict, generated_at: str) -> str:
+    violations = data.get("violations", [])
+    is_valid = data.get("valid", True)
+    status_line = (
+        "✅ Documentation structure matches governance model"
+        if is_valid
+        else "❌ Documentation structure violations found"
+    )
+
+    report = (
+        f"# 📋 Documentation Structure Report\n"
+        f"\n"
+        f"**Generated:** {generated_at}\n"
+        f"\n"
+        f"## Status\n"
+        f"\n"
+        f"{status_line}\n"
+        f"\n"
+        f"## Governance Model\n"
+        f"\n"
+        f"The documentation structure is governed by [`docs/index.md`](../index.md). "
+        f"All documentation must align with the categories and structure defined there.\n"
+        f"\n"
+        f"**Key Principle:** The index is the **sole source of truth** for documentation structure.\n"
+        f"\n"
+        f"## Violations\n"
+        f"\n"
+    )
+
+    if violations:
+        report += _format_violations_content(violations)
+    else:
+        report += "✅ No violations found\n\n"
+
+    report += _format_expected_categories_section(data.get("expected_categories", []))
+
+    report += (
+        "## How to Fix\n"
+        "\n"
+        "1. **For missing directories or README.md files:**\n"
+        "   - Create the directory and add a README.md with its purpose\n"
+        "   - See existing README.md files for the format\n"
+        "\n"
+        "2. **For unexpected files:**\n"
+        "   - If they should be documented: Add an entry to `docs/index.md`\n"
+        "   - If they shouldn't exist: Delete them\n"
+        "\n"
+        "3. **For unexpected directories:**\n"
+        "   - If they should be part of governance: Add to the table in `docs/index.md`\n"
+        "   - If they shouldn't exist: Delete them\n"
+        "\n"
+        "## More Information\n"
+        "\n"
+        "- See [`docs/index.md`](../index.md) for the governance model\n"
+        "- Each category README.md should document its purpose and contents\n"
+        "\n"
+        "---\n"
+        "\n"
+        "*Report generated by Documentation Structure Check*\n"
+    )
+    return report
+
+
+def _check_structure(docs_dir: Path) -> tuple[list[dict], list[str]] | None:
+    if not docs_dir.exists():
+        print("❌ docs/ directory not found")
+        return None
+    index_path = docs_dir / "index.md"
+    if not index_path.exists():
+        print("❌ docs/index.md not found")
+        return None
+    expected = _extract_categories(index_path.read_text())
+    violations = _check_expected_categories(docs_dir, expected)
+    violations += _check_unexpected_items(docs_dir, expected)
+    return violations, expected
+
+
+def run() -> int:
+    print("🔍 Validating documentation structure...")
+
+    result = _check_structure(DOCS_DIR)
+    if result is None:
+        return 1
+    violations, expected = result
+
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+
+    data = {
+        "violations": violations,
+        "valid": len(violations) == 0,
+        "violation_count": len(violations),
+        "expected_categories": expected,
+    }
+    REPORT_JSON.write_text(json.dumps(data, indent=2))
+    REPORT_MD.write_text(_build_md_report(data, _generated_at()))
+
+    if violations:
+        print(f"❌ Found {len(violations)} structure violation(s)")
+        return 1
+    print("✅ Documentation structure is valid")
+    return 0

--- a/cli/tests/checks/test_docs_structure.py
+++ b/cli/tests/checks/test_docs_structure.py
@@ -1,0 +1,180 @@
+"""Tests for the hygiene:docs-structure check."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from slopstopper.checks import docs_structure
+
+
+def _seed_index(docs_dir: Path, categories: list[str]) -> None:
+    rows = "\n".join(f"| [{c}/]({c}/) | Description |" for c in categories)
+    docs_dir.mkdir(exist_ok=True)
+    (docs_dir / "index.md").write_text(
+        "# Docs map\n\n"
+        "| Category | Description |\n"
+        "| -------- | ----------- |\n"
+        f"{rows}\n"
+    )
+
+
+def _seed_category(docs_dir: Path, name: str, with_readme: bool = True) -> Path:
+    cat = docs_dir / name
+    cat.mkdir(parents=True, exist_ok=True)
+    if with_readme:
+        (cat / "README.md").write_text(f"# {name}\n")
+    return cat
+
+
+def test_extract_categories_simple():
+    text = (
+        "| [hygiene/](hygiene/) | Quality checks |\n"
+        "| [security/](security/) | Security checks |\n"
+    )
+    assert docs_structure._extract_categories(text) == ["hygiene", "security"]
+
+
+def test_extract_categories_deduplicates_and_sorts():
+    text = (
+        "| [security/](security/) | A |\n"
+        "| [hygiene/](hygiene/) | B |\n"
+        "| [hygiene/](hygiene/) | C |\n"
+    )
+    assert docs_structure._extract_categories(text) == ["hygiene", "security"]
+
+
+def test_extract_categories_ignores_non_matching_rows():
+    text = "| something | other |\n| [hygiene/](hygiene/) | A |\n"
+    assert docs_structure._extract_categories(text) == ["hygiene"]
+
+
+def test_check_expected_categories_clean(isolated_cwd):
+    docs = Path("docs")
+    docs.mkdir()
+    _seed_category(docs, "hygiene")
+    _seed_category(docs, "security")
+    assert docs_structure._check_expected_categories(docs, ["hygiene", "security"]) == []
+
+
+def test_check_expected_categories_missing_directory(isolated_cwd):
+    docs = Path("docs")
+    docs.mkdir()
+    _seed_category(docs, "hygiene")
+    violations = docs_structure._check_expected_categories(docs, ["hygiene", "security"])
+    assert len(violations) == 1
+    assert violations[0]["type"] == "missing_directory"
+    assert violations[0]["path"] == "docs/security/"
+
+
+def test_check_expected_categories_missing_readme(isolated_cwd):
+    docs = Path("docs")
+    docs.mkdir()
+    _seed_category(docs, "hygiene", with_readme=False)
+    violations = docs_structure._check_expected_categories(docs, ["hygiene"])
+    assert len(violations) == 1
+    assert violations[0]["type"] == "missing_readme"
+
+
+def test_check_unexpected_items_flags_unknown_file(isolated_cwd):
+    docs = Path("docs")
+    docs.mkdir()
+    (docs / "stray.md").write_text("hi")
+    violations = docs_structure._check_unexpected_items(docs, [])
+    assert any(v["type"] == "unexpected_file" and v["path"] == "docs/stray.md" for v in violations)
+
+
+def test_check_unexpected_items_ignores_allowed_top_files(isolated_cwd):
+    docs = Path("docs")
+    docs.mkdir()
+    for allowed in docs_structure.ALLOWED_TOP_FILES:
+        (docs / allowed).write_text(allowed)
+    violations = docs_structure._check_unexpected_items(docs, [])
+    assert violations == []
+
+
+def test_check_unexpected_items_flags_undocumented_dir(isolated_cwd):
+    docs = Path("docs")
+    docs.mkdir()
+    _seed_category(docs, "rogue")
+    violations = docs_structure._check_unexpected_items(docs, ["hygiene"])
+    assert any(v["type"] == "unexpected_directory" and v["path"] == "docs/rogue/" for v in violations)
+
+
+def test_format_expected_categories_section_empty():
+    out = docs_structure._format_expected_categories_section([])
+    assert "No categories declared" in out
+
+
+def test_format_expected_categories_section_renders_rows():
+    out = docs_structure._format_expected_categories_section(["hygiene", "security"])
+    assert "| hygiene/ |" in out
+    assert "| security/ |" in out
+    assert "Must exist with README.md" in out
+
+
+def test_format_violations_groups_by_type():
+    violations = [
+        {"type": "missing_directory", "path": "docs/x/", "message": "Missing directory: docs/x/"},
+        {"type": "unexpected_file", "path": "docs/y.md", "message": "Unexpected file (not in index): docs/y.md"},
+    ]
+    out = docs_structure._format_violations_content(violations)
+    assert "Found **2** violation(s)" in out
+    assert "### Missing Directories" in out
+    assert "### Unexpected Files" in out
+
+
+def test_build_md_report_status_lines():
+    data_clean = {"violations": [], "valid": True, "violation_count": 0, "expected_categories": ["hygiene"]}
+    md_clean = docs_structure._build_md_report(data_clean, "2026-06-12 00:00:00 UTC")
+    assert "✅ Documentation structure matches" in md_clean
+    assert "✅ No violations found" in md_clean
+
+    data_bad = {
+        "violations": [{"type": "missing_directory", "path": "docs/x/", "message": "Missing directory: docs/x/"}],
+        "valid": False,
+        "violation_count": 1,
+        "expected_categories": ["x"],
+    }
+    md_bad = docs_structure._build_md_report(data_bad, "2026-06-12 00:00:00 UTC")
+    assert "❌ Documentation structure violations found" in md_bad
+    assert "Missing directory: docs/x/" in md_bad
+
+
+def test_run_clean_returns_zero_and_writes_both_reports(isolated_cwd, capsys):
+    docs = Path("docs")
+    _seed_index(docs, ["hygiene"])
+    _seed_category(docs, "hygiene")
+    rc = docs_structure.run()
+    assert rc == 0
+    assert docs_structure.REPORT_JSON.exists()
+    assert docs_structure.REPORT_MD.exists()
+    data = json.loads(docs_structure.REPORT_JSON.read_text())
+    assert data["valid"] is True
+    assert data["violation_count"] == 0
+    assert data["expected_categories"] == ["hygiene"]
+
+
+def test_run_flags_missing_category_directory(isolated_cwd):
+    docs = Path("docs")
+    _seed_index(docs, ["hygiene", "security"])
+    _seed_category(docs, "hygiene")
+    rc = docs_structure.run()
+    assert rc == 1
+    data = json.loads(docs_structure.REPORT_JSON.read_text())
+    assert data["valid"] is False
+    assert any(v["type"] == "missing_directory" for v in data["violations"])
+
+
+def test_run_returns_one_when_docs_dir_missing(isolated_cwd, capsys):
+    # No docs/ directory at all
+    rc = docs_structure.run()
+    assert rc == 1
+    assert "docs/ directory not found" in capsys.readouterr().out
+
+
+def test_run_returns_one_when_index_missing(isolated_cwd, capsys):
+    Path("docs").mkdir()
+    rc = docs_structure.run()
+    assert rc == 1
+    assert "docs/index.md not found" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Third check ported under the cutover protocol established in #189 (port + unit-test + parity-test). No GitHub Actions flipped — both bash and CLI keep working in parallel.

## What lands

- `cli/slopstopper/checks/docs_structure.py` — merges the bash flow's two scripts (`check-docs-structure.py` writes JSON, `generate-docs-structure-md.py` reads JSON and writes MD) into a single self-contained function that produces both reports atomically. Same governance logic: parses `docs/index.md`'s category table, checks each declared category has a `README.md`, flags unexpected files/dirs not in the index.
- Registered as `hygiene:docs-structure`.
- 17 new tests; total CLI test count: **61**.
- Exit codes mirror the bash: 0 clean, 1 violations OR missing `docs/`/`docs/index.md`.

## Parity

`check_parity` invocation chains the bash side: `python3 check-docs-structure.py; python3 generate-docs-structure-md.py`. Both `.json` and `.md` reports diff byte-identical (modulo timestamp) against the CLI's single-pass output.

## CI wiring

`ci-cli.yml` `paths:` extends to include both bash scripts.

## Verified locally

```
$ task -t cli/Taskfile.yml test
61 passed in 0.05s

$ task -t cli/Taskfile.yml parity
=== hygiene-docs-size ===          ✅
=== hygiene-entry-files ===        ✅
=== hygiene-docs-structure ===     ✅
All parity checks passed.
```

## Test plan

- [x] `task -t cli/Taskfile.yml test` — 61 tests green
- [x] `task -t cli/Taskfile.yml parity` — all three checks byte-identical
- [x] CCN ≤ 10 across cli/slopstopper/
- [ ] CI: pytest job green
- [ ] CI: parity job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)