### PR TITLE
feat(cli): port hygiene:csp-exceptions + headers adapters

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -38,6 +38,8 @@ on:
       - '.ss/scripts/check-docs-accuracy.py'
       - '.ss/scripts/generate-docs-accuracy-md.py'
       - '.ss/scripts/generate-complexity-md.py'
+      - '.ss/scripts/check-csp-exceptions.py'
+      - '.ss/scripts/headers_adapters/**'
   push:
     branches: [ main ]
     paths:
@@ -51,6 +53,8 @@ on:
       - '.ss/scripts/check-docs-accuracy.py'
       - '.ss/scripts/generate-docs-accuracy-md.py'
       - '.ss/scripts/generate-complexity-md.py'
+      - '.ss/scripts/check-csp-exceptions.py'
+      - '.ss/scripts/headers_adapters/**'
   workflow_dispatch:
 
 permissions:

--- a/cli/Taskfile.yml
+++ b/cli/Taskfile.yml
@@ -171,6 +171,17 @@ tasks:
           ".ss/reports/complexity/complexity-report.csv" \
           ".ss/reports/complexity/complexity-report.md"
 
+        # csp-exceptions exercises the headers-adapter pluggability seam.
+        # Both .json and .md outputs are byte-identical (no timestamp in
+        # either, so no strip needed — but the helper strips the same way
+        # regardless).
+        check_parity \
+          "hygiene-csp-exceptions" \
+          "python3 .ss/scripts/check-csp-exceptions.py" \
+          "cli/.venv/bin/slopstopper run hygiene:csp-exceptions" \
+          ".ss/reports/csp/csp-exceptions-report.json" \
+          ".ss/reports/csp/csp-exceptions-report.md"
+
         echo ""
         if [ "$FAILED" -eq 0 ]; then
           echo "All parity checks passed."

--- a/cli/slopstopper/checks/__init__.py
+++ b/cli/slopstopper/checks/__init__.py
@@ -4,10 +4,18 @@ from __future__ import annotations
 
 from typing import Callable
 
