### PR TITLE
feat(cli): port reliability:smoke as eleventh CLI check (Playwright wrapper)

### DIFF
--- a/cli/Taskfile.yml
+++ b/cli/Taskfile.yml
@@ -231,6 +231,16 @@ tasks:
         # for the build_md_report layer; trust the bash workflow for
         # the live ZAP behaviour.
 
+        # reliability:smoke — intentionally NOT parity-tested. Playwright
+        # smoke runs hit a live URL and emit playwright's own HTML/list
+        # reporter output, not .ss/reports/*-report.{md,json} files we
+        # can diff. The CLI port is a thin subprocess wrapper around
+        # `npx playwright test`: args parsing, env construction and
+        # command building are exhaustively unit-tested in
+        # cli/tests/checks/test_smoke.py (18 tests). Trust the unit
+        # tests for the launch envelope; trust the bash workflow for
+        # the live playwright behaviour.
+
         echo ""
         if [ "$FAILED" -eq 0 ]; then
           echo "All parity checks passed."

--- a/cli/slopstopper/checks/__init__.py
+++ b/cli/slopstopper/checks/__init__.py
@@ -15,6 +15,7 @@ from slopstopper.checks import (
     entry_files,
     sast,
     secrets,
+    smoke,
 )
 
 REGISTRY: dict[str, Callable[[Optional[list[str]]], int]] = {
@@ -24,6 +25,7 @@ REGISTRY: dict[str, Callable[[Optional[list[str]]], int]] = {
     "hygiene:docs-size": docs_size.run,
     "hygiene:docs-structure": docs_structure.run,
     "hygiene:entry-files": entry_files.run,
+    "reliability:smoke": smoke.run,
     "security:dast": dast.run,
     "security:dependencies": dependencies.run,
     "security:sast": sast.run,

--- a/cli/slopstopper/checks/smoke.py
+++ b/cli/slopstopper/checks/smoke.py
@@ -1,0 +1,100 @@
+"""Smoke tests against a live URL (Playwright wrapper).
+
+Ports the bash reliability:smoke flow:
+
+  task ss:reliability:smoke -- https://your-site.example.com
+
+  which is, under the covers:
+
+  SMOKE_TEST_URL=...
+  SMOKE_OG_IMAGE_PATH=$(python3 load_config.py smoke.og_image_path /og-image.png)
+  SMOKE_PAGES=$(python3 load_config.py pages.smoke /)
+  npx playwright test --config=.ss/playwright.config.js
+                      .ss/tests/smoke.spec.ts
+                      --reporter=list[,html]
+
+Subprocess-invokes `npx playwright` — Playwright is Apache-2.0; the
+slopstopper-cli wheel ships zero Playwright code. The test specs at
+.ss/tests/smoke.spec.ts and the Playwright config at
+.ss/playwright.config.js are still adopter-vendored today (lifting them
+into package data is a separate follow-up; see plan).
+
+Exit codes:
+  0 — playwright tests passed
+  non-zero — playwright tests failed, or URL/spec missing
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from slopstopper import config
+
+SPEC_PATH = Path(".ss/tests/smoke.spec.ts")
+PLAYWRIGHT_CONFIG = Path(".ss/playwright.config.js")
+
+
+def _parse_args(args: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="slopstopper run reliability:smoke", add_help=False)
+    p.add_argument("--url", default=None, help="Site URL to smoke-test (else $SMOKE_TEST_URL)")
+    p.add_argument("--ci", action="store_true", help="CI mode: html reporter, CI=true")
+    p.add_argument("--help", "-h", action="help")
+    return p.parse_args(args or [])
+
+
+def _npx_available() -> bool:
+    return shutil.which("npx") is not None
+
+
+def _resolve_url(parsed_url: str | None) -> str | None:
+    return parsed_url or os.environ.get("SMOKE_TEST_URL")
+
+
+def _build_env(url: str, ci_mode: bool) -> dict[str, str]:
+    env = dict(os.environ)
+    env["SMOKE_TEST_URL"] = url
+    env.setdefault("SMOKE_OG_IMAGE_PATH", str(config.get("smoke.og_image_path", "/og-image.png")))
+    env.setdefault("SMOKE_PAGES", str(config.get("pages.smoke", "/")))
+    if ci_mode:
+        env["CI"] = "true"
+    return env
+
+
+def _build_cmd(ci_mode: bool) -> list[str]:
+    reporter = "list,html" if ci_mode else "list"
+    return [
+        "npx", "playwright", "test",
+        f"--config={PLAYWRIGHT_CONFIG}",
+        str(SPEC_PATH),
+        f"--reporter={reporter}",
+    ]
+
+
+def run(args: list[str] | None = None) -> int:
+    if not _npx_available():
+        print("❌ npx is not available — install Node.js to run Playwright tests")
+        return 1
+
+    parsed = _parse_args(args)
+    url = _resolve_url(parsed.url)
+    if not url:
+        print("❌ Error: smoke target URL is required")
+        print("Usage:")
+        print("  slopstopper run reliability:smoke -- --url https://your-site.example.com")
+        print("  SMOKE_TEST_URL=https://your-site slopstopper run reliability:smoke")
+        return 1
+
+    if not SPEC_PATH.exists():
+        print(f"❌ Smoke spec not found at {SPEC_PATH}")
+        print("   The spec is vendored under .ss/tests/ by the installer.")
+        return 1
+
+    print(f"🔍 Running smoke tests against: {url}")
+    env = _build_env(url, parsed.ci)
+    cmd = _build_cmd(parsed.ci)
+    result = subprocess.run(cmd, env=env, check=False)
+    return result.returncode

--- a/cli/tests/checks/test_smoke.py
+++ b/cli/tests/checks/test_smoke.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 
 from slopstopper.checks import smoke
@@ -40,11 +41,16 @@ def test_resolve_url_returns_none_when_neither_set(monkeypatch):
 def test_build_env_threads_url_and_config_defaults(isolated_cwd, monkeypatch):
     monkeypatch.delenv("SMOKE_OG_IMAGE_PATH", raising=False)
     monkeypatch.delenv("SMOKE_PAGES", raising=False)
+    # GitHub Actions sets CI=true in the runner env. We're asserting that
+    # _build_env doesn't ADD CI when ci_mode=False, not that CI is absent
+    # from the caller's environment. Snapshot caller-CI before the call.
+    caller_ci = os.environ.get("CI")
     env = smoke._build_env("https://example.com", ci_mode=False)
     assert env["SMOKE_TEST_URL"] == "https://example.com"
     assert env["SMOKE_OG_IMAGE_PATH"] == "/og-image.png"
     assert env["SMOKE_PAGES"] == "/"
-    assert "CI" not in env or env.get("CI") != "true"
+    # ci_mode=False must not touch CI either direction
+    assert env.get("CI") == caller_ci
 
 
 def test_build_env_reads_config_keys(write_config, monkeypatch):

--- a/cli/tests/checks/test_smoke.py
+++ b/cli/tests/checks/test_smoke.py
@@ -1,0 +1,174 @@
+"""Tests for the reliability:smoke check (Playwright wrapper)."""
+
+from __future__ import annotations
+
+import subprocess
+
+from slopstopper.checks import smoke
+
+
+# ── helpers ──────────────────────────────────────────────────────
+
+
+def test_parse_args_defaults():
+    parsed = smoke._parse_args(None)
+    assert parsed.url is None
+    assert parsed.ci is False
+
+
+def test_parse_args_explicit_url_and_ci():
+    parsed = smoke._parse_args(["--url", "https://example.com", "--ci"])
+    assert parsed.url == "https://example.com"
+    assert parsed.ci is True
+
+
+def test_resolve_url_prefers_flag(monkeypatch):
+    monkeypatch.setenv("SMOKE_TEST_URL", "https://from-env")
+    assert smoke._resolve_url("https://from-flag") == "https://from-flag"
+
+
+def test_resolve_url_falls_back_to_env(monkeypatch):
+    monkeypatch.setenv("SMOKE_TEST_URL", "https://from-env")
+    assert smoke._resolve_url(None) == "https://from-env"
+
+
+def test_resolve_url_returns_none_when_neither_set(monkeypatch):
+    monkeypatch.delenv("SMOKE_TEST_URL", raising=False)
+    assert smoke._resolve_url(None) is None
+
+
+def test_build_env_threads_url_and_config_defaults(isolated_cwd, monkeypatch):
+    monkeypatch.delenv("SMOKE_OG_IMAGE_PATH", raising=False)
+    monkeypatch.delenv("SMOKE_PAGES", raising=False)
+    env = smoke._build_env("https://example.com", ci_mode=False)
+    assert env["SMOKE_TEST_URL"] == "https://example.com"
+    assert env["SMOKE_OG_IMAGE_PATH"] == "/og-image.png"
+    assert env["SMOKE_PAGES"] == "/"
+    assert "CI" not in env or env.get("CI") != "true"
+
+
+def test_build_env_reads_config_keys(write_config, monkeypatch):
+    monkeypatch.delenv("SMOKE_OG_IMAGE_PATH", raising=False)
+    monkeypatch.delenv("SMOKE_PAGES", raising=False)
+    write_config(
+        "smoke:\n  og_image_path: /static/og.png\npages:\n  smoke: /,/blog,/about\n"
+    )
+    env = smoke._build_env("https://example.com", ci_mode=False)
+    assert env["SMOKE_OG_IMAGE_PATH"] == "/static/og.png"
+    assert env["SMOKE_PAGES"] == "/,/blog,/about"
+
+
+def test_build_env_respects_caller_env_vars(monkeypatch):
+    monkeypatch.setenv("SMOKE_OG_IMAGE_PATH", "/preset.png")
+    monkeypatch.setenv("SMOKE_PAGES", "/preset-page")
+    env = smoke._build_env("https://example.com", ci_mode=False)
+    # setdefault means caller's env wins over config defaults
+    assert env["SMOKE_OG_IMAGE_PATH"] == "/preset.png"
+    assert env["SMOKE_PAGES"] == "/preset-page"
+
+
+def test_build_env_sets_ci_when_ci_mode():
+    env = smoke._build_env("https://example.com", ci_mode=True)
+    assert env["CI"] == "true"
+
+
+def test_build_cmd_default_reporter():
+    cmd = smoke._build_cmd(ci_mode=False)
+    assert cmd[0] == "npx"
+    assert "playwright" in cmd
+    assert "test" in cmd
+    assert "--reporter=list" in cmd
+    assert str(smoke.SPEC_PATH) in cmd
+
+
+def test_build_cmd_ci_uses_list_html_reporter():
+    cmd = smoke._build_cmd(ci_mode=True)
+    assert "--reporter=list,html" in cmd
+
+
+# ── subprocess / runtime ─────────────────────────────────────────
+
+
+def test_npx_available_via_which(monkeypatch):
+    monkeypatch.setattr(smoke.shutil, "which", lambda _: "/usr/bin/npx")
+    assert smoke._npx_available() is True
+    monkeypatch.setattr(smoke.shutil, "which", lambda _: None)
+    assert smoke._npx_available() is False
+
+
+def test_run_returns_one_when_npx_missing(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.setattr(smoke, "_npx_available", lambda: False)
+    rc = smoke.run()
+    assert rc == 1
+    assert "npx is not available" in capsys.readouterr().out
+
+
+def test_run_returns_one_when_url_missing(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.setattr(smoke, "_npx_available", lambda: True)
+    monkeypatch.delenv("SMOKE_TEST_URL", raising=False)
+    rc = smoke.run([])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "smoke target URL is required" in out
+
+
+def test_run_returns_one_when_spec_missing(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.setattr(smoke, "_npx_available", lambda: True)
+    rc = smoke.run(["--url", "https://example.com"])
+    assert rc == 1
+    assert "Smoke spec not found" in capsys.readouterr().out
+
+
+def test_run_invokes_playwright_with_expected_args(monkeypatch, isolated_cwd):
+    smoke.SPEC_PATH.parent.mkdir(parents=True, exist_ok=True)
+    smoke.SPEC_PATH.write_text("// fake spec")
+
+    captured: dict = {}
+
+    def fake_run(cmd, env, check):
+        captured["cmd"] = cmd
+        captured["env"] = env
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(smoke, "_npx_available", lambda: True)
+    monkeypatch.setattr(smoke.subprocess, "run", fake_run)
+
+    rc = smoke.run(["--url", "https://example.com"])
+    assert rc == 0
+    assert captured["cmd"][:2] == ["npx", "playwright"]
+    assert "--reporter=list" in captured["cmd"]
+    assert captured["env"]["SMOKE_TEST_URL"] == "https://example.com"
+
+
+def test_run_ci_mode_threads_html_reporter_and_ci_env(monkeypatch, isolated_cwd):
+    smoke.SPEC_PATH.parent.mkdir(parents=True, exist_ok=True)
+    smoke.SPEC_PATH.write_text("// fake spec")
+
+    captured: dict = {}
+
+    def fake_run(cmd, env, check):
+        captured["cmd"] = cmd
+        captured["env"] = env
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(smoke, "_npx_available", lambda: True)
+    monkeypatch.setattr(smoke.subprocess, "run", fake_run)
+
+    rc = smoke.run(["--url", "https://example.com", "--ci"])
+    assert rc == 0
+    assert "--reporter=list,html" in captured["cmd"]
+    assert captured["env"]["CI"] == "true"
+
+
+def test_run_propagates_playwright_failure(monkeypatch, isolated_cwd):
+    smoke.SPEC_PATH.parent.mkdir(parents=True, exist_ok=True)
+    smoke.SPEC_PATH.write_text("// fake spec")
+
+    monkeypatch.setattr(smoke, "_npx_available", lambda: True)
+    monkeypatch.setattr(
+        smoke.subprocess, "run",
+        lambda cmd, env, check: subprocess.CompletedProcess(cmd, 1),
+    )
+
+    rc = smoke.run(["--url", "https://example.com"])
+    assert rc == 1


### PR DESCRIPTION
## Summary

- Ports the bash `reliability:smoke` flow into `cli/slopstopper/checks/smoke.py`, registered as `reliability:smoke`.
- **First reliability-suite port** — establishes the npm-subprocess pattern for the rest of the suite (cwv, seo, accessibility, broken-links).
- Threads URL via `--url` flag or `SMOKE_TEST_URL` env. Resolves `smoke.og_image_path` and `pages.smoke` from `.slopstopper.yml` using the existing config reader.

## Licensing

Playwright is Apache-2.0. Subprocess-invokes `npx playwright test` — slopstopper-cli wheel ships zero Playwright code. Same boundary discipline as docker/gitleaks/semgrep/trivy/zap. Adopters install Node + Playwright themselves.

## Why smoke is excluded from parity

| Reason | Detail |
| --- | --- |
| No diffable reports | Playwright emits HTML/list reporter output, not `.ss/reports/*-report.{md,json}` files we can byte-diff. |
| Non-determinism | Live URL probing — network latency, transient errors, target-site changes. |
| Test surface | The CLI port is a thin launch envelope; args parsing, env construction and command building are exhaustively unit-tested (18 tests). |

Comment in `cli/Taskfile.yml` documents this for future-me / future contributors.

## What's still adopter-vendored

`.ss/tests/smoke.spec.ts` and `.ss/playwright.config.js` are still installed into adopter repos by `install.sh`. Lifting them into `cli/slopstopper/data/` as package data — so adopters can drop them and the CLI extracts at runtime — is a separate follow-up. That's the bigger reliability portability win.

## Status

| | Check | Tests | Parity |
| --- | --- | --- | --- |
| 1 | `hygiene:docs-size` | ✅ | ✅ md |
| 2 | `hygiene:entry-files` | ✅ | ✅ md + json |
| 3 | `hygiene:docs-structure` | ✅ | ✅ md + json |
| 4 | `hygiene:docs-accuracy` | ✅ | ✅ md + json |
| 5 | `hygiene:complexity` | ✅ | ✅ md + csv |
| 6 | `hygiene:csp-exceptions` | ✅ | ✅ md + json |
| 7 | `security:secrets` | ✅ | ✅ md + json |
| 8 | `security:sast` | ✅ | ✅ md (JSON volatile) |
| 9 | `security:dependencies` | ✅ | ✅ md (JSON volatile) |
| 10 | `security:dast` | ✅ | ⏭️ excluded (non-det probes) |
| 11 | `reliability:smoke` | ✅ | ⏭️ excluded (no diffable reports) |

223 tests pass.

## Remaining

- `reliability:cwv` (Lighthouse CI)
- `reliability:seo` (Playwright)
- `reliability:accessibility` (Playwright + axe-core)
- `reliability:broken-links` (Playwright)

## Test plan

- [x] `task -t cli/Taskfile.yml test` — 223 passed
- [x] `task -t cli/Taskfile.yml parity` — all 9 parity-eligible checks green (DAST + smoke excluded by design)
- [x] `slopstopper run reliability:smoke -- --url URL` — args plumbed via REMAINDER passthrough
- [ ] CI `pytest` job green
- [ ] CI `bash↔cli parity` job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)