### PR TITLE
feat(cli): port security:dast as tenth CLI check (OWASP ZAP wrapper)

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -43,6 +43,7 @@ on:
       - '.ss/scripts/generate-secrets-md.py'
       - '.ss/scripts/generate-sast-md.py'
       - '.ss/scripts/generate-dependencies-md.py'
+      - '.ss/scripts/generate-dast-md.py'
   push:
     branches: [ main ]
     paths:
@@ -61,6 +62,7 @@ on:
       - '.ss/scripts/generate-secrets-md.py'
       - '.ss/scripts/generate-sast-md.py'
       - '.ss/scripts/generate-dependencies-md.py'
+      - '.ss/scripts/generate-dast-md.py'
   workflow_dispatch:
 
 permissions:

--- a/cli/Taskfile.yml
+++ b/cli/Taskfile.yml
@@ -217,6 +217,20 @@ tasks:
           "cli/.venv/bin/slopstopper run security:dependencies" \
           ".ss/reports/dependencies/dependencies-report.md"
 
+        # security:dast — intentionally NOT parity-tested. ZAP baseline
+        # scans actively probe a live server and the resulting alerts
+        # are non-deterministic between runs (probe ordering, instance
+        # counts, even alert presence for low-confidence rules), so a
+        # byte-diff between two consecutive scans would fail even at
+        # 100% logical parity. Each scan is also ~1m17s of Docker time
+        # — running both back-to-back costs more than the signal is
+        # worth. The MD generation logic in
+        # cli/slopstopper/checks/dast.py is a straight lift of
+        # .ss/scripts/generate-dast-md.py and is exhaustively unit-
+        # tested in cli/tests/checks/test_dast.py. Trust the unit tests
+        # for the build_md_report layer; trust the bash workflow for
+        # the live ZAP behaviour.
+
         echo ""
         if [ "$FAILED" -eq 0 ]; then
           echo "All parity checks passed."