-from slopstopper.checks import complexity, docs_accuracy, docs_size, docs_structure, entry_files
+from slopstopper.checks import (
+    complexity,
+    csp_exceptions,
+    docs_accuracy,
+    docs_size,
+    docs_structure,
+    entry_files,
+)
 
 REGISTRY: dict[str, Callable[[], int]] = {
     "hygiene:complexity": complexity.run,
+    "hygiene:csp-exceptions": csp_exceptions.run,
     "hygiene:docs-accuracy": docs_accuracy.run,
     "hygiene:docs-size": docs_size.run,
     "hygiene:docs-structure": docs_structure.run,

--- a/cli/slopstopper/checks/csp_exceptions.py
+++ b/cli/slopstopper/checks/csp_exceptions.py
@@ -1,0 +1,310 @@
+"""CSP-Exceptions Drift Detector.
+
+Ports .ss/scripts/check-csp-exceptions.py. Enforces that every per-path
+CSP relaxation in the configured header source is documented in
+`docs/security/CSP_EXCEPTIONS.md`, and vice versa. Header source and
+format come from `.slopstopper.yml`'s `headers:` keys.
+
+Exit codes mirror the bash:
+  0 — source and doc agree (or no source configured — graceful skip)
+  1 — drift detected (details in report)
+  2 — required input files missing OR unknown adapter format
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+from slopstopper import config, headers_adapters
+
+EXCEPTIONS_DOC = Path("docs/security/CSP_EXCEPTIONS.md")
+REPORT_DIR = Path(".ss/reports/csp")
+REPORT_JSON = REPORT_DIR / "csp-exceptions-report.json"
+REPORT_MD = REPORT_DIR / "csp-exceptions-report.md"
+
+REQUIRED_FIELDS = {
+    "Origin allowed",
+    "Directives added",
+    "Loader SRI",
+    "Why",
+    "Approved by",
+    "Data leaving site",
+    "Refresh policy",
+}
+
+ORIGIN_RE = re.compile(r"https?://[^\s`'\"\)\],]+")
+HEADING_RE = re.compile(r"^###\s+`?(/[^\s`]+)`?\s*$")
+FIELD_RE = re.compile(r"^-\s*\*\*([^:*]+):\*\*\s*(.*)$")
+
+
+def _resolve_source() -> tuple[Path | None, str | None, str | None]:
+    """Return (path, format_name, skip_reason)."""
+    source_str = config.get("headers.source")
+    format_name = config.get("headers.format", "auto") or "auto"
+    if not source_str:
+        return None, None, "no headers.source configured in .slopstopper.yml"
+    source_path = Path(str(source_str))
+    if not source_path.exists():
+        return source_path, format_name, f"configured headers source {source_path} does not exist"
+    return source_path, format_name, None
+
+
+def _extract_csp_origins(csp: str) -> set[str]:
+    origins: set[str] = set()
+    for directive in csp.split(";"):
+        for token in directive.strip().split():
+            if token.startswith(("http://", "https://")):
+                origins.add(token.rstrip("/"))
+    return origins
+
+
+# ── CSP_EXCEPTIONS.md parser ────────────────────────────────────────
+
+
+def _new_entry() -> dict:
+    return {"origins": set(), "sri": None, "fields_seen": set()}
+
+
+def _apply_doc_field(entry: dict, field: str, value: str) -> None:
+    entry["fields_seen"].add(field)
+    if field in {"Origin allowed", "Directives added"}:
+        entry["origins"].update(o.rstrip("/") for o in ORIGIN_RE.findall(value))
+    elif field == "Loader SRI":
+        entry["sri"] = value.split()[0] if value else None
+
+
+def _flush_doc_entry(out: dict, state: dict) -> None:
+    if state["current"] is not None and state["path"] is not None:
+        out[state["path"]] = state["current"]
+        state["current"] = None
+        state["path"] = None
+
+
+def _handle_doc_line(out: dict, state: dict, line: str) -> None:
+    if line.startswith("## "):
+        _flush_doc_entry(out, state)
+        state["in_section"] = line.strip() == "## Exceptions"
+        return
+    if not state["in_section"]:
+        return
+    heading = HEADING_RE.match(line)
+    if heading:
+        _flush_doc_entry(out, state)
+        path = heading.group(1)
+        # /* is the site-wide CSP baseline, not a per-path exception. The
+        # headers side filters it out too — keep the doc parser symmetric.
+        if path == "/*":
+            state["path"] = None
+            state["current"] = None
+            return
+        state["path"] = path
+        state["current"] = _new_entry()
+        return
+    if state["current"] is None:
+        return
+    field = FIELD_RE.match(line)
+    if field:
+        _apply_doc_field(state["current"], field.group(1).strip(), field.group(2).strip())
+
+
+def _parse_exceptions_doc(doc_path: Path) -> dict[str, dict]:
+    if not doc_path.exists():
+        return {}
+    out: dict[str, dict] = {}
+    state: dict = {"in_section": False, "path": None, "current": None}
+    for raw_line in doc_path.read_text().splitlines():
+        _handle_doc_line(out, state, raw_line.rstrip())
+    _flush_doc_entry(out, state)
+    return out
+
+
+# ── Comparison ──────────────────────────────────────────────────────
+
+
+def _headers_exception_map(rules: list[dict]) -> dict[str, set[str]]:
+    out: dict[str, set[str]] = {}
+    for rule in rules:
+        path = rule["for"]
+        if path == "/*" or rule["csp"] is None:
+            continue
+        external = _extract_csp_origins(rule["csp"])
+        if external:
+            out[path] = external
+    return out
+
+
+def _sri_issues(path: str, sri: str) -> list[dict]:
+    if "TODO" in sri.upper():
+        return [{
+            "severity": "warn",
+            "path": path,
+            "message": f"`{path}` Loader SRI is a placeholder ({sri}) — refresh before this exception ships",
+        }]
+    if not sri:
+        return [{
+            "severity": "warn",
+            "path": path,
+            "message": f"`{path}` has no Loader SRI — acceptable if the third party does not support SRI; document why in the entry",
+        }]
+    return []
+
+
+def _issues_for_documented_path(path: str, required: set[str], entry: dict, source_label: str) -> list[dict]:
+    issues: list[dict] = []
+    missing_origins = required - entry["origins"]
+    if missing_origins:
+        issues.append({
+            "severity": "error",
+            "path": path,
+            "message": f"`{path}` allows {', '.join(sorted(missing_origins))} in {source_label} but those origins are not listed in CSP_EXCEPTIONS.md",
+        })
+    missing_fields = REQUIRED_FIELDS - entry["fields_seen"]
+    if missing_fields:
+        issues.append({
+            "severity": "error",
+            "path": path,
+            "message": f"`{path}` is missing required field(s) in CSP_EXCEPTIONS.md: {', '.join(sorted(missing_fields))}",
+        })
+    issues.extend(_sri_issues(path, entry["sri"] or ""))
+    return issues
+
+
+def _compare(rules: list[dict], doc_entries: dict[str, dict], source_label: str) -> list[dict]:
+    issues: list[dict] = []
+    headers_map = _headers_exception_map(rules)
+    for path, required in headers_map.items():
+        entry = doc_entries.get(path)
+        if entry is None:
+            issues.append({
+                "severity": "error",
+                "path": path,
+                "message": f"`{path}` in {source_label} allows external origins ({', '.join(sorted(required))}) but has no entry in CSP_EXCEPTIONS.md",
+            })
+            continue
+        issues.extend(_issues_for_documented_path(path, required, entry, source_label))
+    for path in doc_entries:
+        if path not in headers_map:
+            issues.append({
+                "severity": "error",
+                "path": path,
+                "message": f"`{path}` is documented in CSP_EXCEPTIONS.md but no matching CSP exception exists in {source_label}",
+            })
+    return issues
+
+
+# ── Report writers ─────────────────────────────────────────────────
+
+
+def _overall_status(issues: list[dict]) -> str:
+    if any(i["severity"] == "error" for i in issues):
+        return "❌ FAIL"
+    if any(i["severity"] == "warn" for i in issues):
+        return "⚠️ WARN"
+    return "✅ PASS"
+
+
+def _md_issue_section(title: str, severity: str, issues: list[dict]) -> list[str]:
+    bucket = [i for i in issues if i["severity"] == severity]
+    if not bucket:
+        return []
+    lines = [title, ""]
+    lines.extend(f"- **{i['path']}** — {i['message']}" for i in bucket)
+    lines.append("")
+    return lines
+
+
+def _md_fix_section(source_label: str) -> list[str]:
+    return [
+        "## How to Fix",
+        "",
+        "- **Missing doc entry** → add a `### \\`/path\\`` heading under `## Exceptions` in `docs/security/CSP_EXCEPTIONS.md` with all required fields.",
+        f"- **Mismatched origins** → make `Origin allowed` / `Directives added` in the doc list every external origin in the corresponding `{source_label}` entry.",
+        f"- **Stale doc entry** → remove the heading, or restore the matching entry in `{source_label}`.",
+        "- **Placeholder SRI** → recompute with the procedure documented in `CSP_EXCEPTIONS.md` and update both the doc and the page that loads the third-party script.",
+        "",
+    ]
+
+
+def _build_md_report(issues: list[dict], summary: dict) -> str:
+    source_label = summary.get("source", "headers source")
+    lines: list[str] = [
+        "# 🔐 CSP Exceptions Report",
+        "",
+        f"**Status:** {_overall_status(issues)}",
+        "",
+        f"- Headers source: `{source_label}` (format: `{summary.get('format', 'unknown')}`)",
+        f"- Documented exceptions in `docs/security/CSP_EXCEPTIONS.md`: {summary['doc_entries']}",
+        f"- CSP exceptions in source (non-`/*`): {summary['headers_exceptions']}",
+        "",
+    ]
+    if not issues:
+        lines.extend([f"No drift detected. `{source_label}` and `CSP_EXCEPTIONS.md` agree.", ""])
+    else:
+        lines.extend(_md_issue_section("## ❌ Errors", "error", issues))
+        lines.extend(_md_issue_section("## ⚠️ Warnings", "warn", issues))
+    lines.extend(_md_fix_section(source_label))
+    return "\n".join(lines) + "\n"
+
+
+def _write_reports(issues: list[dict], summary: dict) -> None:
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    REPORT_JSON.write_text(json.dumps({"summary": summary, "issues": issues}, indent=2) + "\n")
+    REPORT_MD.write_text(_build_md_report(issues, summary))
+
+
+def _print_results(headers_count: int, doc_count: int, issues: list[dict], source_label: str) -> None:
+    print("🔐 CSP exceptions check")
+    print(f"   source: {source_label}")
+    print(f"   CSP exceptions in source: {headers_count}")
+    print(f"   documented in CSP_EXCEPTIONS.md: {doc_count}")
+    print("━" * 60)
+    if not issues:
+        print("✅ No drift detected.")
+        return
+    for i in issues:
+        icon = "❌" if i["severity"] == "error" else "⚠️ "
+        print(f"   {icon} {i['path']}: {i['message']}")
+    print("━" * 60)
+
+
+def run() -> int:
+    source_path, format_name, skip_reason = _resolve_source()
+    if source_path is None:
+        print(f"ℹ  CSP exceptions check: {skip_reason} — skipping.")
+        return 0
+    if skip_reason:
+        print(f"ℹ  CSP exceptions check: {skip_reason} — skipping.")
+        return 0
+    if format_name not in {*headers_adapters.ADAPTERS.keys(), "auto"}:
+        print(
+            f"❌ Unknown headers.format '{format_name}' in .slopstopper.yml. "
+            f"Known: {', '.join(sorted(headers_adapters.ADAPTERS.keys()))} or 'auto'.",
+            file=sys.stderr,
+        )
+        return 2
+    if not EXCEPTIONS_DOC.exists():
+        print("❌ docs/security/CSP_EXCEPTIONS.md not found", file=sys.stderr)
+        return 2
+
+    rules = headers_adapters.parse(source_path, format_name)
+    doc_entries = _parse_exceptions_doc(EXCEPTIONS_DOC)
+    headers_count = len(_headers_exception_map(rules))
+    issues = _compare(rules, doc_entries, str(source_path))
+
+    _write_reports(issues, {
+        "doc_entries": len(doc_entries),
+        "headers_exceptions": headers_count,
+        "source": str(source_path),
+        "format": format_name,
+    })
+    _print_results(headers_count, len(doc_entries), issues, str(source_path))
+
+    if any(i["severity"] == "error" for i in issues):
+        print("❌ Drift detected. See .ss/reports/csp/csp-exceptions-report.md for full details.")
+        return 1
+    if issues:
+        print("⚠️  Warnings only — passing.")
+    return 0

--- a/cli/slopstopper/headers_adapters/__init__.py
+++ b/cli/slopstopper/headers_adapters/__init__.py
@@ -1,0 +1,54 @@
+"""Headers source adapters.
+
+The CSP-drift check (and anything else that needs a list of {path, csp}
+rules) reads its source via one of these adapters. Adopters pick the
+adapter in `.slopstopper.yml` `headers.format`.
+
+Adapter contract:
+
+    def parse(path: pathlib.Path) -> list[dict]:
+        '''Return [{"for": str, "csp": str | None}, ...] for each rule.'''
+
+Path is the file the adopter named in `.slopstopper.yml` `headers.source`.
+Adapters do not validate the file's existence — the caller checks first.
+
+Built-in adapters live as submodules here. The plan-doc convention for
+adopter-supplied custom adapters is to drop a Python module under
+`.ss/overrides/headers_adapters/<name>.py` exporting `parse(path)`; that
+loader is a future PR.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from slopstopper.headers_adapters import cloudflare_adapter, json_adapter
+
+ADAPTERS = {
+    "json": json_adapter.parse,
+    "cloudflare-text": cloudflare_adapter.parse,
+}
+
+
+def detect_format(path: Path) -> str:
+    """Best-effort format detection from a file path.
+
+    Used when `.slopstopper.yml` says `format: auto`. Extension `.json`
+    means the json adapter; anything else (including no extension, like
+    a bare `_headers` file) means the cloudflare-text adapter.
+    """
+    if path.suffix.lower() == ".json":
+        return "json"
+    return "cloudflare-text"
+
+
+def parse(path: Path, format_name: str) -> list[dict]:
+    """Dispatch to the named adapter.
+
+    Raises KeyError if `format_name` is unknown — caller should validate
+    against ADAPTERS.keys() and report a friendly error.
+    """
+    if format_name == "auto":
+        format_name = detect_format(path)
+    adapter = ADAPTERS[format_name]
+    return adapter(path)

--- a/cli/slopstopper/headers_adapters/cloudflare_adapter.py
+++ b/cli/slopstopper/headers_adapters/cloudflare_adapter.py
@@ -1,0 +1,55 @@
+"""Cloudflare _headers text format adapter.
+
+Parses the native Cloudflare _headers file (also used by Netlify) into
+the same {for, csp} shape as the JSON adapter. Format:
+
+    /path-pattern
+      Header-Name: value
+      Another-Header: value
+
+    /other-pattern
+      ...
+
+Path patterns are at column 0; header lines are indented; lines starting
+with `#` are comments. A blank line followed by a new path at column 0
+starts a new block.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def parse(path: Path) -> list[dict]:
+    """Return [{for: str, csp: str | None}, ...] for each rule block."""
+    rules: list[dict] = []
+    current_path: str | None = None
+    current_headers: dict[str, str] = {}
+
+    def flush() -> None:
+        nonlocal current_path, current_headers
+        if current_path is not None:
+            csp = current_headers.get("Content-Security-Policy")
+            rules.append({
+                "for": current_path,
+                "csp": csp if isinstance(csp, str) else None,
+            })
+        current_path = None
+        current_headers = {}
+
+    for raw in path.read_text().splitlines():
+        line = raw.rstrip()
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if not line.startswith((" ", "\t")):
+            flush()
+            current_path = stripped
+            continue
+        if current_path is None or ":" not in stripped:
+            continue
+        name, _, value = stripped.partition(":")
+        current_headers[name.strip()] = value.strip()
+
+    flush()
+    return rules

--- a/cli/slopstopper/headers_adapters/json_adapter.py
+++ b/cli/slopstopper/headers_adapters/json_adapter.py
@@ -1,0 +1,29 @@
+"""JSON header-source adapter.
+
+Parses `[{"for": "/path", "values": {"Header-Name": "value"}}, ...]` —
+the format slopstopper.dev uses in worker/headers.json. A Cloudflare
+Worker reads the same file and applies headers per request.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def parse(path: Path) -> list[dict]:
+    """Return [{for: str, csp: str | None}, ...] for each entry in the JSON array."""
+    raw = json.loads(path.read_text())
+    if not isinstance(raw, list):
+        return []
+    rules: list[dict] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        for_path = entry.get("for")
+        values = entry.get("values") or {}
+        if not isinstance(for_path, str) or not isinstance(values, dict):
+            continue
+        csp = values.get("Content-Security-Policy")
+        rules.append({"for": for_path, "csp": csp if isinstance(csp, str) else None})
+    return rules

--- a/cli/tests/checks/test_csp_exceptions.py
+++ b/cli/tests/checks/test_csp_exceptions.py
@@ -1,0 +1,226 @@
+"""Tests for the hygiene:csp-exceptions check."""
+
+from __future__ import annotations
+
+import json as _json
+from pathlib import Path
+
+from slopstopper.checks import csp_exceptions
+
+
+HEADERS_JSON_TWO_EXCEPTIONS = _json.dumps([
+    {
+        "for": "/*",
+        "values": {"Content-Security-Policy": "default-src 'self'; script-src 'self'"},
+    },
+    {
+        "for": "/discuss",
+        "values": {
+            "Content-Security-Policy":
+                "default-src 'self'; script-src 'self' https://giscus.app; "
+                "frame-src https://giscus.app"
+        },
+    },
+])
+
+
+CSP_DOC_MATCHES = """# CSP Exceptions
+
+Some preamble.
+
+## Exceptions
+
+### `/discuss`
+
+- **Origin allowed:** `https://giscus.app`
+- **Directives added:** `script-src https://giscus.app`, `frame-src https://giscus.app`
+- **Loader SRI:** sha384-real-hash-here
+- **Why:** giscus widget needs it
+- **Approved by:** dataGriff
+- **Data leaving site:** comments
+- **Refresh policy:** check quarterly
+"""
+
+
+def test_extract_csp_origins_picks_only_external():
+    origins = csp_exceptions._extract_csp_origins(
+        "default-src 'self'; script-src 'self' https://giscus.app; frame-src https://giscus.app/"
+    )
+    assert origins == {"https://giscus.app"}
+
+
+def test_extract_csp_origins_ignores_keywords():
+    assert csp_exceptions._extract_csp_origins("default-src 'self' 'unsafe-inline'") == set()
+
+
+def test_parse_exceptions_doc_picks_up_section(isolated_cwd):
+    doc = isolated_cwd / "csp.md"
+    doc.write_text(CSP_DOC_MATCHES)
+    entries = csp_exceptions._parse_exceptions_doc(doc)
+    assert set(entries) == {"/discuss"}
+    e = entries["/discuss"]
+    assert "https://giscus.app" in e["origins"]
+    assert e["sri"] == "sha384-real-hash-here"
+    assert csp_exceptions.REQUIRED_FIELDS.issubset(e["fields_seen"])
+
+
+def test_parse_exceptions_doc_skips_baseline_slashstar(isolated_cwd):
+    doc = isolated_cwd / "csp.md"
+    doc.write_text(
+        "## Exceptions\n\n### `/*`\n- **Origin allowed:** none\n\n### `/x`\n- **Origin allowed:** `https://a.com`\n"
+    )
+    entries = csp_exceptions._parse_exceptions_doc(doc)
+    assert "/*" not in entries
+    assert "/x" in entries
+
+
+def test_parse_exceptions_doc_returns_empty_on_missing_file(isolated_cwd):
+    assert csp_exceptions._parse_exceptions_doc(isolated_cwd / "no-such.md") == {}
+
+
+def test_headers_exception_map_skips_baseline_and_no_csp():
+    rules = [
+        {"for": "/*", "csp": "default-src 'self' https://baseline.example"},
+        {"for": "/none", "csp": None},
+        {"for": "/keep", "csp": "default-src https://other.example"},
+    ]
+    assert csp_exceptions._headers_exception_map(rules) == {
+        "/keep": {"https://other.example"},
+    }
+
+
+def test_sri_issues_warns_on_placeholder():
+    issues = csp_exceptions._sri_issues("/x", "TODO-replace")
+    assert len(issues) == 1
+    assert issues[0]["severity"] == "warn"
+
+
+def test_sri_issues_warns_on_empty():
+    issues = csp_exceptions._sri_issues("/x", "")
+    assert len(issues) == 1
+    assert "no Loader SRI" in issues[0]["message"]
+
+
+def test_sri_issues_silent_on_real_value():
+    assert csp_exceptions._sri_issues("/x", "sha384-real") == []
+
+
+def test_compare_flags_missing_doc_entry():
+    rules = [
+        {"for": "/x", "csp": "default-src https://example.com"},
+    ]
+    issues = csp_exceptions._compare(rules, {}, "test")
+    assert any(i["severity"] == "error" and i["path"] == "/x" for i in issues)
+
+
+def test_compare_flags_stale_doc_entry():
+    issues = csp_exceptions._compare(
+        rules=[],
+        doc_entries={"/orphan": csp_exceptions._new_entry()},
+        source_label="test",
+    )
+    assert any(i["severity"] == "error" and i["path"] == "/orphan" for i in issues)
+
+
+def test_compare_clean_against_matching_doc(isolated_cwd):
+    rules = [
+        {"for": "/discuss", "csp": "script-src 'self' https://giscus.app"},
+    ]
+    doc = isolated_cwd / "csp.md"
+    doc.write_text(CSP_DOC_MATCHES)
+    doc_entries = csp_exceptions._parse_exceptions_doc(doc)
+    issues = csp_exceptions._compare(rules, doc_entries, "test")
+    # No errors; warnings only allowed if SRI is placeholder. SRI is real here.
+    assert all(i["severity"] != "error" for i in issues)
+
+
+def test_overall_status_fail_warn_pass():
+    assert csp_exceptions._overall_status([{"severity": "error", "path": "/x", "message": "m"}]) == "❌ FAIL"
+    assert csp_exceptions._overall_status([{"severity": "warn", "path": "/x", "message": "m"}]) == "⚠️ WARN"
+    assert csp_exceptions._overall_status([]) == "✅ PASS"
+
+
+def test_build_md_report_contains_status_and_source():
+    md = csp_exceptions._build_md_report(
+        [],
+        {"doc_entries": 1, "headers_exceptions": 1, "source": "worker/headers.json", "format": "json"},
+    )
+    assert "✅ PASS" in md
+    assert "worker/headers.json" in md
+    assert "format: `json`" in md
+
+
+def test_resolve_source_skip_when_unset(write_config):
+    write_config("node_version: '20'\n")
+    path, fmt, reason = csp_exceptions._resolve_source()
+    assert path is None
+    assert reason is not None
+
+
+def test_resolve_source_skip_when_missing(write_config):
+    write_config("headers:\n  source: missing/headers.json\n  format: json\n")
+    path, fmt, reason = csp_exceptions._resolve_source()
+    assert path == Path("missing/headers.json")
+    assert "does not exist" in reason
+
+
+def test_resolve_source_ok_when_present(isolated_cwd, write_config):
+    headers = isolated_cwd / "headers.json"
+    headers.write_text("[]")
+    write_config("headers:\n  source: headers.json\n  format: json\n")
+    path, fmt, reason = csp_exceptions._resolve_source()
+    assert path == Path("headers.json")
+    assert fmt == "json"
+    assert reason is None
+
+
+def _seed_csp_doc(text: str = CSP_DOC_MATCHES) -> None:
+    target = Path("docs/security/CSP_EXCEPTIONS.md")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(text)
+
+
+def test_run_skips_gracefully_when_no_source(isolated_cwd, capsys):
+    rc = csp_exceptions.run()
+    assert rc == 0
+    assert "skipping" in capsys.readouterr().out
+
+
+def test_run_returns_two_when_doc_missing(isolated_cwd, write_config, capsys):
+    headers = isolated_cwd / "headers.json"
+    headers.write_text(HEADERS_JSON_TWO_EXCEPTIONS)
+    write_config("headers:\n  source: headers.json\n  format: json\n")
+    rc = csp_exceptions.run()
+    assert rc == 2
+    assert "CSP_EXCEPTIONS.md not found" in capsys.readouterr().err
+
+
+def test_run_returns_two_on_unknown_format(isolated_cwd, write_config, capsys):
+    headers = isolated_cwd / "headers.json"
+    headers.write_text("[]")
+    write_config("headers:\n  source: headers.json\n  format: bogus\n")
+    rc = csp_exceptions.run()
+    assert rc == 2
+    assert "Unknown headers.format" in capsys.readouterr().err
+
+
+def test_run_returns_one_on_drift(isolated_cwd, write_config):
+    headers = isolated_cwd / "headers.json"
+    headers.write_text(HEADERS_JSON_TWO_EXCEPTIONS)
+    write_config("headers:\n  source: headers.json\n  format: json\n")
+    _seed_csp_doc("# CSP Exceptions\n\n## Exceptions\n\n(empty section)\n")
+    rc = csp_exceptions.run()
+    assert rc == 1
+    report = _json.loads(csp_exceptions.REPORT_JSON.read_text())
+    assert any(i["severity"] == "error" for i in report["issues"])
+
+
+def test_run_clean_returns_zero(isolated_cwd, write_config):
+    headers = isolated_cwd / "headers.json"
+    headers.write_text(HEADERS_JSON_TWO_EXCEPTIONS)
+    write_config("headers:\n  source: headers.json\n  format: json\n")
+    _seed_csp_doc()
+    rc = csp_exceptions.run()
+    assert rc == 0
+    report = _json.loads(csp_exceptions.REPORT_JSON.read_text())
+    assert all(i["severity"] != "error" for i in report["issues"])

--- a/cli/tests/test_headers_adapters.py
+++ b/cli/tests/test_headers_adapters.py
@@ -1,0 +1,110 @@
+"""Tests for the headers adapter registry and built-in adapters."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from slopstopper import headers_adapters
+from slopstopper.headers_adapters import cloudflare_adapter, json_adapter
+
+
+# ── JSON adapter ──────────────────────────────────────────────────
+
+
+def test_json_adapter_parses_basic_shape(tmp_path):
+    payload = [
+        {"for": "/foo", "values": {"Content-Security-Policy": "default-src 'self'"}},
+        {"for": "/bar", "values": {"Cache-Control": "no-cache"}},
+    ]
+    path = tmp_path / "headers.json"
+    path.write_text(json.dumps(payload))
+    rules = json_adapter.parse(path)
+    assert rules == [
+        {"for": "/foo", "csp": "default-src 'self'"},
+        {"for": "/bar", "csp": None},
+    ]
+
+
+def test_json_adapter_returns_empty_for_non_list(tmp_path):
+    path = tmp_path / "headers.json"
+    path.write_text(json.dumps({"oops": "object"}))
+    assert json_adapter.parse(path) == []
+
+
+def test_json_adapter_skips_malformed_entries(tmp_path):
+    payload = [
+        {"for": "/good", "values": {"Content-Security-Policy": "x"}},
+        "string-entry",
+        {"missing": "for"},
+        {"for": 123, "values": {}},
+        {"for": "/values-not-dict", "values": "x"},
+    ]
+    path = tmp_path / "headers.json"
+    path.write_text(json.dumps(payload))
+    rules = json_adapter.parse(path)
+    assert rules == [{"for": "/good", "csp": "x"}]
+
+
+# ── Cloudflare _headers adapter ────────────────────────────────────
+
+
+def test_cloudflare_adapter_parses_two_blocks(tmp_path):
+    path = tmp_path / "_headers"
+    path.write_text(
+        "/foo\n"
+        "  Content-Security-Policy: default-src 'self'\n"
+        "  Cache-Control: max-age=60\n"
+        "\n"
+        "/bar\n"
+        "  Cache-Control: no-cache\n"
+    )
+    rules = cloudflare_adapter.parse(path)
+    assert rules == [
+        {"for": "/foo", "csp": "default-src 'self'"},
+        {"for": "/bar", "csp": None},
+    ]
+
+
+def test_cloudflare_adapter_ignores_comments_and_blanks(tmp_path):
+    path = tmp_path / "_headers"
+    path.write_text(
+        "# top comment\n"
+        "\n"
+        "/x\n"
+        "  # indented comment lines are skipped\n"
+        "  Content-Security-Policy: x\n"
+    )
+    assert cloudflare_adapter.parse(path) == [{"for": "/x", "csp": "x"}]
+
+
+def test_cloudflare_adapter_handles_tab_indent(tmp_path):
+    path = tmp_path / "_headers"
+    path.write_text("/x\n\tContent-Security-Policy: tabbed\n")
+    assert cloudflare_adapter.parse(path) == [{"for": "/x", "csp": "tabbed"}]
+
+
+# ── Registry / dispatcher ─────────────────────────────────────────
+
+
+def test_detect_format_json_for_json_extension(tmp_path):
+    assert headers_adapters.detect_format(tmp_path / "x.json") == "json"
+
+
+def test_detect_format_cloudflare_for_anything_else(tmp_path):
+    assert headers_adapters.detect_format(tmp_path / "_headers") == "cloudflare-text"
+    assert headers_adapters.detect_format(tmp_path / "x.toml") == "cloudflare-text"
+
+
+def test_parse_auto_dispatches_by_extension(tmp_path):
+    path = tmp_path / "h.json"
+    path.write_text(json.dumps([{"for": "/", "values": {}}]))
+    rules = headers_adapters.parse(path, "auto")
+    assert rules == [{"for": "/", "csp": None}]
+
+
+def test_parse_unknown_format_raises_key_error(tmp_path):
+    with pytest.raises(KeyError):
+        headers_adapters.parse(tmp_path / "x", "bogus-format")


### PR DESCRIPTION
## Summary

Sixth check ported — includes the **headers-adapter pluggability seam** as an importable subpackage (`slopstopper.headers_adapters`). Same `ADAPTERS` registry + `parse()` dispatcher contract as the existing `.ss/scripts/headers_adapters/`.

The plan-doc convention for adopter-supplied custom adapters (load `.py` modules from `.ss/overrides/headers_adapters/` at runtime) is left for a follow-up PR — this one focuses on lift-and-shift of the existing surface so parity is provable.

## What lands

- `cli/slopstopper/headers_adapters/` — built-in `json` and `cloudflare-text` adapters lifted verbatim.
- `cli/slopstopper/checks/csp_exceptions.py` — full port of `check-csp-exceptions.py`. Reads `headers.source` + `headers.format` from `.slopstopper.yml`, runs the configured adapter, parses `docs/security/CSP_EXCEPTIONS.md`, compares, writes both JSON + MD reports.
- 32 new tests; total CLI test count: **130**.
- Registered as `hygiene:csp-exceptions`.

## Parity

Both JSON and MD reports diff **byte-identical** against bash output — neither carries a timestamp.

## Verified locally

```
$ task -t cli/Taskfile.yml test
130 passed in 0.08s

$ task -t cli/Taskfile.yml parity
=== hygiene-docs-size ===          ✅
=== hygiene-entry-files ===        ✅
=== hygiene-docs-structure ===     ✅
=== hygiene-docs-accuracy ===      ✅
=== hygiene-complexity ===         ✅
=== hygiene-csp-exceptions ===     ✅
All parity checks passed.
```

## Test plan

- [x] `task -t cli/Taskfile.yml test` — 130 tests green
- [x] `task -t cli/Taskfile.yml parity` — all six checks byte-identical
- [x] CCN ≤ 10 across cli/slopstopper/
- [ ] CI: pytest job green
- [ ] CI: parity job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)