### PR TITLE
feat(cli): port security:dependencies as ninth CLI check (trivy wrapper)

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -42,6 +42,7 @@ on:
       - '.ss/scripts/headers_adapters/**'
       - '.ss/scripts/generate-secrets-md.py'
       - '.ss/scripts/generate-sast-md.py'
+      - '.ss/scripts/generate-dependencies-md.py'
   push:
     branches: [ main ]
     paths:
@@ -59,6 +60,7 @@ on:
       - '.ss/scripts/headers_adapters/**'
       - '.ss/scripts/generate-secrets-md.py'
       - '.ss/scripts/generate-sast-md.py'
+      - '.ss/scripts/generate-dependencies-md.py'
   workflow_dispatch:
 
 permissions:

--- a/cli/Taskfile.yml
+++ b/cli/Taskfile.yml
@@ -206,6 +206,17 @@ tasks:
           "cli/.venv/bin/slopstopper run security:sast" \
           ".ss/reports/sast/sast-report.md"
 
+        # security:dependencies — only the MD report is parity-diffed.
+        # trivy's JSON includes CreatedAt, ReportID and ArtifactID that
+        # change every run. The MD is derived from `Results`→
+        # `Vulnerabilities`, the security-meaningful fields, so it
+        # provides the parity signal.
+        check_parity \
+          "security-dependencies" \
+          "task ss:security:vulnerability:all" \
+          "cli/.venv/bin/slopstopper run security:dependencies" \
+          ".ss/reports/dependencies/dependencies-report.md"
+
         echo ""
         if [ "$FAILED" -eq 0 ]; then
           echo "All parity checks passed."

