### PR TITLE
feat(cli): port reliability:cwv as twelfth CLI check (Lighthouse CI wrapper)

### DIFF
--- a/cli/Taskfile.yml
+++ b/cli/Taskfile.yml
@@ -241,6 +241,15 @@ tasks:
         # tests for the launch envelope; trust the bash workflow for
         # the live playwright behaviour.
 
+        # reliability:cwv — intentionally NOT parity-tested. Lighthouse
+        # CI hits a live URL and emits its own HTML/JSON artifacts
+        # alongside thresholding output; nothing in .ss/reports/ to
+        # diff. CWV scores are also non-deterministic (TBT, LCP vary
+        # with network and CPU jitter on the runner). The CLI port is
+        # a thin subprocess wrapper around `npx lhci autorun`;
+        # args/url/config plumbing is unit-tested in
+        # cli/tests/checks/test_cwv.py (13 tests).
+
         echo ""
         if [ "$FAILED" -eq 0 ]; then
           echo "All parity checks passed."

--- a/cli/slopstopper/checks/__init__.py
+++ b/cli/slopstopper/checks/__init__.py
@@ -7,6 +7,7 @@ from typing import Callable, Optional
 from slopstopper.checks import (
     complexity,
     csp_exceptions,
+    cwv,
     dast,
     dependencies,
     docs_accuracy,
@@ -25,6 +26,7 @@ REGISTRY: dict[str, Callable[[Optional[list[str]]], int]] = {
     "hygiene:docs-size": docs_size.run,
     "hygiene:docs-structure": docs_structure.run,
     "hygiene:entry-files": entry_files.run,
+    "reliability:cwv": cwv.run,
     "reliability:smoke": smoke.run,
     "security:dast": dast.run,
     "security:dependencies": dependencies.run,

--- a/cli/slopstopper/checks/cwv.py
+++ b/cli/slopstopper/checks/cwv.py
@@ -1,0 +1,83 @@
+"""Core Web Vitals audit (Lighthouse CI wrapper).
+
+Ports the bash reliability:cwv flow:
+
+  task ss:reliability:cwv -- https://your-site.example.com
+
+  which is, under the covers:
+
+  npx lhci autorun --collect.url="$CWV_URL" --config=.ss/lighthouserc.json
+
+Subprocess-invokes `npx lhci` — Lighthouse CI is Apache-2.0; the
+slopstopper-cli wheel ships zero Lighthouse code. The .ss/lighthouserc.json
+config (and any *-ci variant) is still adopter-vendored today; lifting
+into package data is a follow-up.
+
+Exit codes:
+  0 — lhci passed all thresholds
+  non-zero — lhci failed thresholds or URL/config missing
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+LHCI_CONFIG = Path(".ss/lighthouserc.json")
+
+
+def _parse_args(args: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="slopstopper run reliability:cwv", add_help=False)
+    p.add_argument("--url", default=None, help="Site URL to audit (else $CWV_URL)")
+    p.add_argument(
+        "--config",
+        default=str(LHCI_CONFIG),
+        help=f"Lighthouse CI config path (default: {LHCI_CONFIG})",
+    )
+    p.add_argument("--help", "-h", action="help")
+    return p.parse_args(args or [])
+
+
+def _npx_available() -> bool:
+    return shutil.which("npx") is not None
+
+
+def _resolve_url(parsed_url: str | None) -> str | None:
+    return parsed_url or os.environ.get("CWV_URL")
+
+
+def _build_cmd(url: str, config_path: str) -> list[str]:
+    return [
+        "npx", "lhci", "autorun",
+        f"--collect.url={url}",
+        f"--config={config_path}",
+    ]
+
+
+def run(args: list[str] | None = None) -> int:
+    if not _npx_available():
+        print("❌ npx is not available — install Node.js to run Lighthouse CI")
+        return 1
+
+    parsed = _parse_args(args)
+    url = _resolve_url(parsed.url)
+    if not url:
+        print("❌ Error: CWV target URL is required")
+        print("Usage:")
+        print("  slopstopper run reliability:cwv -- --url https://your-site.example.com")
+        print("  CWV_URL=https://your-site slopstopper run reliability:cwv")
+        return 1
+
+    config_path = Path(parsed.config)
+    if not config_path.exists():
+        print(f"❌ Lighthouse CI config not found at {config_path}")
+        print("   The config is vendored under .ss/ by the installer.")
+        return 1
+
+    print(f"🚦 Running Core Web Vitals audit against: {url}")
+    cmd = _build_cmd(url, str(config_path))
+    result = subprocess.run(cmd, check=False)
+    return result.returncode

--- a/cli/tests/checks/test_cwv.py
+++ b/cli/tests/checks/test_cwv.py
@@ -1,0 +1,128 @@
+"""Tests for the reliability:cwv check (Lighthouse CI wrapper)."""
+
+from __future__ import annotations
+
+import subprocess
+
+from slopstopper.checks import cwv
+
+
+# ── helpers ──────────────────────────────────────────────────────
+
+
+def test_parse_args_defaults():
+    parsed = cwv._parse_args(None)
+    assert parsed.url is None
+    assert parsed.config == str(cwv.LHCI_CONFIG)
+
+
+def test_parse_args_explicit():
+    parsed = cwv._parse_args(["--url", "https://example.com", "--config", "custom.json"])
+    assert parsed.url == "https://example.com"
+    assert parsed.config == "custom.json"
+
+
+def test_resolve_url_prefers_flag(monkeypatch):
+    monkeypatch.setenv("CWV_URL", "https://from-env")
+    assert cwv._resolve_url("https://from-flag") == "https://from-flag"
+
+
+def test_resolve_url_falls_back_to_env(monkeypatch):
+    monkeypatch.setenv("CWV_URL", "https://from-env")
+    assert cwv._resolve_url(None) == "https://from-env"
+
+
+def test_resolve_url_none_when_neither_set(monkeypatch):
+    monkeypatch.delenv("CWV_URL", raising=False)
+    assert cwv._resolve_url(None) is None
+
+
+def test_build_cmd_threads_url_and_config():
+    cmd = cwv._build_cmd("https://example.com", "myconf.json")
+    assert cmd[:3] == ["npx", "lhci", "autorun"]
+    assert "--collect.url=https://example.com" in cmd
+    assert "--config=myconf.json" in cmd
+
+
+# ── subprocess / runtime ─────────────────────────────────────────
+
+
+def test_npx_available_via_which(monkeypatch):
+    monkeypatch.setattr(cwv.shutil, "which", lambda _: "/usr/bin/npx")
+    assert cwv._npx_available() is True
+    monkeypatch.setattr(cwv.shutil, "which", lambda _: None)
+    assert cwv._npx_available() is False
+
+
+def test_run_returns_one_when_npx_missing(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.setattr(cwv, "_npx_available", lambda: False)
+    rc = cwv.run()
+    assert rc == 1
+    assert "npx is not available" in capsys.readouterr().out
+
+
+def test_run_returns_one_when_url_missing(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.setattr(cwv, "_npx_available", lambda: True)
+    monkeypatch.delenv("CWV_URL", raising=False)
+    rc = cwv.run([])
+    assert rc == 1
+    assert "CWV target URL is required" in capsys.readouterr().out
+
+
+def test_run_returns_one_when_config_missing(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.setattr(cwv, "_npx_available", lambda: True)
+    rc = cwv.run(["--url", "https://example.com"])
+    assert rc == 1
+    assert "Lighthouse CI config not found" in capsys.readouterr().out
+
+
+def test_run_invokes_lhci_with_expected_args(monkeypatch, isolated_cwd):
+    cwv.LHCI_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+    cwv.LHCI_CONFIG.write_text("{}")
+
+    captured: dict = {}
+
+    def fake_run(cmd, check):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(cwv, "_npx_available", lambda: True)
+    monkeypatch.setattr(cwv.subprocess, "run", fake_run)
+
+    rc = cwv.run(["--url", "https://example.com"])
+    assert rc == 0
+    assert captured["cmd"][:3] == ["npx", "lhci", "autorun"]
+    assert "--collect.url=https://example.com" in captured["cmd"]
+    assert f"--config={cwv.LHCI_CONFIG}" in captured["cmd"]
+
+
+def test_run_propagates_lhci_failure(monkeypatch, isolated_cwd):
+    cwv.LHCI_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+    cwv.LHCI_CONFIG.write_text("{}")
+
+    monkeypatch.setattr(cwv, "_npx_available", lambda: True)
+    monkeypatch.setattr(
+        cwv.subprocess, "run",
+        lambda cmd, check: subprocess.CompletedProcess(cmd, 1),
+    )
+
+    rc = cwv.run(["--url", "https://example.com"])
+    assert rc == 1
+
+
+def test_run_accepts_explicit_config(monkeypatch, isolated_cwd):
+    custom = isolated_cwd / "custom-lhci.json"
+    custom.write_text("{}")
+
+    captured: dict = {}
+
+    def fake_run(cmd, check):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(cwv, "_npx_available", lambda: True)
+    monkeypatch.setattr(cwv.subprocess, "run", fake_run)
+
+    rc = cwv.run(["--url", "https://example.com", "--config", str(custom)])
+    assert rc == 0
+    assert f"--config={custom}" in captured["cmd"]


### PR DESCRIPTION
## Summary

- Ports the bash `reliability:cwv` flow (`npx lhci autorun --collect.url=<URL> --config=.ss/lighthouserc.json`) into `cli/slopstopper/checks/cwv.py`, registered as `reliability:cwv`.
- Threads `CWV_URL` via `--url` flag or env. Accepts `--config` to override the default `.ss/lighthouserc.json` (useful for CI-mode variants).

## Licensing

Lighthouse CI is Apache-2.0. Subprocess-invokes `npx lhci` — slopstopper-cli wheel ships zero Lighthouse code. Same boundary discipline as docker/gitleaks/semgrep/trivy/zap/playwright.

## Why CWV is excluded from parity

| Reason | Detail |
| --- | --- |
| No diffable reports | lhci emits its own HTML/JSON artifacts and threshold output, not `.ss/reports/*-report.{md,json}` files we can byte-diff. |
| Non-determinism | TBT/LCP/CLS vary with network latency and CPU jitter on the runner — two consecutive runs against the same URL never produce the same scores. |
| Test surface | The CLI port is a thin launch envelope; args/url/config plumbing is unit-tested (13 tests). |

## Status

| | Check | Tests | Parity |
| --- | --- | --- | --- |
| 1–6 | hygiene suite (all) | ✅ | ✅ |
| 7 | `security:secrets` | ✅ | ✅ md + json |
| 8 | `security:sast` | ✅ | ✅ md (JSON volatile) |
| 9 | `security:dependencies` | ✅ | ✅ md (JSON volatile) |
| 10 | `security:dast` | ✅ | ⏭️ excluded |
| 11 | `reliability:smoke` | ✅ | ⏭️ excluded |
| 12 | `reliability:cwv` | ✅ | ⏭️ excluded |

236 tests pass.

## Remaining

- `reliability:seo` (Playwright)
- `reliability:accessibility` (Playwright + axe-core)
- `reliability:broken-links` (Playwright)

All three are Playwright-spec wrappers, near-identical shape to `reliability:smoke`. Expect them to move quickly.

## Test plan

- [x] `task -t cli/Taskfile.yml test` — 236 passed
- [x] `slopstopper run reliability:cwv -- --url URL` — args plumbed via REMAINDER passthrough
- [ ] CI `pytest` job green
- [ ] CI `bash↔cli parity` job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)