--- a/cli/slopstopper/checks/__init__.py
+++ b/cli/slopstopper/checks/__init__.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Optional
 
 from slopstopper.checks import (
     complexity,
     csp_exceptions,
+    dast,
     dependencies,
     docs_accuracy,
     docs_size,
@@ -16,13 +17,14 @@ from slopstopper.checks import (
     secrets,
 )
 
-REGISTRY: dict[str, Callable[[], int]] = {
+REGISTRY: dict[str, Callable[[Optional[list[str]]], int]] = {
     "hygiene:complexity": complexity.run,
     "hygiene:csp-exceptions": csp_exceptions.run,
     "hygiene:docs-accuracy": docs_accuracy.run,
     "hygiene:docs-size": docs_size.run,
     "hygiene:docs-structure": docs_structure.run,
     "hygiene:entry-files": entry_files.run,
+    "security:dast": dast.run,
     "security:dependencies": dependencies.run,
     "security:sast": sast.run,
     "security:secrets": secrets.run,

--- a/cli/slopstopper/checks/complexity.py
+++ b/cli/slopstopper/checks/complexity.py
@@ -197,7 +197,7 @@ def _build_md_report(rows: list[tuple]) -> str:
     return md
 
 
-def run() -> int:
+def run(_args: list[str] | None = None) -> int:
     if not _lizard_available():
         print(_LIZARD_INSTALL_HELP)
         return 1

--- a/cli/slopstopper/checks/csp_exceptions.py
+++ b/cli/slopstopper/checks/csp_exceptions.py
@@ -270,7 +270,7 @@ def _print_results(headers_count: int, doc_count: int, issues: list[dict], sourc
     print("━" * 60)
 
 
-def run() -> int:
+def run(_args: list[str] | None = None) -> int:
     source_path, format_name, skip_reason = _resolve_source()
     if source_path is None:
         print(f"ℹ  CSP exceptions check: {skip_reason} — skipping.")

--- a/cli/slopstopper/checks/dast.py
+++ b/cli/slopstopper/checks/dast.py
@@ -1,0 +1,265 @@
+"""Dynamic Application Security Testing (OWASP ZAP baseline scan).
+
+Ports the bash security:dast flow:
+
+  task dast:check-tool          (verifies Docker is on PATH)
+  + docker run --rm
+        -v $PWD/.ss/reports/dast:/zap/wrk/:rw
+        [-v $PWD/.zap:/zap/wrk/.zap:ro]
+        ghcr.io/zaproxy/zaproxy:stable
+        zap-baseline.py -t <TARGET> -J dast-report.json -I
+        [-c .zap/rules.tsv]
+  + python3 .ss/scripts/generate-dast-md.py
+
+into one self-contained check. The only check today that takes a CLI
+arg (`--target URL`); plumbed through `slopstopper run security:dast
+-- --target https://example.com`.
+
+ZAP is Apache-2.0. Subprocess-invokes `docker` to run the official
+ZAP image — slopstopper-cli wheel ships zero ZAP code.
+
+Exit codes:
+  0 — analysis completed (gating happens at the workflow level)
+  1 — Docker is not installed, or nothing listening on a localhost target
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import time
+from datetime import datetime
+from pathlib import Path
+
+REPORT_DIR = Path(".ss/reports/dast")
+REPORT_JSON = REPORT_DIR / "dast-report.json"
+REPORT_MD = REPORT_DIR / "dast-report.md"
+
+DEFAULT_TARGET = "http://localhost:8080"
+
+RISK_LABELS = {
+    "3": "High",
+    "2": "Medium",
+    "1": "Low",
+    "0": "Informational",
+}
+
+
+def _parse_args(args: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="slopstopper run security:dast", add_help=False)
+    p.add_argument("--target", default=DEFAULT_TARGET)
+    p.add_argument("--help", "-h", action="help")
+    return p.parse_args(args or [])
+
+
+def _docker_available() -> bool:
+    return shutil.which("docker") is not None
+
+
+def _target_is_localhost(target: str) -> bool:
+    return "localhost" in target or target.startswith("http://127.0.0.1")
+
+
+def _localhost_responding(url: str = "http://localhost:8080") -> bool:
+    try:
+        subprocess.run(
+            ["curl", "-sf", url],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+        return True
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+
+
+def _start_local_server() -> subprocess.Popen | None:
+    if not Path("server.js").exists():
+        return None
+    proc = subprocess.Popen(
+        ["node", "server.js"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    for _ in range(30):
+        if _localhost_responding():
+            print("✅ Server is ready")
+            return proc
+        time.sleep(1)
+    proc.terminate()
+    print("❌ Server failed to start within 30 seconds")
+    return None
+
+
+def _docker_host_target(target: str) -> str:
+    """Translate a localhost URL to one routable from inside the ZAP container.
+
+    Linux Docker uses the bridge gateway 172.17.0.1; Docker Desktop on
+    macOS (and Windows) routes via the magic host.docker.internal name.
+    """
+    if platform.system() == "Darwin":
+        host = "host.docker.internal"
+    else:
+        host = "172.17.0.1"
+    m = re.match(r"https?://[^:/]+:?(\d+)?", target)
+    port = (m.group(1) if m else None) or "8080"
+    return f"http://{host}:{port}"
+
+
+def _run_zap(target: str) -> None:
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    os.chmod(REPORT_DIR, 0o777)
+    cmd = [
+        "docker", "run", "--rm",
+        "-v", f"{Path.cwd() / REPORT_DIR}:/zap/wrk/:rw",
+    ]
+    rules_path = Path(".zap/rules.tsv")
+    if rules_path.exists():
+        cmd += ["-v", f"{Path.cwd() / '.zap'}:/zap/wrk/.zap:ro"]
+    cmd += [
+        "ghcr.io/zaproxy/zaproxy:stable",
+        "zap-baseline.py",
+        "-t", target,
+        "-J", "dast-report.json",
+        "-I",
+    ]
+    if rules_path.exists():
+        cmd += ["-c", ".zap/rules.tsv"]
+    subprocess.run(cmd, check=False)
+
+
+def _read_data() -> dict:
+    if not REPORT_JSON.exists():
+        return {}
+    try:
+        return json.loads(REPORT_JSON.read_text())
+    except json.JSONDecodeError:
+        return {}
+
+
+def _collect_alerts(data: dict) -> dict[str, list[dict]]:
+    alerts_by_risk: dict[str, list[dict]] = {"3": [], "2": [], "1": [], "0": []}
+    for site in data.get("site", []):
+        for alert in site.get("alerts", []):
+            riskcode = str(alert.get("riskcode", "0"))
+            entry = {
+                "name": alert.get("name", alert.get("alert", "unknown")),
+                "riskcode": riskcode,
+                "confidence": alert.get("confidence", "?"),
+                "desc": alert.get("desc", "").replace("\n", " ").strip(),
+                "instances": len(alert.get("instances", [])),
+                "solution": alert.get("solution", "").replace("\n", " ").strip(),
+            }
+            bucket = alerts_by_risk.get(riskcode, alerts_by_risk["0"])
+            bucket.append(entry)
+    return alerts_by_risk
+
+
+def _format_alert_row(alert: dict) -> str:
+    name = alert["name"]
+    risk = RISK_LABELS.get(alert["riskcode"], "Unknown")
+    instances = alert["instances"]
+    desc = (alert["desc"][:77] + "...") if len(alert["desc"]) > 80 else alert["desc"]
+    return f"| {name} | {risk} | {instances} | {desc} |"
+
+
+def _format_alert_section(alerts: list[dict], section_title: str, icon: str) -> str:
+    if not alerts:
+        return ""
+    out = f"## {icon} {section_title}\n\n"
+    out += "| Alert | Risk | Instances | Description |\n"
+    out += "|-------|------|-----------|-------------|\n"
+    for alert in alerts:
+        out += _format_alert_row(alert) + "\n"
+    out += "\n"
+    return out
+
+
+def _generated_at() -> str:
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _build_md_report(data: dict) -> str:
+    alerts = _collect_alerts(data)
+    high, medium, low, info = alerts["3"], alerts["2"], alerts["1"], alerts["0"]
+    total = sum(len(v) for v in alerts.values())
+
+    md = "# DAST Analysis Report\n\n"
+    md += f"**Generated**: {_generated_at()}\n\n"
+    md += "## Summary\n\n"
+
+    if total == 0:
+        md += "## ✅ DAST Status\n\nNo alerts detected.\n\n"
+    else:
+        md += "| Risk Level | Count |\n"
+        md += "|------------|-------|\n"
+        md += f"| 🔴 High | {len(high)} |\n"
+        md += f"| 🟡 Medium | {len(medium)} |\n"
+        md += f"| 🔵 Low | {len(low)} |\n"
+        md += f"| ℹ️ Informational | {len(info)} |\n"
+        md += f"| **Total** | **{total}** |\n\n"
+        md += _format_alert_section(high, "High Risk Alerts", "🔴")
+        md += _format_alert_section(medium, "Medium Risk Alerts", "🟡")
+        md += _format_alert_section(low, "Low Risk Alerts", "🔵")
+        md += _format_alert_section(info, "Informational Alerts", "ℹ️")
+
+    md += "## Guidelines\n\n"
+    md += "- **High**: Must be addressed before merging\n"
+    md += "- **Medium**: Should be reviewed and addressed\n"
+    md += "- **Low**: Informational — review when time allows\n"
+    md += "- Run `task dast -- <url>` locally to reproduce\n\n"
+    md += "## More Information\n\n"
+    md += "- Generated by [OWASP ZAP](https://www.zaproxy.org/)\n"
+    md += "- Reports location: `.ss/reports/dast/`\n"
+    md += "  - `dast-report.md` (this file)\n"
+    md += "  - `dast-report.json` (machine-readable)\n"
+    return md
+
+
+def run(args: list[str] | None = None) -> int:
+    if not _docker_available():
+        print("❌ Docker is required to run OWASP ZAP")
+        print("Please install Docker: https://docs.docker.com/get-docker/")
+        return 1
+
+    parsed = _parse_args(args)
+    target = parsed.target
+
+    print(f"🌐 Running DAST analysis against {target}…")
+
+    server_proc: subprocess.Popen | None = None
+    try:
+        if _target_is_localhost(target):
+            if not _localhost_responding():
+                server_proc = _start_local_server()
+                if server_proc is None and not _localhost_responding():
+                    print(f"❌ Nothing listening on {target} and no server.js to start.")
+                    print("   Start your app's server first, then re-run.")
+                    return 1
+            target = _docker_host_target(target)
+            print(f"📍 Using Docker-compatible target: {target}")
+
+        _run_zap(target)
+        data = _read_data()
+        REPORT_MD.write_text(_build_md_report(data))
+
+        alerts = _collect_alerts(data)
+        blocking = len(alerts["3"]) + len(alerts["2"])
+        total = sum(len(v) for v in alerts.values())
+        if blocking > 0:
+            print(f"⚠️  Found {blocking} high/medium alert(s) (total {total})")
+        elif total > 0:
+            print(f"ℹ️  Found {total} alert(s) — none high/medium")
+        else:
+            print("✅ No alerts detected")
+        print(f"📁 Reports saved to: {REPORT_DIR}/")
+        return 0
+    finally:
+        if server_proc is not None:
+            server_proc.terminate()

--- a/cli/slopstopper/checks/dast.py
+++ b/cli/slopstopper/checks/dast.py
@@ -222,43 +222,59 @@ def _build_md_report(data: dict) -> str:
     return md
 
 
+def _prepare_localhost_target(target: str) -> tuple[str | None, subprocess.Popen | None]:
+    """For a localhost target, ensure a server is running and rewrite the URL
+    to be reachable from inside the ZAP container.
+
+    Returns (rewritten_target, owned_server_proc). If a server we don't own
+    was already listening, owned_server_proc is None. If we can't bring a
+    server up, returns (None, None).
+    """
+    server_proc: subprocess.Popen | None = None
+    if not _localhost_responding():
+        server_proc = _start_local_server()
+        if server_proc is None and not _localhost_responding():
+            return None, None
+    rewritten = _docker_host_target(target)
+    print(f"📍 Using Docker-compatible target: {rewritten}")
+    return rewritten, server_proc
+
+
+def _print_summary(data: dict) -> None:
+    alerts = _collect_alerts(data)
+    blocking = len(alerts["3"]) + len(alerts["2"])
+    total = sum(len(v) for v in alerts.values())
+    if blocking > 0:
+        print(f"⚠️  Found {blocking} high/medium alert(s) (total {total})")
+    elif total > 0:
+        print(f"ℹ️  Found {total} alert(s) — none high/medium")
+    else:
+        print("✅ No alerts detected")
+    print(f"📁 Reports saved to: {REPORT_DIR}/")
+
+
 def run(args: list[str] | None = None) -> int:
     if not _docker_available():
         print("❌ Docker is required to run OWASP ZAP")
         print("Please install Docker: https://docs.docker.com/get-docker/")
         return 1
 
-    parsed = _parse_args(args)
-    target = parsed.target
-
+    target = _parse_args(args).target
     print(f"🌐 Running DAST analysis against {target}…")
 
     server_proc: subprocess.Popen | None = None
     try:
         if _target_is_localhost(target):
-            if not _localhost_responding():
-                server_proc = _start_local_server()
-                if server_proc is None and not _localhost_responding():
-                    print(f"❌ Nothing listening on {target} and no server.js to start.")
-                    print("   Start your app's server first, then re-run.")
-                    return 1
-            target = _docker_host_target(target)
-            print(f"📍 Using Docker-compatible target: {target}")
+            target, server_proc = _prepare_localhost_target(target)
+            if target is None:
+                print("❌ Nothing listening on localhost and no server.js to start.")
+                print("   Start your app's server first, then re-run.")
+                return 1
 
         _run_zap(target)
         data = _read_data()
         REPORT_MD.write_text(_build_md_report(data))
-
-        alerts = _collect_alerts(data)
-        blocking = len(alerts["3"]) + len(alerts["2"])
-        total = sum(len(v) for v in alerts.values())
-        if blocking > 0:
-            print(f"⚠️  Found {blocking} high/medium alert(s) (total {total})")
-        elif total > 0:
-            print(f"ℹ️  Found {total} alert(s) — none high/medium")
-        else:
-            print("✅ No alerts detected")
-        print(f"📁 Reports saved to: {REPORT_DIR}/")
+        _print_summary(data)
         return 0
     finally:
         if server_proc is not None:

--- a/cli/slopstopper/checks/dependencies.py
+++ b/cli/slopstopper/checks/dependencies.py
@@ -156,7 +156,7 @@ def _build_md_report(data: dict) -> str:
     return md
 
 
-def run() -> int:
+def run(_args: list[str] | None = None) -> int:
     if not _trivy_available():
         print(_INSTALL_HELP)
         return 1

--- a/cli/slopstopper/checks/docs_accuracy.py
+++ b/cli/slopstopper/checks/docs_accuracy.py
@@ -250,7 +250,7 @@ def _build_md_report(data: dict, generated_at: str) -> str:
     return "\n".join(lines) + "\n"
 
 
-def run() -> int:
+def run(_args: list[str] | None = None) -> int:
     print("🔍 Checking documentation accuracy…")
 
     if not DOCS_DIR.is_dir():

--- a/cli/slopstopper/checks/docs_size.py
+++ b/cli/slopstopper/checks/docs_size.py
@@ -201,7 +201,7 @@ def _print_terminal_summary(
     print()
 
 
-def run() -> int:
+def run(_args: list[str] | None = None) -> int:
     thresholds = _load_thresholds()
     files_with_size = [(p, p.stat().st_size) for p in _iter_doc_files()]
     stats = _compute_stats(files_with_size)

--- a/cli/slopstopper/checks/docs_structure.py
+++ b/cli/slopstopper/checks/docs_structure.py
@@ -215,7 +215,7 @@ def _check_structure(docs_dir: Path) -> tuple[list[dict], list[str]] | None:
     return violations, expected
 
 
-def run() -> int:
+def run(_args: list[str] | None = None) -> int:
     print("🔍 Validating documentation structure...")
 
     result = _check_structure(DOCS_DIR)

--- a/cli/slopstopper/checks/entry_files.py
+++ b/cli/slopstopper/checks/entry_files.py
@@ -154,7 +154,7 @@ def _print_summary(measurements: list[dict], status_line: str) -> None:
     print(f"📁 Reports saved to: {REPORT_DIR}/")
 
 
-def run() -> int:
+def run(_args: list[str] | None = None) -> int:
     max_words = _load_max_words()
     measurements, missing = _measure_all(max_words)
 

--- a/cli/slopstopper/checks/sast.py
+++ b/cli/slopstopper/checks/sast.py
@@ -189,7 +189,7 @@ def _build_md_report(data: dict) -> str:
     return md
 
 
-def run() -> int:
+def run(_args: list[str] | None = None) -> int:
     if not _semgrep_available():
         print(_INSTALL_HELP)
         return 1

--- a/cli/slopstopper/checks/secrets.py
+++ b/cli/slopstopper/checks/secrets.py
@@ -114,7 +114,7 @@ def _build_md_report(findings: list[dict]) -> str:
     return md
 
 
-def run() -> int:
+def run(_args: list[str] | None = None) -> int:
     if not _gitleaks_available():
         print(_INSTALL_HELP)
         return 1

--- a/cli/slopstopper/cli.py
+++ b/cli/slopstopper/cli.py
@@ -26,19 +26,27 @@ def main(argv: list[str] | None = None) -> int:
         "check",
         help="Check name in 'category:name' form (e.g. hygiene:docs-size)",
     )
+    # Extra args after the check name flow through to the check's own
+    # parser. Only a couple of checks use this (e.g. security:dast
+    # takes --target); most ignore.
+    run_parser.add_argument(
+        "check_args",
+        nargs=argparse.REMAINDER,
+        help="Extra args forwarded to the check (e.g. --target URL for dast)",
+    )
 
     args = parser.parse_args(argv)
 
     if args.command == "run":
-        return _dispatch_run(args.check)
+        return _dispatch_run(args.check, args.check_args)
 
     parser.error(f"unknown command: {args.command}")
     return 2
 
 
-def _dispatch_run(check_name: str) -> int:
+def _dispatch_run(check_name: str, check_args: list[str]) -> int:
     if check_name not in REGISTRY:
         print(f"❌ unknown check: {check_name}", file=sys.stderr)
         print(f"   known checks: {', '.join(sorted(REGISTRY))}", file=sys.stderr)
         return 2
-    return REGISTRY[check_name]()
+    return REGISTRY[check_name](check_args)

--- a/cli/tests/checks/test_dast.py
+++ b/cli/tests/checks/test_dast.py
@@ -1,0 +1,234 @@
+"""Tests for the security:dast check (OWASP ZAP wrapper)."""
+
+from __future__ import annotations
+
+import json
+
+from slopstopper.checks import dast
+
+
+HIGH_ALERT = {
+    "name": "SQL Injection",
+    "riskcode": "3",
+    "confidence": 3,
+    "desc": "SQL injection in /search",
+    "instances": [{"uri": "/search"}],
+    "solution": "Parameterize queries",
+}
+
+MEDIUM_ALERT = {
+    "name": "Content Security Policy Missing",
+    "riskcode": "2",
+    "confidence": 2,
+    "desc": "No CSP header",
+    "instances": [{"uri": "/"}],
+    "solution": "Add CSP",
+}
+
+LOW_ALERT = {
+    "name": "Cookie No HttpOnly",
+    "riskcode": "1",
+    "confidence": 2,
+    "desc": "Cookie missing HttpOnly",
+    "instances": [{"uri": "/"}, {"uri": "/login"}],
+    "solution": "Set HttpOnly",
+}
+
+INFO_ALERT = {
+    "name": "Informational X",
+    "riskcode": "0",
+    "confidence": 1,
+    "desc": "FYI only",
+    "instances": [{"uri": "/"}],
+    "solution": "n/a",
+}
+
+
+def _zap_payload(*alerts: dict) -> dict:
+    return {"site": [{"@name": "http://test", "alerts": list(alerts)}]}
+
+
+# ── helpers ──────────────────────────────────────────────────────
+
+
+def test_parse_args_defaults_to_localhost():
+    parsed = dast._parse_args(None)
+    assert parsed.target == dast.DEFAULT_TARGET
+
+
+def test_parse_args_accepts_explicit_target():
+    parsed = dast._parse_args(["--target", "https://staging.example.com"])
+    assert parsed.target == "https://staging.example.com"
+
+
+def test_target_is_localhost_recognises_variants():
+    assert dast._target_is_localhost("http://localhost:8080") is True
+    assert dast._target_is_localhost("http://127.0.0.1:3000") is True
+    assert dast._target_is_localhost("https://example.com") is False
+
+
+def test_docker_host_target_macos(monkeypatch):
+    monkeypatch.setattr(dast.platform, "system", lambda: "Darwin")
+    assert dast._docker_host_target("http://localhost:8080") == "http://host.docker.internal:8080"
+
+
+def test_docker_host_target_linux(monkeypatch):
+    monkeypatch.setattr(dast.platform, "system", lambda: "Linux")
+    assert dast._docker_host_target("http://localhost:8080") == "http://172.17.0.1:8080"
+
+
+def test_docker_host_target_preserves_non_default_port(monkeypatch):
+    monkeypatch.setattr(dast.platform, "system", lambda: "Linux")
+    assert dast._docker_host_target("http://localhost:3000") == "http://172.17.0.1:3000"
+
+
+def test_docker_host_target_defaults_port_when_omitted(monkeypatch):
+    monkeypatch.setattr(dast.platform, "system", lambda: "Linux")
+    assert dast._docker_host_target("http://localhost") == "http://172.17.0.1:8080"
+
+
+def test_collect_alerts_buckets_by_riskcode():
+    data = _zap_payload(HIGH_ALERT, MEDIUM_ALERT, LOW_ALERT, INFO_ALERT)
+    alerts = dast._collect_alerts(data)
+    assert [a["name"] for a in alerts["3"]] == ["SQL Injection"]
+    assert [a["name"] for a in alerts["2"]] == ["Content Security Policy Missing"]
+    assert [a["name"] for a in alerts["1"]] == ["Cookie No HttpOnly"]
+    assert [a["name"] for a in alerts["0"]] == ["Informational X"]
+
+
+def test_collect_alerts_counts_instances():
+    data = _zap_payload(LOW_ALERT)
+    alerts = dast._collect_alerts(data)
+    assert alerts["1"][0]["instances"] == 2
+
+
+def test_collect_alerts_normalises_newlines_in_desc():
+    multi = {**HIGH_ALERT, "desc": "line one\nline two"}
+    alerts = dast._collect_alerts(_zap_payload(multi))
+    assert alerts["3"][0]["desc"] == "line one line two"
+
+
+def test_collect_alerts_empty():
+    assert dast._collect_alerts({}) == {"3": [], "2": [], "1": [], "0": []}
+
+
+def test_format_alert_row_truncates_long_desc():
+    long = {**dast._collect_alerts(_zap_payload(HIGH_ALERT))["3"][0], "desc": "x" * 200}
+    row = dast._format_alert_row(long)
+    assert "..." in row
+    assert "SQL Injection" in row
+    assert "High" in row
+
+
+def test_format_alert_section_renders_table():
+    alerts = dast._collect_alerts(_zap_payload(HIGH_ALERT))["3"]
+    section = dast._format_alert_section(alerts, "High Risk Alerts", "🔴")
+    assert "🔴 High Risk Alerts" in section
+    assert "| Alert | Risk | Instances | Description |" in section
+    assert "SQL Injection" in section
+
+
+def test_format_alert_section_empty():
+    assert dast._format_alert_section([], "Heading", "ICON") == ""
+
+
+def test_build_md_report_clean():
+    md = dast._build_md_report({"site": []})
+    assert "✅ DAST Status" in md
+    assert "No alerts detected" in md
+
+
+def test_build_md_report_with_findings_counts_by_severity():
+    md = dast._build_md_report(_zap_payload(HIGH_ALERT, MEDIUM_ALERT, LOW_ALERT, INFO_ALERT))
+    assert "| 🔴 High | 1 |" in md
+    assert "| 🟡 Medium | 1 |" in md
+    assert "| 🔵 Low | 1 |" in md
+    assert "| ℹ️ Informational | 1 |" in md
+    assert "| **Total** | **4** |" in md
+    assert "🔴 High Risk Alerts" in md
+    assert "🟡 Medium Risk Alerts" in md
+
+
+# ── subprocess / runtime ─────────────────────────────────────────
+
+
+def test_docker_available_via_which(monkeypatch):
+    monkeypatch.setattr(dast.shutil, "which", lambda _: "/usr/bin/docker")
+    assert dast._docker_available() is True
+    monkeypatch.setattr(dast.shutil, "which", lambda _: None)
+    assert dast._docker_available() is False
+
+
+def test_read_data_returns_empty_when_file_missing(isolated_cwd):
+    assert dast._read_data() == {}
+
+
+def test_read_data_handles_malformed_json(isolated_cwd):
+    dast.REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    dast.REPORT_JSON.write_text("not json")
+    assert dast._read_data() == {}
+
+
+def test_read_data_parses_payload(isolated_cwd):
+    dast.REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    dast.REPORT_JSON.write_text(json.dumps(_zap_payload(HIGH_ALERT)))
+    data = dast._read_data()
+    assert data["site"][0]["alerts"][0]["name"] == "SQL Injection"
+
+
+def test_run_returns_one_when_docker_missing(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.setattr(dast, "_docker_available", lambda: False)
+    rc = dast.run()
+    assert rc == 1
+    assert "Docker is required" in capsys.readouterr().out
+
+
+def test_run_returns_one_for_localhost_with_no_server(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.setattr(dast, "_docker_available", lambda: True)
+    monkeypatch.setattr(dast, "_localhost_responding", lambda url="http://localhost:8080": False)
+    monkeypatch.setattr(dast, "_start_local_server", lambda: None)
+    rc = dast.run(["--target", "http://localhost:8080"])
+    assert rc == 1
+    assert "Nothing listening" in capsys.readouterr().out
+
+
+def test_run_clean_when_no_alerts(monkeypatch, isolated_cwd, capsys):
+    def fake_zap(_target):
+        dast.REPORT_DIR.mkdir(parents=True, exist_ok=True)
+        dast.REPORT_JSON.write_text(json.dumps({"site": []}))
+
+    monkeypatch.setattr(dast, "_docker_available", lambda: True)
+    monkeypatch.setattr(dast, "_run_zap", fake_zap)
+    rc = dast.run(["--target", "https://example.com"])
+    assert rc == 0
+    assert "✅ No alerts detected" in capsys.readouterr().out
+    assert "No alerts detected" in dast.REPORT_MD.read_text()
+
+
+def test_run_with_blocking_alerts(monkeypatch, isolated_cwd, capsys):
+    def fake_zap(_target):
+        dast.REPORT_DIR.mkdir(parents=True, exist_ok=True)
+        dast.REPORT_JSON.write_text(json.dumps(_zap_payload(HIGH_ALERT, MEDIUM_ALERT, LOW_ALERT)))
+
+    monkeypatch.setattr(dast, "_docker_available", lambda: True)
+    monkeypatch.setattr(dast, "_run_zap", fake_zap)
+    rc = dast.run(["--target", "https://example.com"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Found 2 high/medium" in out
+    md = dast.REPORT_MD.read_text()
+    assert "SQL Injection" in md
+    assert "Content Security Policy Missing" in md
+
+
+def test_run_with_only_low_or_info(monkeypatch, isolated_cwd, capsys):
+    def fake_zap(_target):
+        dast.REPORT_DIR.mkdir(parents=True, exist_ok=True)
+        dast.REPORT_JSON.write_text(json.dumps(_zap_payload(LOW_ALERT, INFO_ALERT)))
+
+    monkeypatch.setattr(dast, "_docker_available", lambda: True)
+    monkeypatch.setattr(dast, "_run_zap", fake_zap)
+    rc = dast.run(["--target", "https://example.com"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Found 2 alert(s) — none high/medium" in out


### PR DESCRIPTION
## Summary

- Ports the bash `security:dast` flow (`docker run ghcr.io/zaproxy/zaproxy:stable zap-baseline.py` + `generate-dast-md.py`) into `cli/slopstopper/checks/dast.py`, registered as `security:dast`.
- **First check that takes a CLI argument** — `--target URL`. Plumbed through with `argparse.REMAINDER` in the dispatcher; each existing check's `run()` gains `_args: list[str] | None = None` that they all ignore.
- Reuses the bash port's Docker host-routing tricks: `host.docker.internal` on macOS, `172.17.0.1` bridge gateway on Linux, original-port preservation.
- Auto-starts local `server.js` when targeting localhost and nothing's listening (matches bash behaviour).

## Licensing

ZAP is Apache-2.0. Subprocess-invokes `docker` to run the official ZAP image — the slopstopper-cli wheel ships zero ZAP code. Same boundary discipline as gitleaks/semgrep/trivy.

## Why DAST is excluded from parity

| Reason | Detail |
| --- | --- |
| Non-determinism | ZAP baseline actively probes the live server; alert ordering and instance counts vary between back-to-back runs even at 100% logical parity. A byte-diff between two ZAP scans would fail on the test bench. |
| Cost | Each scan is ~1m17s of Docker time. Running both back-to-back in CI is ~2.5 min for marginal signal. |
| Coverage | `_build_md_report` is a straight lift of `generate-dast-md.py` and is exhaustively unit-tested (25 tests). The bash workflow continues to be the live signal for ZAP behaviour. |

Comment in `cli/Taskfile.yml` documents this for future-me / future contributors.

## Status

| | Check | Tests | Parity |
| --- | --- | --- | --- |
| 1 | `hygiene:docs-size` | ✅ | ✅ md |
| 2 | `hygiene:entry-files` | ✅ | ✅ md + json |
| 3 | `hygiene:docs-structure` | ✅ | ✅ md + json |
| 4 | `hygiene:docs-accuracy` | ✅ | ✅ md + json |
| 5 | `hygiene:complexity` | ✅ | ✅ md + csv |
| 6 | `hygiene:csp-exceptions` | ✅ | ✅ md + json |
| 7 | `security:secrets` | ✅ | ✅ md + json |
| 8 | `security:sast` | ✅ | ✅ md (JSON volatile) |
| 9 | `security:dependencies` | ✅ | ✅ md (JSON volatile) |
| 10 | `security:dast` | ✅ | ⏭️ excluded (see above) |

205 tests pass. 9 parity checks green locally.

## Remaining

Reliability suite (npm tooling):

- `reliability:accessibility` (axe-core / Playwright)
- `reliability:seo` (Playwright)
- `reliability:broken-links` (Playwright)
- `reliability:smoke` (Playwright)
- `reliability:core-web-vitals` (Lighthouse CI)

## Test plan

- [x] `task -t cli/Taskfile.yml test` — 205 passed
- [x] `task -t cli/Taskfile.yml parity` — all 9 checks green (DAST excluded by design)
- [x] `slopstopper run security:dast --help` — confirms `--target URL` flag exposed
- [ ] CI `pytest` job green
- [ ] CI `bash↔cli parity` job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)