--- a/cli/slopstopper/checks/__init__.py
+++ b/cli/slopstopper/checks/__init__.py
@@ -7,6 +7,7 @@ from typing import Callable
 from slopstopper.checks import (
     complexity,
     csp_exceptions,
+    dependencies,
     docs_accuracy,
     docs_size,
     docs_structure,
@@ -22,6 +23,7 @@ REGISTRY: dict[str, Callable[[], int]] = {
     "hygiene:docs-size": docs_size.run,
     "hygiene:docs-structure": docs_structure.run,
     "hygiene:entry-files": entry_files.run,
+    "security:dependencies": dependencies.run,
     "security:sast": sast.run,
     "security:secrets": secrets.run,
 }

--- a/cli/slopstopper/checks/dependencies.py
+++ b/cli/slopstopper/checks/dependencies.py
@@ -1,0 +1,179 @@
+"""Dependency vulnerability scanning (Trivy wrapper).
+
+Ports the bash security:vulnerability:all flow:
+
+  task vulnerability:all:check-tool   (installs trivy if missing)
+  + trivy fs --format json --output=... --skip-dirs node_modules
+             --skip-dirs .git .
+  + python3 .ss/scripts/generate-dependencies-md.py
+
+into one self-contained check. Subprocess-invokes trivy — same
+licensing-boundary pattern as gitleaks (MIT) and semgrep (LGPL-2.1):
+adopters install the binary themselves, the CLI wheel ships zero
+trivy code. Trivy itself is Apache-2.0 so the boundary is gentler
+than semgrep's, but the discipline is identical.
+
+Exit codes:
+  0 — analysis completed (gating happens at the workflow level)
+  1 — trivy is not installed
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPORT_DIR = Path(".ss/reports/dependencies")
+REPORT_JSON = REPORT_DIR / "dependencies-report.json"
+REPORT_MD = REPORT_DIR / "dependencies-report.md"
+
+_INSTALL_HELP = (
+    "❌ trivy is not installed.\n"
+    "Install with:\n"
+    "  brew install aquasecurity/trivy/trivy     # macOS\n"
+    "  sudo apt-get install trivy                # Debian/Ubuntu (with trivy apt repo)\n"
+    "More: https://trivy.dev/latest/getting-started/installation/"
+)
+
+
+def _trivy_available() -> bool:
+    return shutil.which("trivy") is not None
+
+
+def _run_trivy() -> None:
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            "trivy", "fs",
+            "--format", "json",
+            "--output", str(REPORT_JSON),
+            "--skip-dirs", "node_modules",
+            "--skip-dirs", ".git",
+            ".",
+        ],
+        check=False,
+    )
+
+
+def _read_data() -> dict:
+    if not REPORT_JSON.exists():
+        return {}
+    try:
+        return json.loads(REPORT_JSON.read_text())
+    except json.JSONDecodeError:
+        return {}
+
+
+def _collect_vulnerabilities(data: dict) -> tuple[list[dict], list[dict], list[dict], list[dict]]:
+    critical: list[dict] = []
+    high: list[dict] = []
+    medium: list[dict] = []
+    low: list[dict] = []
+    for result in data.get("Results", []):
+        target = result.get("Target", "unknown")
+        for vuln in result.get("Vulnerabilities", []):
+            entry = {
+                "id": vuln.get("VulnerabilityID", "unknown"),
+                "pkg": vuln.get("PkgName", "unknown"),
+                "installed": vuln.get("InstalledVersion", "?"),
+                "fixed": vuln.get("FixedVersion", "none"),
+                "severity": vuln.get("Severity", "UNKNOWN"),
+                "title": vuln.get("Title", ""),
+                "target": target,
+            }
+            sev = entry["severity"].upper()
+            if sev == "CRITICAL":
+                critical.append(entry)
+            elif sev == "HIGH":
+                high.append(entry)
+            elif sev == "MEDIUM":
+                medium.append(entry)
+            else:
+                low.append(entry)
+    return critical, high, medium, low
+
+
+def _format_vuln_row(v: dict) -> str:
+    title = (v["title"][:57] + "...") if len(v["title"]) > 60 else v["title"]
+    return (
+        f"| {v['id']} | `{v['pkg']}` | {v['installed']} | {v['fixed']} "
+        f"| {v['severity']} | {title} |"
+    )
+
+
+def _format_vuln_section(vulns: list[dict], section_title: str, icon: str) -> str:
+    if not vulns:
+        return ""
+    out = f"## {icon} {section_title}\n\n"
+    out += "| CVE | Package | Installed | Fixed In | Severity | Title |\n"
+    out += "|-----|---------|-----------|----------|----------|-------|\n"
+    for v in vulns:
+        out += _format_vuln_row(v) + "\n"
+    out += "\n"
+    return out
+
+
+def _generated_at() -> str:
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _build_md_report(data: dict) -> str:
+    critical, high, medium, low = _collect_vulnerabilities(data)
+    total = len(critical) + len(high) + len(medium) + len(low)
+
+    md = "# Dependency Vulnerability Report\n\n"
+    md += f"**Generated**: {_generated_at()}\n\n"
+    md += "## Summary\n\n"
+
+    if total == 0:
+        md += "## ✅ Dependencies Status\n\nNo vulnerabilities detected.\n\n"
+    else:
+        md += "| Severity | Count |\n"
+        md += "|----------|-------|\n"
+        md += f"| 🔴 Critical | {len(critical)} |\n"
+        md += f"| 🟠 High | {len(high)} |\n"
+        md += f"| 🟡 Medium | {len(medium)} |\n"
+        md += f"| 🔵 Low | {len(low)} |\n"
+        md += f"| **Total** | **{total}** |\n\n"
+        md += _format_vuln_section(critical, "Critical Vulnerabilities", "🔴")
+        md += _format_vuln_section(high, "High Vulnerabilities", "🟠")
+        md += _format_vuln_section(medium, "Medium Vulnerabilities", "🟡")
+        md += _format_vuln_section(low, "Low Vulnerabilities", "🔵")
+
+    md += "## Guidelines\n\n"
+    md += "- **Critical/High**: Update or replace the vulnerable package before merging\n"
+    md += "- **Medium**: Review and plan remediation\n"
+    md += "- **Low**: Informational — update when convenient\n"
+    md += "- Run `task dependencies` locally to reproduce\n\n"
+    md += "## More Information\n\n"
+    md += "- Generated by [Trivy](https://trivy.dev/)\n"
+    md += "- Reports location: `.ss/reports/dependencies/`\n"
+    md += "  - `dependencies-report.md` (this file)\n"
+    md += "  - `dependencies-report.json` (machine-readable)\n"
+    return md
+
+
+def run() -> int:
+    if not _trivy_available():
+        print(_INSTALL_HELP)
+        return 1
+
+    print("🔍 Scanning dependencies for vulnerabilities…")
+    _run_trivy()
+    data = _read_data()
+    REPORT_MD.write_text(_build_md_report(data))
+
+    critical, high, medium, low = _collect_vulnerabilities(data)
+    total = len(critical) + len(high) + len(medium) + len(low)
+    blocking = len(critical) + len(high)
+    if blocking > 0:
+        print(f"⚠️  Found {blocking} CRITICAL/HIGH vulnerability(ies) (total {total})")
+    elif total > 0:
+        print(f"ℹ️  Found {total} vulnerability(ies) — none CRITICAL/HIGH")
+    else:
+        print("✅ No vulnerabilities detected")
+    print(f"📁 Reports saved to: {REPORT_DIR}/")
+    return 0

--- a/cli/tests/checks/test_dependencies.py
+++ b/cli/tests/checks/test_dependencies.py
@@ -1,0 +1,202 @@
+"""Tests for the security:dependencies check (trivy wrapper)."""
+
+from __future__ import annotations
+
+import json
+
+from slopstopper.checks import dependencies
+
+
+CRITICAL_VULN = {
+    "VulnerabilityID": "CVE-2024-0001",
+    "PkgName": "left-pad",
+    "InstalledVersion": "1.0.0",
+    "FixedVersion": "1.0.1",
+    "Severity": "CRITICAL",
+    "Title": "Remote code execution",
+}
+
+HIGH_VULN = {
+    "VulnerabilityID": "CVE-2024-0002",
+    "PkgName": "lodash",
+    "InstalledVersion": "4.17.20",
+    "FixedVersion": "4.17.21",
+    "Severity": "HIGH",
+    "Title": "Prototype pollution",
+}
+
+MEDIUM_VULN = {
+    "VulnerabilityID": "CVE-2024-0003",
+    "PkgName": "axios",
+    "InstalledVersion": "0.21.0",
+    "FixedVersion": "0.21.4",
+    "Severity": "MEDIUM",
+    "Title": "SSRF",
+}
+
+LOW_VULN = {
+    "VulnerabilityID": "CVE-2024-0004",
+    "PkgName": "minimist",
+    "InstalledVersion": "1.2.0",
+    "FixedVersion": "1.2.6",
+    "Severity": "LOW",
+    "Title": "Minor issue",
+}
+
+
+def _trivy_payload(*vulns: dict, target: str = "package-lock.json") -> dict:
+    return {"Results": [{"Target": target, "Vulnerabilities": list(vulns)}]}
+
+
+# ── helpers ──────────────────────────────────────────────────────
+
+
+def test_collect_vulnerabilities_buckets_by_severity():
+    data = _trivy_payload(CRITICAL_VULN, HIGH_VULN, MEDIUM_VULN, LOW_VULN)
+    critical, high, medium, low = dependencies._collect_vulnerabilities(data)
+    assert [v["id"] for v in critical] == ["CVE-2024-0001"]
+    assert [v["id"] for v in high] == ["CVE-2024-0002"]
+    assert [v["id"] for v in medium] == ["CVE-2024-0003"]
+    assert [v["id"] for v in low] == ["CVE-2024-0004"]
+
+
+def test_collect_vulnerabilities_unknown_severity_lands_in_low():
+    odd = {**HIGH_VULN, "Severity": "UNKNOWN"}
+    critical, high, medium, low = dependencies._collect_vulnerabilities(_trivy_payload(odd))
+    assert critical == [] and high == [] and medium == []
+    assert len(low) == 1
+
+
+def test_collect_vulnerabilities_missing_fields_defaults():
+    data = _trivy_payload({"Severity": "HIGH"})
+    _, high, _, _ = dependencies._collect_vulnerabilities(data)
+    assert high[0]["id"] == "unknown"
+    assert high[0]["pkg"] == "unknown"
+    assert high[0]["installed"] == "?"
+    assert high[0]["fixed"] == "none"
+
+
+def test_collect_vulnerabilities_empty_data():
+    assert dependencies._collect_vulnerabilities({}) == ([], [], [], [])
+    assert dependencies._collect_vulnerabilities({"Results": []}) == ([], [], [], [])
+
+
+def test_format_vuln_row_truncates_long_title():
+    long = {
+        **dependencies._collect_vulnerabilities(_trivy_payload(HIGH_VULN))[1][0],
+        "title": "x" * 200,
+    }
+    row = dependencies._format_vuln_row(long)
+    assert "..." in row
+    assert "lodash" in row
+
+
+def test_format_vuln_section_renders_table():
+    vulns = dependencies._collect_vulnerabilities(_trivy_payload(CRITICAL_VULN))[0]
+    section = dependencies._format_vuln_section(vulns, "Critical Vulnerabilities", "🔴")
+    assert "🔴 Critical Vulnerabilities" in section
+    assert "| CVE | Package | Installed | Fixed In | Severity | Title |" in section
+    assert "CVE-2024-0001" in section
+
+
+def test_format_vuln_section_empty():
+    assert dependencies._format_vuln_section([], "Heading", "ICON") == ""
+
+
+def test_build_md_report_clean():
+    md = dependencies._build_md_report({"Results": []})
+    assert "✅ Dependencies Status" in md
+    assert "No vulnerabilities detected" in md
+
+
+def test_build_md_report_with_findings_counts_by_severity():
+    data = _trivy_payload(CRITICAL_VULN, HIGH_VULN, MEDIUM_VULN, LOW_VULN)
+    md = dependencies._build_md_report(data)
+    assert "| 🔴 Critical | 1 |" in md
+    assert "| 🟠 High | 1 |" in md
+    assert "| 🟡 Medium | 1 |" in md
+    assert "| 🔵 Low | 1 |" in md
+    assert "| **Total** | **4** |" in md
+    assert "🔴 Critical Vulnerabilities" in md
+    assert "🟠 High Vulnerabilities" in md
+
+
+# ── subprocess / runtime ─────────────────────────────────────────
+
+
+def test_trivy_available_via_which(monkeypatch):
+    monkeypatch.setattr(dependencies.shutil, "which", lambda _: "/usr/bin/trivy")
+    assert dependencies._trivy_available() is True
+    monkeypatch.setattr(dependencies.shutil, "which", lambda _: None)
+    assert dependencies._trivy_available() is False
+
+
+def test_read_data_returns_empty_when_file_missing(isolated_cwd):
+    assert dependencies._read_data() == {}
+
+
+def test_read_data_handles_malformed_json(isolated_cwd):
+    dependencies.REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    dependencies.REPORT_JSON.write_text("not json")
+    assert dependencies._read_data() == {}
+
+
+def test_read_data_parses_payload(isolated_cwd):
+    dependencies.REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    dependencies.REPORT_JSON.write_text(json.dumps(_trivy_payload(HIGH_VULN)))
+    data = dependencies._read_data()
+    assert data["Results"][0]["Target"] == "package-lock.json"
+
+
+def test_run_returns_one_when_trivy_missing(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.setattr(dependencies, "_trivy_available", lambda: False)
+    rc = dependencies.run()
+    assert rc == 1
+    assert "trivy is not installed" in capsys.readouterr().out
+
+
+def test_run_clean_when_no_vulns(monkeypatch, isolated_cwd, capsys):
+    def fake_trivy():
+        dependencies.REPORT_DIR.mkdir(parents=True, exist_ok=True)
+        dependencies.REPORT_JSON.write_text(json.dumps({"Results": []}))
+
+    monkeypatch.setattr(dependencies, "_trivy_available", lambda: True)
+    monkeypatch.setattr(dependencies, "_run_trivy", fake_trivy)
+    rc = dependencies.run()
+    assert rc == 0
+    assert "✅ No vulnerabilities detected" in capsys.readouterr().out
+    assert "No vulnerabilities detected" in dependencies.REPORT_MD.read_text()
+
+
+def test_run_with_blocking_vulns_returns_zero(monkeypatch, isolated_cwd, capsys):
+    def fake_trivy():
+        dependencies.REPORT_DIR.mkdir(parents=True, exist_ok=True)
+        dependencies.REPORT_JSON.write_text(
+            json.dumps(_trivy_payload(CRITICAL_VULN, HIGH_VULN, MEDIUM_VULN))
+        )
+
+    monkeypatch.setattr(dependencies, "_trivy_available", lambda: True)
+    monkeypatch.setattr(dependencies, "_run_trivy", fake_trivy)
+    rc = dependencies.run()
+    # Bash flow doesn't gate at this layer; gating happens in CI.
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Found 2 CRITICAL/HIGH" in out
+    md = dependencies.REPORT_MD.read_text()
+    assert "CVE-2024-0001" in md
+    assert "CVE-2024-0002" in md
+
+
+def test_run_with_only_medium_or_low(monkeypatch, isolated_cwd, capsys):
+    def fake_trivy():
+        dependencies.REPORT_DIR.mkdir(parents=True, exist_ok=True)
+        dependencies.REPORT_JSON.write_text(
+            json.dumps(_trivy_payload(MEDIUM_VULN, LOW_VULN))
+        )
+
+    monkeypatch.setattr(dependencies, "_trivy_available", lambda: True)
+    monkeypatch.setattr(dependencies, "_run_trivy", fake_trivy)
+    rc = dependencies.run()
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Found 2 vulnerability(ies) — none CRITICAL/HIGH" in out


### PR DESCRIPTION
## Summary

- Ports the bash `security:vulnerability:all` flow (`trivy fs` + `generate-dependencies-md.py`) into `cli/slopstopper/checks/dependencies.py`, registered as `security:dependencies`.
- Subprocess-invokes the `trivy` binary — adopters install trivy themselves (Apache-2.0). The slopstopper-cli wheel ships zero trivy code.
- Same MD-only parity strategy as SAST: trivy's JSON has `CreatedAt`, `ReportID`, `ArtifactID` that change every run. The MD is derived from `Results`→`Vulnerabilities`, the security-meaningful fields, so it provides the parity signal.

## Status

| | Check | Tests | Parity |
| --- | --- | --- | --- |
| 1 | `hygiene:docs-size` | ✅ | ✅ md |
| 2 | `hygiene:entry-files` | ✅ | ✅ md + json |
| 3 | `hygiene:docs-structure` | ✅ | ✅ md + json |
| 4 | `hygiene:docs-accuracy` | ✅ | ✅ md + json |
| 5 | `hygiene:complexity` | ✅ | ✅ md + csv |
| 6 | `hygiene:csp-exceptions` | ✅ | ✅ md + json |
| 7 | `security:secrets` | ✅ | ✅ md + json |
| 8 | `security:sast` | ✅ | ✅ md (JSON volatile) |
| 9 | `security:dependencies` | ✅ | ✅ md (JSON volatile) |

180 tests pass. 9 parity checks green locally.

## Remaining

- `security:dast` (OWASP ZAP via Docker — most complex)
- reliability suite (accessibility, seo, broken-links, smoke, core-web-vitals — npm tooling)

## Test plan

- [x] `task -t cli/Taskfile.yml test` — 180 passed
- [x] `task -t cli/Taskfile.yml parity` — all 9 checks green
- [ ] CI `pytest` job green
- [ ] CI `bash↔cli parity` job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)