### PR TITLE
feat(cli): port hygiene:complexity as fifth CLI check

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -37,6 +37,7 @@ on:
       - '.ss/scripts/generate-docs-structure-md.py'
       - '.ss/scripts/check-docs-accuracy.py'
       - '.ss/scripts/generate-docs-accuracy-md.py'
+      - '.ss/scripts/generate-complexity-md.py'
   push:
     branches: [ main ]
     paths:
@@ -49,6 +50,7 @@ on:
       - '.ss/scripts/generate-docs-structure-md.py'
       - '.ss/scripts/check-docs-accuracy.py'
       - '.ss/scripts/generate-docs-accuracy-md.py'
+      - '.ss/scripts/generate-complexity-md.py'
   workflow_dispatch:
 
 permissions:

--- a/cli/Taskfile.yml
+++ b/cli/Taskfile.yml
@@ -53,9 +53,13 @@ tasks:
         set -e
         TMP=$(mktemp -d)
         trap 'rm -rf "$TMP"' EXIT
-        # Strip timestamp lines from both .md (**Generated: ...) and .json
-        # ("generated_at": ...,) reports so parity isn't broken by clock drift.
-        STRIP='^\*\*Generated:|"generated_at"'
+        # Strip timestamp lines from both .md reports and .json reports so
+        # parity isn't broken by clock drift between bash and CLI runs.
+        # Patterns observed across checks:
+        #   **Generated:** YYYY-MM-DD ...     (docs-size, entry-files, docs-structure, docs-accuracy)
+        #   **Generated**: YYYY-MM-DD ...     (complexity — asterisks before colon)
+        #   "generated_at": "...",            (every JSON report)
+        STRIP='^\*\*Generated|"generated_at"'
         FAILED=0
 
         # check_parity NAME BASH_CMD CLI_CMD REPORT_PATH [REPORT_PATH...]
@@ -154,6 +158,18 @@ tasks:
           "cli/.venv/bin/slopstopper run hygiene:docs-accuracy" \
           ".ss/reports/docs/docs-accuracy-report.json" \
           ".ss/reports/docs/docs-accuracy-report.md"
+
+        # hygiene:complexity shells out to `python -m lizard`. The bash
+        # side calls the full task target (which check-installs lizard,
+        # runs lizard --csv, then runs generate-complexity-md.py); the CLI
+        # side does the same via subprocess. Both produce identical CSV
+        # and MD when run against the same tree.
+        check_parity \
+          "hygiene-complexity" \
+          "task ss:hygiene:complexity" \
+          "cli/.venv/bin/slopstopper run hygiene:complexity" \
+          ".ss/reports/complexity/complexity-report.csv" \
+          ".ss/reports/complexity/complexity-report.md"
 
         echo ""
         if [ "$FAILED" -eq 0 ]; then

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -21,7 +21,14 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
-test = ["pytest>=7"]
+test = [
+  "pytest>=7",
+  # `lizard` is invoked at runtime by hygiene:complexity via subprocess
+  # (`python -m lizard`). Not a runtime dep of slopstopper-cli itself —
+  # adopters install it themselves in production. Pulled into the test
+  # extra so CI parity + integration tests can exercise the real tool.
+  "lizard>=1.17",
+]
 
 [project.scripts]
 slopstopper = "slopstopper.cli:main"

--- a/cli/slopstopper/checks/__init__.py
+++ b/cli/slopstopper/checks/__init__.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from typing import Callable
 
