### PR TITLE
feat(cli): port hygiene:docs-accuracy as fourth CLI check

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -35,6 +35,8 @@ on:
       - '.ss/scripts/check-entry-file-size.py'
       - '.ss/scripts/check-docs-structure.py'
       - '.ss/scripts/generate-docs-structure-md.py'
+      - '.ss/scripts/check-docs-accuracy.py'
+      - '.ss/scripts/generate-docs-accuracy-md.py'
   push:
     branches: [ main ]
     paths:
@@ -45,6 +47,8 @@ on:
       - '.ss/scripts/check-entry-file-size.py'
       - '.ss/scripts/check-docs-structure.py'
       - '.ss/scripts/generate-docs-structure-md.py'
+      - '.ss/scripts/check-docs-accuracy.py'
+      - '.ss/scripts/generate-docs-accuracy-md.py'
   workflow_dispatch:
 
 permissions:

--- a/cli/Taskfile.yml
+++ b/cli/Taskfile.yml
@@ -148,6 +148,13 @@ tasks:
           ".ss/reports/docs/docs-structure-report.json" \
           ".ss/reports/docs/docs-structure-report.md"
 
+        check_parity \
+          "hygiene-docs-accuracy" \
+          "python3 .ss/scripts/check-docs-accuracy.py; python3 .ss/scripts/generate-docs-accuracy-md.py" \
+          "cli/.venv/bin/slopstopper run hygiene:docs-accuracy" \
+          ".ss/reports/docs/docs-accuracy-report.json" \
+          ".ss/reports/docs/docs-accuracy-report.md"
+
         echo ""
         if [ "$FAILED" -eq 0 ]; then
           echo "All parity checks passed."

--- a/cli/slopstopper/checks/__init__.py
+++ b/cli/slopstopper/checks/__init__.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from typing import Callable
 
