### PR TITLE
feat(cli): port security:sast as eighth CLI check (semgrep wrapper)

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -41,6 +41,7 @@ on:
       - '.ss/scripts/check-csp-exceptions.py'
       - '.ss/scripts/headers_adapters/**'
       - '.ss/scripts/generate-secrets-md.py'
+      - '.ss/scripts/generate-sast-md.py'
   push:
     branches: [ main ]
     paths:
@@ -57,6 +58,7 @@ on:
       - '.ss/scripts/check-csp-exceptions.py'
       - '.ss/scripts/headers_adapters/**'
       - '.ss/scripts/generate-secrets-md.py'
+      - '.ss/scripts/generate-sast-md.py'
   workflow_dispatch:
 
 permissions:

--- a/cli/Taskfile.yml
+++ b/cli/Taskfile.yml
@@ -194,6 +194,18 @@ tasks:
           ".ss/reports/secrets/secrets-report.json" \
           ".ss/reports/secrets/secrets-report.md"
 
+        # security:sast — only the MD report is parity-diffed. semgrep's
+        # JSON output includes per-run timing data (total_time,
+        # max_memory_bytes, profiling_times…) that is naturally
+        # non-deterministic between back-to-back invocations. The MD is
+        # derived from `results` and `errors`, the security-meaningful
+        # fields, so it provides the parity signal.
+        check_parity \
+          "security-sast" \
+          "task ss:security:sast" \
+          "cli/.venv/bin/slopstopper run security:sast" \
+          ".ss/reports/sast/sast-report.md"
+
         echo ""
         if [ "$FAILED" -eq 0 ]; then
           echo "All parity checks passed."

--- a/cli/slopstopper/checks/__init__.py
+++ b/cli/slopstopper/checks/__init__.py
@@ -11,6 +11,7 @@ from slopstopper.checks import (
     docs_size,
     docs_structure,
     entry_files,
+    sast,
     secrets,
 )
 
@@ -21,5 +22,6 @@ REGISTRY: dict[str, Callable[[], int]] = {
     "hygiene:docs-size": docs_size.run,
     "hygiene:docs-structure": docs_structure.run,
     "hygiene:entry-files": entry_files.run,
+    "security:sast": sast.run,
     "security:secrets": secrets.run,
 }