-from slopstopper.checks import docs_accuracy, docs_size, docs_structure, entry_files
+from slopstopper.checks import complexity, docs_accuracy, docs_size, docs_structure, entry_files
 
 REGISTRY: dict[str, Callable[[], int]] = {
+    "hygiene:complexity": complexity.run,
     "hygiene:docs-accuracy": docs_accuracy.run,
     "hygiene:docs-size": docs_size.run,
     "hygiene:docs-structure": docs_structure.run,

--- a/cli/slopstopper/checks/complexity.py
+++ b/cli/slopstopper/checks/complexity.py
@@ -1,0 +1,223 @@
+"""Code complexity analyzer (Lizard wrapper).
+
+Ports the bash hygiene:complexity flow:
+
+  .ss/scripts/check-tool   (in Taskfile.ss.yml — installs lizard)
+  + python3 -m lizard . ... --csv > complexity-report.csv
+  + .ss/scripts/generate-complexity-md.py
+
+into one self-contained check. Subprocess-invokes `python -m lizard`
+(using sys.executable so the same Python running the CLI provides
+lizard), captures the CSV, parses it, writes both the CSV and the
+markdown report.
+
+This is the CLI's first external-tool integration. Subprocess-invoke
+boundary is the load-bearing licensing rule (see plan doc): we call
+lizard's CLI, never `import lizard`. Adopter installs lizard
+themselves (or via the test extra in cli/pyproject.toml's [test]
+group, which is what CI does).
+
+Exit codes:
+  0 — analysis completed (independent of whether high-complexity items
+      exist — gating happens at the workflow level, mirroring bash)
+  1 — lizard is not installed
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPORT_DIR = Path(".ss/reports/complexity")
+REPORT_CSV = REPORT_DIR / "complexity-report.csv"
+REPORT_MD = REPORT_DIR / "complexity-report.md"
+
+# Exclude tests, generated files, vendored deps from the scan. Same list
+# as Taskfile.ss.yml's hygiene:complexity:analyze.
+LIZARD_EXCLUDES = (
+    "tests/*",
+    ".ss/tests/*",
+    ".github/*",
+    "node_modules/*",
+    ".git/*",
+)
+
+CCN_THRESHOLD = 10
+
+_LIZARD_INSTALL_HELP = (
+    "❌ lizard is not installed.\n"
+    "Install with:\n"
+    "  pip3 install --user lizard\n"
+    "  python3 -m pip install --user lizard\n"
+    "Note: do NOT install via 'brew install lizard' — that's lz4's lizard,\n"
+    "a completely different tool that will shadow the Python package."
+)
+
+
+def _lizard_available() -> bool:
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "lizard", "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result.returncode == 0
+    except OSError:
+        return False
+
+
+def _run_lizard(target_dir: str = ".") -> str:
+    """Invoke `python -m lizard <target> --csv ...` and return stdout."""
+    cmd = [sys.executable, "-m", "lizard", target_dir]
+    for ex in LIZARD_EXCLUDES:
+        cmd += ["-x", ex]
+    cmd += ["--csv"]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    return result.stdout
+
+
+def _parse_csv_rows(csv_text: str) -> list[tuple]:
+    """Parse lizard's CSV output.
+
+    Columns (0-indexed):
+      0 nloc, 1 ccn, 2 tokens, 3 params, 4 length,
+      5 location ("function@start-end@./path"),
+      6 file path, 7 function name, 8 long name, ...
+
+    Returns [(nloc, ccn, tokens, params, length, location, file), ...].
+    Rows with non-numeric leading columns (header rows from fixtures) are
+    silently skipped.
+    """
+    rows: list[tuple] = []
+    reader = csv.reader(io.StringIO(csv_text))
+    for row in reader:
+        if len(row) < 6:
+            continue
+        try:
+            nloc = int(row[0])
+            ccn = int(row[1])
+            tokens = int(row[2])
+            params = int(row[3])
+            length = int(row[4])
+        except ValueError:
+            continue
+        location = row[5].strip('"')
+        if len(row) > 6 and row[6]:
+            file_path = row[6].strip('"')
+        elif "@" in location:
+            file_path = location.split("@")[-1]
+        else:
+            file_path = location.split(":")[0]
+        rows.append((nloc, ccn, tokens, params, length, location, file_path))
+    return rows
+
+
+def _compute_summary_lines(rows: list[tuple]) -> list[str]:
+    if not rows:
+        return [
+            "Total NLOC   Avg.NLOC  Avg.CCN  Avg.Tokens  Fun Cnt  Warning Cnt",
+            "----------------------------------------------------------------",
+            "         0        0.0      0.0         0.0        0            0",
+            "",
+            "No functions analyzed.",
+        ]
+
+    fun_cnt = len(rows)
+    total_nloc = sum(r[0] for r in rows)
+    avg_nloc = total_nloc / fun_cnt
+    avg_ccn = sum(r[1] for r in rows) / fun_cnt
+    avg_tokens = sum(r[2] for r in rows) / fun_cnt
+    warning_cnt = sum(1 for r in rows if r[1] > CCN_THRESHOLD)
+
+    files = {r[6] for r in rows}
+    file_count = len(files)
+    file_word = "file" if file_count == 1 else "files"
+
+    return [
+        "Total NLOC   Avg.NLOC  Avg.CCN  Avg.Tokens  Fun Cnt  Warning Cnt",
+        "----------------------------------------------------------------",
+        f"{total_nloc:>10}  {avg_nloc:>9.1f}  {avg_ccn:>7.1f}  {avg_tokens:>10.1f}  {fun_cnt:>7}  {warning_cnt:>11}",
+        "",
+        f"{file_count} {file_word} analyzed.",
+    ]
+
+
+def _format_summary_section(summary_lines: list[str]) -> str:
+    if not summary_lines:
+        return ""
+    return "```\n" + "\n".join(summary_lines) + "\n```\n\n"
+
+
+def _format_high_complexity_section(rows: list[tuple]) -> str:
+    high = [r for r in rows if r[1] > CCN_THRESHOLD]
+    if not high:
+        return "## ✅ Complexity Status\n\nNo high-complexity items found (all CCN ≤ 10)\n\n"
+
+    out = "## ⚠️ High Complexity Items (CCN > 10)\n\n"
+    out += "| NLOC | CCN | Tokens | Params | Length | Location |\n"
+    out += "|------|-----|--------|--------|--------|----------|\n"
+    for nloc, ccn, tokens, params, length, location, _file in high:
+        out += f"| {nloc} | {ccn} | {tokens} | {params} | {length} | `{location}` |\n"
+    return out
+
+
+def _generated_at() -> str:
+    # Bash uses `datetime.now().strftime(...)` (naive local time). The
+    # parity test strips this line so format is irrelevant, but using
+    # timezone.utc here matches what the docs-size port chose.
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _build_md_report(rows: list[tuple]) -> str:
+    summary = _compute_summary_lines(rows)
+    md = "# Code Complexity Analysis Report\n\n"
+    md += f"**Generated**: {_generated_at()}\n\n"
+    md += "## Summary\n\n"
+    md += _format_summary_section(summary)
+    md += _format_high_complexity_section(rows)
+    md += "## Guidelines\n\n"
+    md += "- **Cyclomatic Complexity (CCN)**: Measure of code complexity based on decision points\n"
+    md += "  - **Good**: CCN ≤ 10\n"
+    md += "  - **Warning**: 10 < CCN ≤ 15\n"
+    md += "  - **Critical**: CCN > 15\n\n"
+    md += "- **Function Length (NLOC)**: Number of lines of code\n"
+    md += "  - Target: Keep functions under 50 lines\n"
+    md += "  - For this static template, code should be minimal\n\n"
+    md += "- **Threshold**: Any function with CCN > 10 should be reviewed and simplified\n\n"
+    md += "## More Information\n\n"
+    md += "- Generated by [Lizard](http://www.lizard.ws/)\n"
+    md += "- Reports location: `.ss/reports/complexity/`\n"
+    md += "  - `complexity-report.md` (this file)\n"
+    md += "  - `complexity-report.csv` (machine-readable)\n"
+    return md
+
+
+def run() -> int:
+    if not _lizard_available():
+        print(_LIZARD_INSTALL_HELP)
+        return 1
+
+    print("🔍 Analyzing code complexity…")
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+
+    csv_text = _run_lizard()
+    REPORT_CSV.write_text(csv_text)
+
+    rows = _parse_csv_rows(csv_text)
+    REPORT_MD.write_text(_build_md_report(rows))
+
+    high_count = sum(1 for r in rows if r[1] > CCN_THRESHOLD)
+    if high_count:
+        print(f"⚠️  Found {high_count} item(s) with cyclomatic complexity > 10")
+    else:
+        print("✅ No high-complexity items found (all CCN ≤ 10)")
+
+    print(f"📁 Reports saved to: {REPORT_DIR}/")
+    print(f"   • {REPORT_MD.name}")
+    print(f"   • {REPORT_CSV.name}")
+    return 0

--- a/cli/tests/checks/test_complexity.py
+++ b/cli/tests/checks/test_complexity.py
@@ -1,0 +1,154 @@
+"""Tests for the hygiene:complexity check."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from slopstopper.checks import complexity
+
+
+# Sample CSV in lizard's shape: nloc,ccn,tokens,params,length,location,file,...
+SAMPLE_CSV_LOW = (
+    '5,2,42,1,7,"foo@10-14@./src/a.py","./src/a.py","foo","foo( x )",10,14\n'
+    '8,3,80,2,12,"bar@20-31@./src/a.py","./src/a.py","bar","bar( x, y )",20,31\n'
+)
+SAMPLE_CSV_WITH_WARNING = (
+    SAMPLE_CSV_LOW
+    + '40,15,300,1,55,"complicated@40-94@./src/b.py","./src/b.py","complicated","complicated( x )",40,94\n'
+)
+
+
+def test_parse_csv_rows_extracts_numeric_fields():
+    rows = complexity._parse_csv_rows(SAMPLE_CSV_LOW)
+    assert len(rows) == 2
+    assert rows[0][:5] == (5, 2, 42, 1, 7)
+    assert rows[0][5] == "foo@10-14@./src/a.py"
+    assert rows[0][6] == "./src/a.py"
+
+
+def test_parse_csv_rows_skips_header_rows():
+    csv_with_header = (
+        "NLOC,CCN,token,PARAM,length,location,file\n"
+        + SAMPLE_CSV_LOW
+    )
+    rows = complexity._parse_csv_rows(csv_with_header)
+    assert len(rows) == 2
+
+
+def test_parse_csv_rows_handles_missing_file_column():
+    # Older fixtures may omit column 6 — fall back to location's @-segment.
+    csv_no_file_col = '5,2,42,1,7,"foo@10-14@./src/a.py"\n'
+    rows = complexity._parse_csv_rows(csv_no_file_col)
+    assert rows[0][6] == "./src/a.py"
+
+
+def test_parse_csv_rows_falls_back_for_colon_location():
+    # Even older format: "path:line" instead of "func@start-end@./path".
+    csv_colon = "5,2,42,1,7,src/a.py:10\n"
+    rows = complexity._parse_csv_rows(csv_colon)
+    assert rows[0][6] == "src/a.py"
+
+
+def test_parse_csv_rows_returns_empty_on_empty_input():
+    assert complexity._parse_csv_rows("") == []
+
+
+def test_compute_summary_lines_empty_block():
+    lines = complexity._compute_summary_lines([])
+    assert "No functions analyzed." in lines
+    assert any("Total NLOC" in line for line in lines)
+
+
+def test_compute_summary_lines_aggregates_correctly():
+    rows = complexity._parse_csv_rows(SAMPLE_CSV_LOW)
+    lines = complexity._compute_summary_lines(rows)
+    # Total NLOC = 5 + 8 = 13, fun_cnt = 2, files = {"./src/a.py"} → 1
+    assert "13" in lines[2]
+    assert "2 files" in lines[4] or "1 file" in lines[4]
+
+
+def test_compute_summary_lines_counts_warnings():
+    rows = complexity._parse_csv_rows(SAMPLE_CSV_WITH_WARNING)
+    lines = complexity._compute_summary_lines(rows)
+    # The third row has CCN=15 > 10 → warning_cnt = 1
+    assert lines[2].split()[-1] == "1"
+
+
+def test_format_summary_section_wraps_in_fence():
+    section = complexity._format_summary_section(["line a", "line b"])
+    assert section.startswith("```\n")
+    assert section.endswith("```\n\n")
+    assert "line a" in section
+
+
+def test_format_summary_section_empty():
+    assert complexity._format_summary_section([]) == ""
+
+
+def test_format_high_complexity_section_clean():
+    rows = complexity._parse_csv_rows(SAMPLE_CSV_LOW)
+    section = complexity._format_high_complexity_section(rows)
+    assert "✅" in section
+    assert "No high-complexity items" in section
+
+
+def test_format_high_complexity_section_with_warning():
+    rows = complexity._parse_csv_rows(SAMPLE_CSV_WITH_WARNING)
+    section = complexity._format_high_complexity_section(rows)
+    assert "⚠️" in section
+    assert "| 40 | 15 |" in section  # row table entry
+    assert "complicated@40-94" in section
+
+
+def test_build_md_report_contains_all_sections():
+    rows = complexity._parse_csv_rows(SAMPLE_CSV_LOW)
+    md = complexity._build_md_report(rows)
+    assert "# Code Complexity Analysis Report" in md
+    assert "## Summary" in md
+    assert "## Guidelines" in md
+    assert "## More Information" in md
+
+
+def test_lizard_available_returns_false_when_subprocess_errors(monkeypatch):
+    def fake_run(*args, **kwargs):
+        raise OSError("nope")
+
+    monkeypatch.setattr(complexity.subprocess, "run", fake_run)
+    assert complexity._lizard_available() is False
+
+
+def test_lizard_available_returns_true_on_success(monkeypatch):
+    class FakeResult:
+        returncode = 0
+
+    monkeypatch.setattr(complexity.subprocess, "run", lambda *a, **k: FakeResult())
+    assert complexity._lizard_available() is True
+
+
+def test_run_returns_one_when_lizard_missing(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.setattr(complexity, "_lizard_available", lambda: False)
+    rc = complexity.run()
+    assert rc == 1
+    assert "lizard is not installed" in capsys.readouterr().out
+
+
+def test_run_writes_csv_and_md_using_mocked_lizard(monkeypatch, isolated_cwd):
+    monkeypatch.setattr(complexity, "_lizard_available", lambda: True)
+    monkeypatch.setattr(complexity, "_run_lizard", lambda target_dir=".": SAMPLE_CSV_WITH_WARNING)
+    rc = complexity.run()
+    assert rc == 0
+    assert complexity.REPORT_CSV.read_text() == SAMPLE_CSV_WITH_WARNING
+    md = complexity.REPORT_MD.read_text()
+    assert "⚠️ High Complexity Items" in md
+    assert "complicated@40-94" in md
+
+
+def test_run_reports_clean_when_no_warnings(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.setattr(complexity, "_lizard_available", lambda: True)
+    monkeypatch.setattr(complexity, "_run_lizard", lambda target_dir=".": SAMPLE_CSV_LOW)
+    rc = complexity.run()
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "✅ No high-complexity items found" in out


### PR DESCRIPTION
## Summary

Fifth check ported — **first external-tool integration**. Subprocess-invokes `python -m lizard`, parses the CSV, writes report. Establishes the licensing-boundary pattern from the plan doc: lizard is invoked as a CLI, never `import`ed as a library.

## What lands

- `cli/slopstopper/checks/complexity.py` — collapses the bash flow's three sub-tasks (check-tool / analyze / report) into one `run()`. Verifies lizard available, runs it with the same exclude list as `Taskfile.ss.yml`, parses CSV (lifted from `generate-complexity-md.py`), writes both reports.
- Uses `sys.executable` for the subprocess so the same Python running the CLI provides lizard. Works in venvs, pipx envs, and system Python.
- Registered as `hygiene:complexity`.
- 18 new tests; total CLI test count: **98**.

## Test dependencies

`lizard>=1.17` added to `cli/pyproject.toml`'s `[test]` extra. **Not a runtime dep** — adopters install lizard themselves in production. Pulled into test extras only so CI parity + integration tests can exercise the real tool.

## Parity scaffolding

- Bash side: `task ss:hygiene:complexity` (canonical task target — runs the full bash chain).
- Both `complexity-report.csv` and `complexity-report.md` diff byte-identical against CLI output.
- Strip-regex broadened from `^\*\*Generated:` to `^\*\*Generated` so it catches complexity's `**Generated**:` format (asterisks before colon) as well as the `**Generated:**` format used by the other ports.

## Verified locally

```
$ task -t cli/Taskfile.yml test
98 passed in 0.06s

$ task -t cli/Taskfile.yml parity
=== hygiene-docs-size ===          ✅
=== hygiene-entry-files ===        ✅
=== hygiene-docs-structure ===     ✅
=== hygiene-docs-accuracy ===      ✅
=== hygiene-complexity ===         ✅
All parity checks passed.
```

## Test plan

- [x] `task -t cli/Taskfile.yml test` — 98 tests green
- [x] `task -t cli/Taskfile.yml parity` — all five checks byte-identical
- [x] CCN ≤ 10 across cli/slopstopper/
- [ ] CI: pytest job green
- [ ] CI: parity job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)