-from slopstopper.checks import docs_size, docs_structure, entry_files
+from slopstopper.checks import docs_accuracy, docs_size, docs_structure, entry_files
 
 REGISTRY: dict[str, Callable[[], int]] = {
+    "hygiene:docs-accuracy": docs_accuracy.run,
     "hygiene:docs-size": docs_size.run,
     "hygiene:docs-structure": docs_structure.run,
     "hygiene:entry-files": entry_files.run,

--- a/cli/slopstopper/checks/docs_accuracy.py
+++ b/cli/slopstopper/checks/docs_accuracy.py
@@ -1,0 +1,280 @@
+"""Documentation accuracy validator.
+
+Ports .ss/scripts/check-docs-accuracy.py + generate-docs-accuracy-md.py.
+Scans docs/**/*.md plus the four repo-root entry files (README.md,
+AGENTS.md, CLAUDE.md, CONTRIBUTING.md) for four kinds of drift:
+
+  - broken_link        — markdown link target missing on disk
+  - stale_task_ref     — `task <namespace:name>` doesn't match Taskfile
+  - stale_workflow_ref — .github/workflows/<file> doesn't exist
+  - stale_file_ref     — backtick-quoted filepath not found on disk
+
+Writes a JSON report (machine-readable) and a Markdown report (human-
+readable). Exit codes mirror the bash:
+
+  0 — clean
+  1 — issues OR docs/ missing
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPORT_DIR = Path(".ss/reports/docs")
+REPORT_JSON = REPORT_DIR / "docs-accuracy-report.json"
+REPORT_MD = REPORT_DIR / "docs-accuracy-report.md"
+
+DOCS_DIR = Path("docs")
+ROOT_ENTRY_FILES = ("README.md", "AGENTS.md", "CLAUDE.md", "CONTRIBUTING.md")
+
+# Refs that look like file paths but represent something else:
+_GITHUB_WEB_PATH_SEGMENTS = frozenset({
+    "issues", "discussions", "pulls", "milestones", "projects", "wiki",
+    "pulse", "graphs", "settings", "compare", "tree", "blob", "raw",
+    "blame", "commits", "tags", "releases", "packages", "actions",
+})
+
+_TRACKED_EXTENSIONS = frozenset(
+    (".html", ".js", ".css", ".json", ".yml", ".yaml", ".toml", ".py", ".sh", ".md")
+)
+_SKIP_REF_PREFIXES = ("http", "mailto", "/")
+_PLACEHOLDER_SUBS = ("example", "your-", "<", "YYYY")
+
+# Phrases that indicate a backtick-quoted file ref is an example or
+# suggestion, not a real path. Used to suppress false positives in tutorial
+# prose and "how to add a new check" instructions.
+_SUGGESTION_CTX = re.compile(
+    r'(split into|could create|create a|for example|e\.g\.|such as|'
+    r'examples?:|add\b.*\bhere|when.*needed|naming|format|add a\b|generat\w*)',
+    re.IGNORECASE,
+)
+
+_TASKFILE_TASK_RE = re.compile(r"^  ([a-z][a-z0-9:_-]+):", re.MULTILINE)
+_MD_LINK_RE = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')
+_TASK_REF_RE = re.compile(r'(?:^|\s)task\s+([a-z][a-z0-9_-]*:[a-z0-9:_-]+)')
+_WF_REF_RE = re.compile(r'\.github/workflows/([a-z0-9_.-]+\.(?:yml|md))')
+_BACKTICK_FILE_RE = re.compile(r'`([a-zA-Z0-9_./-]+\.[a-z]{1,4})`')
+
+
+def _get_taskfile_tasks() -> set[str]:
+    tasks: set[str] = set()
+    root = Path("Taskfile.yml")
+    if root.exists():
+        tasks |= {m.group(1) for m in _TASKFILE_TASK_RE.finditer(root.read_text())}
+    ss = Path("Taskfile.ss.yml")
+    if ss.exists():
+        tasks |= {"ss:" + m.group(1) for m in _TASKFILE_TASK_RE.finditer(ss.read_text())}
+    return tasks
+
+
+def _get_workflow_files() -> set[str]:
+    wf_dir = Path(".github/workflows")
+    if not wf_dir.is_dir():
+        return set()
+    return {f.name for f in wf_dir.iterdir() if f.is_file()}
+
+
+def _line_of(content: str, position: int) -> int:
+    return content[:position].count("\n") + 1
+
+
+def _check_broken_links(md_path: Path) -> list[dict]:
+    issues: list[dict] = []
+    content = md_path.read_text()
+    base = md_path.parent
+    for m in _MD_LINK_RE.finditer(content):
+        display, target = m.group(1), m.group(2)
+        if target.startswith(("http://", "https://", "mailto:", "#")):
+            continue
+        target_path = target.split("?")[0].split("#")[0]
+        if not target_path:
+            continue
+        if any(part in _GITHUB_WEB_PATH_SEGMENTS for part in Path(target_path).parts):
+            continue
+        resolved = (base / target_path).resolve()
+        if not resolved.exists():
+            issues.append({
+                "type": "broken_link",
+                "file": str(md_path),
+                "line": _line_of(content, m.start()),
+                "message": f"Broken link: [{display}]({target}) — target does not exist",
+            })
+    return issues
+
+
+def _check_task_references(md_path: Path, valid_tasks: set[str]) -> list[dict]:
+    issues: list[dict] = []
+    content = md_path.read_text()
+    for m in _TASK_REF_RE.finditer(content):
+        task_name = m.group(1)
+        if task_name not in valid_tasks:
+            issues.append({
+                "type": "stale_task_ref",
+                "file": str(md_path),
+                "line": _line_of(content, m.start()),
+                "message": f"Task reference `task {task_name}` not found in Taskfile.yml",
+            })
+    return issues
+
+
+def _check_workflow_references(md_path: Path, valid_workflows: set[str]) -> list[dict]:
+    issues: list[dict] = []
+    content = md_path.read_text()
+    for m in _WF_REF_RE.finditer(content):
+        wf_name = m.group(1)
+        if wf_name not in valid_workflows:
+            issues.append({
+                "type": "stale_workflow_ref",
+                "file": str(md_path),
+                "line": _line_of(content, m.start()),
+                "message": f"Workflow reference `.github/workflows/{wf_name}` does not exist",
+            })
+    return issues
+
+
+def _ref_is_placeholder_or_external(ref: str, ext: str) -> bool:
+    if ref.startswith(_SKIP_REF_PREFIXES):
+        return True
+    if ext not in _TRACKED_EXTENSIONS:
+        return True
+    if any(sub in ref for sub in _PLACEHOLDER_SUBS):
+        return True
+    if ext in (".yml", ".yaml") and "/" not in ref:
+        return True
+    return False
+
+
+def _should_skip_file_ref(ref: str, ext: str, base: Path, content: str, m: re.Match) -> bool:
+    if _ref_is_placeholder_or_external(ref, ext):
+        return True
+    if Path(ref).exists() or (base / ref).exists():
+        return True
+    start = max(0, m.start() - 250)
+    end = min(len(content), m.end() + 250)
+    return bool(_SUGGESTION_CTX.search(content[start:end]))
+
+
+def _check_source_file_references(md_path: Path) -> list[dict]:
+    issues: list[dict] = []
+    content = md_path.read_text()
+    base = md_path.parent
+    for m in _BACKTICK_FILE_RE.finditer(content):
+        ref = m.group(1)
+        ext = Path(ref).suffix
+        if _should_skip_file_ref(ref, ext, base, content, m):
+            continue
+        issues.append({
+            "type": "stale_file_ref",
+            "file": str(md_path),
+            "line": _line_of(content, m.start()),
+            "message": f"Possible stale file reference: `{ref}` not found on disk",
+        })
+    return issues
+
+
+def _collect_targets() -> list[Path]:
+    targets = sorted(DOCS_DIR.rglob("*.md"))
+    for entry in ROOT_ENTRY_FILES:
+        entry_path = Path(entry)
+        if entry_path.exists():
+            targets.append(entry_path)
+    return targets
+
+
+def _collect_all_issues(targets: list[Path], valid_tasks: set[str], valid_workflows: set[str]) -> list[dict]:
+    issues: list[dict] = []
+    for md_file in targets:
+        issues += _check_broken_links(md_file)
+        issues += _check_task_references(md_file, valid_tasks)
+        issues += _check_workflow_references(md_file, valid_workflows)
+        issues += _check_source_file_references(md_file)
+    return issues
+
+
+def _generated_at() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+_TYPE_LABELS = {
+    "broken_link": "Broken Internal Links",
+    "stale_task_ref": "Stale Taskfile References",
+    "stale_workflow_ref": "Stale Workflow References",
+    "stale_file_ref": "Possible Stale File References",
+}
+
+
+def _build_md_report(data: dict, generated_at: str) -> str:
+    issues = data.get("issues", [])
+    is_clean = data.get("clean", True)
+
+    lines = [
+        "# 🔎 Documentation Accuracy Report",
+        "",
+        f"**Generated:** {generated_at}",
+        "",
+        "## Status",
+        "",
+    ]
+    if is_clean:
+        lines.append("✅ All documentation accuracy checks passed — no stale references detected.")
+    else:
+        lines.append(f"⚠️ Found **{len(issues)}** accuracy issue(s) that may need attention.")
+
+    lines += ["", "## Issues", ""]
+
+    if not issues:
+        lines.append("No issues found.")
+    else:
+        by_type: dict[str, list[dict]] = {}
+        for issue in issues:
+            by_type.setdefault(issue["type"], []).append(issue)
+        for itype, group in by_type.items():
+            label = _TYPE_LABELS.get(itype, itype)
+            lines.append(f"### {label}")
+            lines.append("")
+            for item in group:
+                lines.append(f"- **{item['file']}** (line {item['line']}): {item['message']}")
+            lines.append("")
+
+    lines += [
+        "## How to Fix",
+        "",
+        "1. Review each issue above.",
+        "2. Update the referenced docs to match the current project state.",
+        "3. Run `task ss:hygiene:docs-accuracy` locally to verify fixes.",
+        "",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def run() -> int:
+    print("🔍 Checking documentation accuracy…")
+
+    if not DOCS_DIR.is_dir():
+        print("❌ docs/ directory not found")
+        return 1
+
+    valid_tasks = _get_taskfile_tasks()
+    valid_workflows = _get_workflow_files()
+    targets = _collect_targets()
+    issues = _collect_all_issues(targets, valid_tasks, valid_workflows)
+
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    data = {
+        "issues": issues,
+        "issue_count": len(issues),
+        "clean": len(issues) == 0,
+    }
+    REPORT_JSON.write_text(json.dumps(data, indent=2))
+    REPORT_MD.write_text(_build_md_report(data, _generated_at()))
+
+    if issues:
+        print(f"⚠️  Found {len(issues)} accuracy issue(s)")
+        for issue in issues:
+            print(f"  {issue['file']}:{issue['line']} — {issue['message']}")
+        return 1
+    print("✅ Documentation accuracy checks passed")
+    return 0

--- a/cli/tests/checks/test_docs_accuracy.py
+++ b/cli/tests/checks/test_docs_accuracy.py
@@ -1,0 +1,179 @@
+"""Tests for the hygiene:docs-accuracy check."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from slopstopper.checks import docs_accuracy
+
+
+def _write(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+
+
+def test_get_taskfile_tasks_reads_both_files(isolated_cwd):
+    _write(Path("Taskfile.yml"), "version: '3'\ntasks:\n  build:\n    cmds: []\n")
+    _write(
+        Path("Taskfile.ss.yml"),
+        "version: '3'\ntasks:\n  hygiene:lint:\n    cmds: []\n  security:sast:\n    cmds: []\n",
+    )
+    tasks = docs_accuracy._get_taskfile_tasks()
+    assert "build" in tasks
+    assert "ss:hygiene:lint" in tasks
+    assert "ss:security:sast" in tasks
+
+
+def test_get_workflow_files_lists_files_only(isolated_cwd):
+    wf = isolated_cwd / ".github" / "workflows"
+    wf.mkdir(parents=True)
+    (wf / "ss-x.yml").write_text("name: x")
+    (wf / "ss-y.lock.yml").write_text("name: y")
+    (wf / "subdir").mkdir()
+    assert docs_accuracy._get_workflow_files() == {"ss-x.yml", "ss-y.lock.yml"}
+
+
+def test_check_broken_links_flags_missing_target(isolated_cwd):
+    md = isolated_cwd / "docs" / "x.md"
+    _write(md, "See [here](missing.md)\n")
+    issues = docs_accuracy._check_broken_links(md)
+    assert len(issues) == 1
+    assert issues[0]["type"] == "broken_link"
+    assert "missing.md" in issues[0]["message"]
+
+
+def test_check_broken_links_skips_external_and_anchors(isolated_cwd):
+    md = isolated_cwd / "docs" / "x.md"
+    _write(
+        md,
+        "[ext](https://example.com)\n[m](mailto:a@b)\n[a](#anchor)\n[q](file.md?x=1)\n",
+    )
+    # file.md doesn't exist; but http/mailto/anchor are all skipped, and the
+    # query-string strip means file.md gets checked → it should fail.
+    issues = docs_accuracy._check_broken_links(md)
+    assert all(i["type"] == "broken_link" for i in issues)
+    assert any("file.md" in i["message"] for i in issues)
+    assert not any("https://" in i["message"] for i in issues)
+
+
+def test_check_broken_links_skips_github_web_paths(isolated_cwd):
+    md = isolated_cwd / "docs" / "x.md"
+    _write(md, "[file an issue](../../issues/new)\n[PR](../../pulls/1)\n")
+    assert docs_accuracy._check_broken_links(md) == []
+
+
+def test_check_broken_links_resolves_relative(isolated_cwd):
+    docs = isolated_cwd / "docs"
+    _write(docs / "x.md", "[t](other.md)\n")
+    (docs / "other.md").write_text("hi\n")
+    assert docs_accuracy._check_broken_links(docs / "x.md") == []
+
+
+def test_check_task_references_flags_unknown(isolated_cwd):
+    md = isolated_cwd / "docs" / "x.md"
+    # Regex requires whitespace (or BOL) before "task" — backtick adjacency
+    # is deliberately not matched to avoid false-positives on inline code.
+    _write(md, "Run task ss:nonexistent:check to verify.\n")
+    issues = docs_accuracy._check_task_references(md, {"ss:hygiene:lint"})
+    assert len(issues) == 1
+    assert issues[0]["type"] == "stale_task_ref"
+    assert "ss:nonexistent:check" in issues[0]["message"]
+
+
+def test_check_task_references_ignores_unnamespaced(isolated_cwd):
+    md = isolated_cwd / "docs" / "x.md"
+    _write(md, "this is task runner adjacent prose\n")
+    assert docs_accuracy._check_task_references(md, set()) == []
+
+
+def test_check_workflow_references_flags_missing(isolated_cwd):
+    md = isolated_cwd / "docs" / "x.md"
+    _write(md, "See .github/workflows/nope.yml for details.\n")
+    issues = docs_accuracy._check_workflow_references(md, {"present.yml"})
+    assert len(issues) == 1
+    assert issues[0]["type"] == "stale_workflow_ref"
+
+
+def test_check_workflow_references_passes_existing(isolated_cwd):
+    md = isolated_cwd / "docs" / "x.md"
+    _write(md, "See .github/workflows/ok.yml for details.\n")
+    assert docs_accuracy._check_workflow_references(md, {"ok.yml"}) == []
+
+
+def test_ref_is_placeholder_or_external_flags_examples():
+    assert docs_accuracy._ref_is_placeholder_or_external("https://x.com", ".com") is True
+    assert docs_accuracy._ref_is_placeholder_or_external("example.py", ".py") is True
+    assert docs_accuracy._ref_is_placeholder_or_external("your-repo.yml", ".yml") is True
+    assert docs_accuracy._ref_is_placeholder_or_external("setup.bin", ".bin") is True
+    # Bare yml is treated as tutorial prose, not a real reference.
+    assert docs_accuracy._ref_is_placeholder_or_external("config.yml", ".yml") is True
+
+
+def test_ref_is_placeholder_or_external_lets_real_paths_through():
+    assert docs_accuracy._ref_is_placeholder_or_external("docs/x.md", ".md") is False
+    assert docs_accuracy._ref_is_placeholder_or_external("path/to/.yml", ".yml") is False
+
+
+def test_check_source_file_references_flags_missing(isolated_cwd):
+    md = isolated_cwd / "docs" / "x.md"
+    _write(md, "The script `.ss/scripts/missing.py` does X.\n")
+    issues = docs_accuracy._check_source_file_references(md)
+    assert len(issues) == 1
+    assert issues[0]["type"] == "stale_file_ref"
+
+
+def test_check_source_file_references_suppresses_via_suggestion_context(isolated_cwd):
+    md = isolated_cwd / "docs" / "x.md"
+    _write(md, "For example, `something.py` could be created.\n")
+    assert docs_accuracy._check_source_file_references(md) == []
+
+
+def test_build_md_report_clean():
+    md = docs_accuracy._build_md_report(
+        {"issues": [], "issue_count": 0, "clean": True}, "2026-06-12 00:00:00 UTC"
+    )
+    assert "✅" in md
+    assert "No issues found" in md
+
+
+def test_build_md_report_with_issues_groups_by_type():
+    data = {
+        "issues": [
+            {"type": "broken_link", "file": "docs/a.md", "line": 5, "message": "X"},
+            {"type": "stale_task_ref", "file": "docs/b.md", "line": 10, "message": "Y"},
+        ],
+        "issue_count": 2,
+        "clean": False,
+    }
+    md = docs_accuracy._build_md_report(data, "2026-06-12 00:00:00 UTC")
+    assert "Found **2** accuracy issue(s)" in md
+    assert "### Broken Internal Links" in md
+    assert "### Stale Taskfile References" in md
+    assert "docs/a.md" in md and "(line 5)" in md
+
+
+def test_run_clean_returns_zero(isolated_cwd):
+    _write(Path("docs/index.md"), "# docs\n")
+    rc = docs_accuracy.run()
+    assert rc == 0
+    assert docs_accuracy.REPORT_JSON.exists()
+    assert docs_accuracy.REPORT_MD.exists()
+    data = json.loads(docs_accuracy.REPORT_JSON.read_text())
+    assert data["clean"] is True
+    assert data["issue_count"] == 0
+
+
+def test_run_returns_one_when_docs_missing(isolated_cwd, capsys):
+    rc = docs_accuracy.run()
+    assert rc == 1
+    assert "docs/ directory not found" in capsys.readouterr().out
+
+
+def test_run_flags_broken_link(isolated_cwd):
+    _write(Path("docs/x.md"), "See [gone](does-not-exist.md)\n")
+    rc = docs_accuracy.run()
+    assert rc == 1
+    data = json.loads(docs_accuracy.REPORT_JSON.read_text())
+    assert data["clean"] is False
+    assert any(i["type"] == "broken_link" for i in data["issues"])


### PR DESCRIPTION
## Summary

Fourth check ported under the cutover protocol (port + tests + parity). No GitHub Actions flipped.

## What lands

- `cli/slopstopper/checks/docs_accuracy.py` — merges `check-docs-accuracy.py` + `generate-docs-accuracy-md.py` into one self-contained check. Scans `docs/**/*.md` plus the four repo-root entry files for four kinds of drift (broken links, stale task refs, stale workflow refs, stale file refs).
- All regexes and false-positive suppression logic lifted verbatim.
- Dropped two dead helpers from the bash (`get_project_files()` was computed but never read — both `check_broken_links` and `check_source_file_references` use `Path.exists()` directly). Output unaffected.
- Registered as `hygiene:docs-accuracy`.
- 19 new tests; total CLI test count: **80**.

## Parity

Bash side chains `check ; generate`. Both `.json` and `.md` reports diff byte-identical (modulo timestamp).

## Verified locally

```
$ task -t cli/Taskfile.yml test
80 passed in 0.05s

$ task -t cli/Taskfile.yml parity
=== hygiene-docs-size ===          ✅
=== hygiene-entry-files ===        ✅
=== hygiene-docs-structure ===     ✅
=== hygiene-docs-accuracy ===      ✅
All parity checks passed.
```

## Test plan

- [x] `task -t cli/Taskfile.yml test` — 80 tests green
- [x] `task -t cli/Taskfile.yml parity` — all four checks byte-identical
- [x] CCN ≤ 10 across cli/slopstopper/
- [ ] CI: pytest job green
- [ ] CI: parity job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)