--- a/cli/slopstopper/checks/sast.py
+++ b/cli/slopstopper/checks/sast.py
@@ -1,0 +1,209 @@
+"""Static Application Security Testing (Semgrep wrapper).
+
+Ports the bash security:sast flow:
+
+  task sast:check-tool          (installs semgrep if missing)
+  + semgrep --config=auto --json --output=... --exclude=node_modules
+            --exclude=.git .
+  + python3 .ss/scripts/generate-sast-md.py
+
+into one self-contained check. Subprocess-invokes semgrep — same
+licensing-boundary pattern as complexity (lizard) and secrets
+(gitleaks). The boundary matters MORE here: Semgrep OSS is LGPL-2.1,
+not MIT/Apache. `import semgrep` would drag LGPL contagion into the
+slopstopper-cli MIT contract. Subprocess invocation keeps it on the
+adopter's side.
+
+Exit codes:
+  0 — analysis completed
+  1 — semgrep is not installed
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPORT_DIR = Path(".ss/reports/sast")
+REPORT_JSON = REPORT_DIR / "sast-report.json"
+REPORT_MD = REPORT_DIR / "sast-report.md"
+
+_INSTALL_HELP = (
+    "❌ semgrep is not installed.\n"
+    "Install with:\n"
+    "  pip3 install --user semgrep\n"
+    "  brew install semgrep\n"
+    "More: https://semgrep.dev/docs/getting-started/quickstart-oss"
+)
+
+
+def _semgrep_available() -> bool:
+    return shutil.which("semgrep") is not None
+
+
+def _run_semgrep() -> None:
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            "semgrep",
+            "--config=auto",
+            "--json",
+            f"--output={REPORT_JSON}",
+            "--exclude=node_modules",
+            "--exclude=.git",
+            ".",
+        ],
+        check=False,
+    )
+
+
+def _read_data() -> dict:
+    if not REPORT_JSON.exists():
+        return {"results": [], "errors": []}
+    try:
+        return json.loads(REPORT_JSON.read_text())
+    except json.JSONDecodeError:
+        return {"results": [], "errors": []}
+
+
+def _categorize_findings(results: list[dict]) -> tuple[list[dict], list[dict]]:
+    errors: list[dict] = []
+    warnings: list[dict] = []
+    for finding in results:
+        severity = finding.get("extra", {}).get("severity", "").upper()
+        if severity == "ERROR":
+            errors.append(finding)
+        else:
+            warnings.append(finding)
+    return errors, warnings
+
+
+def _format_finding_row(finding: dict) -> str:
+    check_id = finding.get("check_id", "unknown")
+    path = finding.get("path", "unknown")
+    start_line = finding.get("start", {}).get("line", "?")
+    message = finding.get("extra", {}).get("message", "").replace("\n", " ").strip()
+    severity = finding.get("extra", {}).get("severity", "unknown")
+    location = f"`{path}:{start_line}`"
+    truncated = (message[:77] + "...") if len(message) > 80 else message
+    return f"| {check_id} | {severity} | {location} | {truncated} |"
+
+
+def _format_findings_section(findings: list[dict], section_title: str, icon: str) -> str:
+    if not findings:
+        return ""
+    out = f"## {icon} {section_title}\n\n"
+    out += "| Rule | Severity | Location | Message |\n"
+    out += "|------|----------|----------|---------|\n"
+    for finding in findings:
+        out += _format_finding_row(finding) + "\n"
+    out += "\n"
+    return out
+
+
+def _collect_parsing_errors(errors: list[dict]) -> dict[str, list]:
+    parsing_error_files: dict[str, list] = {}
+    for error in errors:
+        error_type = error.get("type", [])
+        if not (isinstance(error_type, list) and error_type and error_type[0] == "PartialParsing"):
+            continue
+        path = error.get("path", "unknown")
+        parsing_error_files.setdefault(path, [])
+        spans = error.get("spans", [])
+        if spans:
+            start_line = spans[0].get("start", {}).get("line", "?")
+            parsing_error_files[path].append(start_line)
+    return parsing_error_files
+
+
+def _format_scan_errors_explanation(errors: list[dict]) -> str:
+    if not errors:
+        return ""
+    out = "### 📋 Scan Errors Explanation\n\n"
+    parsing_error_files = _collect_parsing_errors(errors)
+    if parsing_error_files:
+        out += f"The {len(errors)} warning(s) are **parsing errors in YAML workflow files**, not security issues:\n\n"
+        for path, lines in sorted(parsing_error_files.items()):
+            out += f"- `{path}` (line(s): {', '.join(map(str, lines))})\n"
+        out += "\n"
+        out += "**Why**: Semgrep's YAML analyzer attempts to parse embedded bash scripts in `run:` blocks. "
+        out += "The bash code contains special characters and operators (pipes, redirects) that don't parse as valid YAML syntax.\n\n"
+        out += "**Is this safe to ignore?** ✅ **Yes.** These are only debug/logging scripts—not production code. "
+        out += "The bash syntax is valid and the workflows execute correctly. The SAST scan itself completed successfully with valid results.\n\n"
+    else:
+        out += f"Semgrep reported {len(errors)} error(s) during scanning:\n\n"
+        for i, error in enumerate(errors, 1):
+            msg = error.get("message", "Unknown error").split('\n')[0]
+            out += f"{i}. {msg}\n"
+        out += "\n"
+    return out
+
+
+def _generated_at() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _build_md_report(data: dict) -> str:
+    results = data.get("results", [])
+    errors = data.get("errors", [])
+    error_findings, warning_findings = _categorize_findings(results)
+    total_findings = len(results)
+
+    md = "# SAST Analysis Report\n\n"
+    md += f"**Generated**: {_generated_at()}\n\n"
+    md += "## Summary\n\n"
+
+    if errors:
+        md += f"> ⚠️ Semgrep encountered {len(errors)} scan error(s). Results may be incomplete.\n\n"
+        md += _format_scan_errors_explanation(errors) + "\n"
+
+    if total_findings == 0:
+        md += "## ✅ SAST Status\n\nNo findings detected.\n\n"
+    else:
+        md += "| Metric | Count |\n"
+        md += "|--------|-------|\n"
+        md += f"| Total findings | {total_findings} |\n"
+        md += f"| Errors | {len(error_findings)} |\n"
+        md += f"| Warnings | {len(warning_findings)} |\n\n"
+        md += _format_findings_section(error_findings, "Error Findings", "🔴")
+        md += _format_findings_section(warning_findings, "Warning Findings", "⚠️")
+
+    md += "## Guidelines\n\n"
+    md += "- **Errors**: Must be reviewed and addressed before merging\n"
+    md += "- **Warnings**: Should be reviewed; may indicate potential issues\n"
+    md += "- Run `task sast` locally to reproduce findings\n\n"
+    md += "## Limitations\n\n"
+    md += "This scan uses **Semgrep OSS** (open-source version). The following enterprise features are not available:\n\n"
+    md += "- ✘ **Semgrep Code (SAST)** - Paid feature with advanced security rules\n"
+    md += "- ✘ **Semgrep Supply Chain (SCA)** - Paid feature for dependency vulnerability detection\n\n"
+    md += "To enable these features, [register for a free Semgrep account](https://semgrep.dev/signup) and authenticate with `semgrep login`.\n\n"
+    md += "## More Information\n\n"
+    md += "- Generated by [Semgrep](https://semgrep.dev/) (OSS Edition)\n"
+    md += "- Reports location: `.ss/reports/sast/`\n"
+    md += "  - `sast-report.md` (this file)\n"
+    md += "  - `sast-report.json` (machine-readable)\n"
+    md += "- Learn more: [Semgrep Tiers and Pricing](https://semgrep.dev/pricing)\n"
+    return md
+
+
+def run() -> int:
+    if not _semgrep_available():
+        print(_INSTALL_HELP)
+        return 1
+
+    print("🔍 Running SAST analysis…")
+    _run_semgrep()
+    data = _read_data()
+    REPORT_MD.write_text(_build_md_report(data))
+
+    results = data.get("results", [])
+    if results:
+        errors, warnings = _categorize_findings(results)
+        print(f"⚠️  Found {len(results)} finding(s): {len(errors)} error(s), {len(warnings)} warning(s)")
+    else:
+        print("✅ No findings detected")
+    print(f"📁 Reports saved to: {REPORT_DIR}/")
+    return 0

--- a/cli/tests/checks/test_sast.py
+++ b/cli/tests/checks/test_sast.py
@@ -1,0 +1,200 @@
+"""Tests for the security:sast check (semgrep wrapper)."""
+
+from __future__ import annotations
+
+import json
+
+from slopstopper.checks import sast
+
+
+ERROR_FINDING = {
+    "check_id": "rule.x.error",
+    "path": "src/risky.py",
+    "start": {"line": 42, "col": 1, "offset": 0},
+    "extra": {"severity": "ERROR", "message": "Hardcoded secret detected"},
+}
+
+WARNING_FINDING = {
+    "check_id": "rule.y.warning",
+    "path": "src/other.py",
+    "start": {"line": 99, "col": 1, "offset": 0},
+    "extra": {"severity": "WARNING", "message": "Possibly unsafe call"},
+}
+
+INFO_FINDING = {
+    "check_id": "rule.z.info",
+    "path": "src/log.py",
+    "start": {"line": 5},
+    "extra": {"severity": "INFO", "message": "Informational"},
+}
+
+
+# ── helpers ──────────────────────────────────────────────────────
+
+
+def test_categorize_findings_buckets_by_uppercase_severity():
+    errors, warnings = sast._categorize_findings([ERROR_FINDING, WARNING_FINDING, INFO_FINDING])
+    assert errors == [ERROR_FINDING]
+    # WARNING + INFO both bucket as warnings (non-ERROR)
+    assert warnings == [WARNING_FINDING, INFO_FINDING]
+
+
+def test_format_finding_row_truncates_long_message():
+    long = {
+        **ERROR_FINDING,
+        "extra": {"severity": "ERROR", "message": "x" * 200},
+    }
+    row = sast._format_finding_row(long)
+    assert "..." in row
+    assert "src/risky.py:42" in row
+
+
+def test_format_finding_row_normalises_newlines():
+    multi = {
+        **WARNING_FINDING,
+        "extra": {"severity": "WARNING", "message": "line one\nline two"},
+    }
+    row = sast._format_finding_row(multi)
+    assert "\n" not in row.replace("\n", "", 0)  # row itself is one line
+    # the newline in message was replaced with space
+    assert "line one line two" in row
+
+
+def test_format_findings_section_renders_table():
+    section = sast._format_findings_section([ERROR_FINDING], "Error Findings", "🔴")
+    assert "🔴 Error Findings" in section
+    assert "| Rule | Severity | Location | Message |" in section
+    assert "rule.x.error" in section
+
+
+def test_format_findings_section_empty():
+    assert sast._format_findings_section([], "Heading", "ICON") == ""
+
+
+def test_collect_parsing_errors_picks_yaml_partial_parse():
+    errors = [
+        {
+            "type": ["PartialParsing"],
+            "path": ".github/workflows/x.yml",
+            "spans": [{"start": {"line": 12}}],
+        },
+        {"type": ["OtherType"], "path": "irrelevant"},  # ignored
+    ]
+    out = sast._collect_parsing_errors(errors)
+    assert ".github/workflows/x.yml" in out
+    assert 12 in out[".github/workflows/x.yml"]
+    assert "irrelevant" not in out
+
+
+def test_format_scan_errors_explanation_yaml_path():
+    errors = [
+        {"type": ["PartialParsing"], "path": ".github/workflows/x.yml",
+         "spans": [{"start": {"line": 1}}]},
+        {"type": ["PartialParsing"], "path": ".github/workflows/y.yml",
+         "spans": [{"start": {"line": 2}}]},
+    ]
+    out = sast._format_scan_errors_explanation(errors)
+    assert "parsing errors in YAML workflow files" in out
+    assert "`.github/workflows/x.yml`" in out
+    assert "Safe to ignore" in out or "safe to ignore" in out.lower()
+
+
+def test_format_scan_errors_explanation_generic_path():
+    errors = [{"type": ["Random"], "path": "x.py", "message": "Something broke"}]
+    out = sast._format_scan_errors_explanation(errors)
+    assert "Semgrep reported 1 error(s)" in out
+    assert "Something broke" in out
+
+
+def test_format_scan_errors_explanation_empty():
+    assert sast._format_scan_errors_explanation([]) == ""
+
+
+def test_build_md_report_clean():
+    md = sast._build_md_report({"results": [], "errors": []})
+    assert "✅ SAST Status" in md
+    assert "No findings detected" in md
+
+
+def test_build_md_report_with_findings_counts_severities():
+    md = sast._build_md_report({"results": [ERROR_FINDING, WARNING_FINDING], "errors": []})
+    assert "| Total findings | 2 |" in md
+    assert "| Errors | 1 |" in md
+    assert "| Warnings | 1 |" in md
+    assert "🔴 Error Findings" in md
+    assert "⚠️ Warning Findings" in md
+
+
+def test_build_md_report_includes_errors_summary():
+    md = sast._build_md_report({
+        "results": [],
+        "errors": [{"type": ["PartialParsing"], "path": "x.yml", "spans": [{"start": {"line": 1}}]}],
+    })
+    assert "Semgrep encountered 1 scan error(s)" in md
+    assert "parsing errors in YAML" in md
+
+
+# ── subprocess / runtime ─────────────────────────────────────────
+
+
+def test_semgrep_available_via_which(monkeypatch):
+    monkeypatch.setattr(sast.shutil, "which", lambda _: "/usr/bin/semgrep")
+    assert sast._semgrep_available() is True
+    monkeypatch.setattr(sast.shutil, "which", lambda _: None)
+    assert sast._semgrep_available() is False
+
+
+def test_read_data_returns_empty_when_file_missing(isolated_cwd):
+    assert sast._read_data() == {"results": [], "errors": []}
+
+
+def test_read_data_handles_malformed_json(isolated_cwd):
+    sast.REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    sast.REPORT_JSON.write_text("not json")
+    assert sast._read_data() == {"results": [], "errors": []}
+
+
+def test_read_data_parses_payload(isolated_cwd):
+    sast.REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    sast.REPORT_JSON.write_text(json.dumps({"results": [ERROR_FINDING], "errors": []}))
+    data = sast._read_data()
+    assert data["results"] == [ERROR_FINDING]
+
+
+def test_run_returns_one_when_semgrep_missing(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.setattr(sast, "_semgrep_available", lambda: False)
+    rc = sast.run()
+    assert rc == 1
+    assert "semgrep is not installed" in capsys.readouterr().out
+
+
+def test_run_clean_when_no_results(monkeypatch, isolated_cwd, capsys):
+    def fake_semgrep():
+        sast.REPORT_DIR.mkdir(parents=True, exist_ok=True)
+        sast.REPORT_JSON.write_text(json.dumps({"results": [], "errors": []}))
+
+    monkeypatch.setattr(sast, "_semgrep_available", lambda: True)
+    monkeypatch.setattr(sast, "_run_semgrep", fake_semgrep)
+    rc = sast.run()
+    assert rc == 0
+    assert "✅ No findings detected" in capsys.readouterr().out
+    assert "No findings detected" in sast.REPORT_MD.read_text()
+
+
+def test_run_with_findings_returns_zero_and_writes_report(monkeypatch, isolated_cwd, capsys):
+    def fake_semgrep():
+        sast.REPORT_DIR.mkdir(parents=True, exist_ok=True)
+        sast.REPORT_JSON.write_text(json.dumps(
+            {"results": [ERROR_FINDING, WARNING_FINDING], "errors": []}
+        ))
+
+    monkeypatch.setattr(sast, "_semgrep_available", lambda: True)
+    monkeypatch.setattr(sast, "_run_semgrep", fake_semgrep)
+    rc = sast.run()
+    # Bash flow returns 0 even with findings; gating happens elsewhere.
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Found 2 finding(s)" in out
+    md = sast.REPORT_MD.read_text()
+    assert "rule.x.error" in md
+    assert "rule.y.warning" in md


### PR DESCRIPTION
## Summary

Eighth check. Subprocess-invokes semgrep — the **licensing-boundary discipline matters MORE here** than for previous ports because Semgrep OSS is **LGPL-2.1**, not MIT/Apache. `import semgrep` would drag LGPL contagion into the slopstopper-cli MIT contract. Subprocess invocation keeps it on the adopter's side.

## What lands

- `cli/slopstopper/checks/sast.py` — collapses the bash flow's three sub-tasks (check-tool / analyze / report). Verifies semgrep, prints install help if missing, runs `semgrep --config=auto --json --output=...`, reads JSON, categorises ERROR vs WARNING, renders MD report with all sections lifted from `generate-sast-md.py` (including the YAML-PartialParsing special-case explanation).
- Registered as `security:sast`.
- 19 new tests; total CLI test count: **163**.

## Parity scope: MD only

semgrep's JSON output includes a `time` block (`total_time`, `max_memory_bytes`, `profiling_times`, …) that is naturally non-deterministic between back-to-back invocations. **Full JSON byte-equality is not achievable.**

The MD report is derived from `results` and `errors` — the security-meaningful fields. Both bash and CLI invocations produce byte-identical MD reports (modulo timestamp). Documented in `cli/Taskfile.yml`'s parity entry.

This is the first check where the parity helper diffs only one report (MD); the helper already supports variadic report paths from #190, no change needed.

## Verified locally

```
$ task -t cli/Taskfile.yml test
163 passed in 0.09s

$ task -t cli/Taskfile.yml parity
=== ...all seven previous… ===
=== security-sast ===
  ✅ sast-report.md
✅ security-sast parity OK
All parity checks passed.
```

## Test plan

- [x] `task -t cli/Taskfile.yml test` — 163 tests green
- [x] `task -t cli/Taskfile.yml parity` — all 8 checks
- [x] CCN ≤ 10 across cli/slopstopper/
- [ ] CI: pytest job green
- [ ] CI: parity job green (semgrep auto-installed by bash side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)