### PR TITLE
feat(cli): port reliability:accessibility as thirteenth CLI check

### DIFF
--- a/cli/Taskfile.yml
+++ b/cli/Taskfile.yml
@@ -250,6 +250,15 @@ tasks:
         # args/url/config plumbing is unit-tested in
         # cli/tests/checks/test_cwv.py (13 tests).
 
+        # reliability:accessibility — intentionally NOT parity-tested.
+        # Same shape as reliability:smoke (Playwright + axe-core,
+        # results in .ss/playwright-report/, no .ss/reports/*-report.*
+        # to diff; results can flicker on first paint timing). Port
+        # plumbs --url, ACCESSIBILITY_TEST_URL / SMOKE_TEST_URL
+        # fallback, and ACCESSIBILITY_PAGES via discover-pages.py
+        # subprocess. Args / env / discover-pages plumbing is unit-
+        # tested in cli/tests/checks/test_accessibility.py (23 tests).
+
         echo ""
         if [ "$FAILED" -eq 0 ]; then
           echo "All parity checks passed."

--- a/cli/slopstopper/checks/__init__.py
+++ b/cli/slopstopper/checks/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Callable, Optional
 
 from slopstopper.checks import (
+    accessibility,
     complexity,
     csp_exceptions,
     cwv,
@@ -26,6 +27,7 @@ REGISTRY: dict[str, Callable[[Optional[list[str]]], int]] = {
     "hygiene:docs-size": docs_size.run,
     "hygiene:docs-structure": docs_structure.run,
     "hygiene:entry-files": entry_files.run,
+    "reliability:accessibility": accessibility.run,
     "reliability:cwv": cwv.run,
     "reliability:smoke": smoke.run,
     "security:dast": dast.run,

--- a/cli/slopstopper/checks/accessibility.py
+++ b/cli/slopstopper/checks/accessibility.py
@@ -1,0 +1,134 @@
+"""Accessibility audit (Playwright + axe-core wrapper).
+
+Ports the bash reliability:accessibility flow:
+
+  task ss:reliability:accessibility -- https://your-site.example.com
+
+  which is, under the covers:
+
+  ACCESSIBILITY_PAGES=$(python3 .ss/scripts/discover-pages.py
+                                accessibility --event=local)
+  ACCESSIBILITY_TEST_URL=...
+  npx playwright test --config=.ss/playwright.config.js
+                      .ss/tests/accessibility.spec.ts
+                      --reporter=list[,html]
+
+Subprocess-invokes `npx playwright`. Playwright is Apache-2.0, axe-core
+is MPL-2.0; the slopstopper-cli wheel ships zero code from either —
+both bind in via the adopter's node_modules. Discover-pages.py is
+still an adopter-vendored Python script today (subprocess-invoked
+here for parity); lifting it into the package is a follow-up.
+
+Falls back to SMOKE_TEST_URL when ACCESSIBILITY_TEST_URL is unset,
+matching the bash flow exactly.
+
+Exit codes:
+  0 — playwright tests passed
+  non-zero — playwright tests failed, or URL/spec missing
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+SPEC_PATH = Path(".ss/tests/accessibility.spec.ts")
+PLAYWRIGHT_CONFIG = Path(".ss/playwright.config.js")
+DISCOVER_PAGES = Path(".ss/scripts/discover-pages.py")
+
+
+def _parse_args(args: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="slopstopper run reliability:accessibility", add_help=False
+    )
+    p.add_argument("--url", default=None, help="Site URL to audit")
+    p.add_argument("--ci", action="store_true", help="CI mode: html reporter, CI=true")
+    p.add_argument("--help", "-h", action="help")
+    return p.parse_args(args or [])
+
+
+def _npx_available() -> bool:
+    return shutil.which("npx") is not None
+
+
+def _resolve_url(parsed_url: str | None) -> str | None:
+    return (
+        parsed_url
+        or os.environ.get("ACCESSIBILITY_TEST_URL")
+        or os.environ.get("SMOKE_TEST_URL")
+    )
+
+
+def _discover_pages() -> str | None:
+    """Subprocess discover-pages.py to resolve pages.accessibility from config.
+
+    Mirrors the bash behaviour: only runs if discover-pages.py exists; on
+    any failure, returns None and lets the spec fall back to its default.
+    """
+    if not DISCOVER_PAGES.exists():
+        return None
+    try:
+        result = subprocess.run(
+            [sys.executable, str(DISCOVER_PAGES), "accessibility", "--event=local"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+        out = result.stdout.strip()
+        return out or None
+    except OSError:
+        return None
+
+
+def _build_env(url: str, ci_mode: bool) -> dict[str, str]:
+    env = dict(os.environ)
+    env["ACCESSIBILITY_TEST_URL"] = url
+    if "ACCESSIBILITY_PAGES" not in env:
+        pages = _discover_pages()
+        if pages is not None:
+            env["ACCESSIBILITY_PAGES"] = pages
+    if ci_mode:
+        env["CI"] = "true"
+    return env
+
+
+def _build_cmd(ci_mode: bool) -> list[str]:
+    reporter = "list,html" if ci_mode else "list"
+    return [
+        "npx", "playwright", "test",
+        f"--config={PLAYWRIGHT_CONFIG}",
+        str(SPEC_PATH),
+        f"--reporter={reporter}",
+    ]
+
+
+def run(args: list[str] | None = None) -> int:
+    if not _npx_available():
+        print("❌ npx is not available — install Node.js to run Playwright tests")
+        return 1
+
+    parsed = _parse_args(args)
+    url = _resolve_url(parsed.url)
+    if not url:
+        print("❌ Error: accessibility target URL is required")
+        print("Usage:")
+        print("  slopstopper run reliability:accessibility -- --url https://your-site.example.com")
+        print("  ACCESSIBILITY_TEST_URL=https://your-site slopstopper run reliability:accessibility")
+        return 1
+
+    if not SPEC_PATH.exists():
+        print(f"❌ Accessibility spec not found at {SPEC_PATH}")
+        print("   The spec is vendored under .ss/tests/ by the installer.")
+        return 1
+
+    print(f"♿ Running accessibility audit against: {url}")
+    env = _build_env(url, parsed.ci)
+    cmd = _build_cmd(parsed.ci)
+    result = subprocess.run(cmd, env=env, check=False)
+    return result.returncode

--- a/cli/tests/checks/test_accessibility.py
+++ b/cli/tests/checks/test_accessibility.py
@@ -1,0 +1,213 @@
+"""Tests for the reliability:accessibility check (Playwright + axe-core wrapper)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+from slopstopper.checks import accessibility
+
+
+# ── helpers ──────────────────────────────────────────────────────
+
+
+def test_parse_args_defaults():
+    parsed = accessibility._parse_args(None)
+    assert parsed.url is None
+    assert parsed.ci is False
+
+
+def test_parse_args_explicit():
+    parsed = accessibility._parse_args(["--url", "https://example.com", "--ci"])
+    assert parsed.url == "https://example.com"
+    assert parsed.ci is True
+
+
+def test_resolve_url_prefers_flag(monkeypatch):
+    monkeypatch.setenv("ACCESSIBILITY_TEST_URL", "https://from-a11y")
+    monkeypatch.setenv("SMOKE_TEST_URL", "https://from-smoke")
+    assert accessibility._resolve_url("https://from-flag") == "https://from-flag"
+
+
+def test_resolve_url_falls_through_a11y_env(monkeypatch):
+    monkeypatch.setenv("ACCESSIBILITY_TEST_URL", "https://from-a11y")
+    monkeypatch.setenv("SMOKE_TEST_URL", "https://from-smoke")
+    assert accessibility._resolve_url(None) == "https://from-a11y"
+
+
+def test_resolve_url_falls_through_smoke_env(monkeypatch):
+    monkeypatch.delenv("ACCESSIBILITY_TEST_URL", raising=False)
+    monkeypatch.setenv("SMOKE_TEST_URL", "https://from-smoke")
+    assert accessibility._resolve_url(None) == "https://from-smoke"
+
+
+def test_resolve_url_none_when_neither_set(monkeypatch):
+    monkeypatch.delenv("ACCESSIBILITY_TEST_URL", raising=False)
+    monkeypatch.delenv("SMOKE_TEST_URL", raising=False)
+    assert accessibility._resolve_url(None) is None
+
+
+def test_discover_pages_returns_none_when_script_missing(isolated_cwd):
+    assert accessibility._discover_pages() is None
+
+
+def test_discover_pages_returns_stdout_when_script_succeeds(monkeypatch, isolated_cwd):
+    accessibility.DISCOVER_PAGES.parent.mkdir(parents=True, exist_ok=True)
+    accessibility.DISCOVER_PAGES.write_text("# stub")
+
+    def fake_run(cmd, capture_output, text, check):
+        return subprocess.CompletedProcess(cmd, 0, stdout="/,/blog\n", stderr="")
+
+    monkeypatch.setattr(accessibility.subprocess, "run", fake_run)
+    assert accessibility._discover_pages() == "/,/blog"
+
+
+def test_discover_pages_returns_none_on_non_zero_exit(monkeypatch, isolated_cwd):
+    accessibility.DISCOVER_PAGES.parent.mkdir(parents=True, exist_ok=True)
+    accessibility.DISCOVER_PAGES.write_text("# stub")
+
+    monkeypatch.setattr(
+        accessibility.subprocess, "run",
+        lambda cmd, capture_output, text, check: subprocess.CompletedProcess(
+            cmd, 1, stdout="should ignore", stderr="error"
+        ),
+    )
+    assert accessibility._discover_pages() is None
+
+
+def test_build_env_threads_url(isolated_cwd, monkeypatch):
+    monkeypatch.delenv("ACCESSIBILITY_PAGES", raising=False)
+    monkeypatch.setattr(accessibility, "_discover_pages", lambda: None)
+    env = accessibility._build_env("https://example.com", ci_mode=False)
+    assert env["ACCESSIBILITY_TEST_URL"] == "https://example.com"
+
+
+def test_build_env_calls_discover_pages_when_unset(isolated_cwd, monkeypatch):
+    monkeypatch.delenv("ACCESSIBILITY_PAGES", raising=False)
+    monkeypatch.setattr(accessibility, "_discover_pages", lambda: "/,/about")
+    env = accessibility._build_env("https://example.com", ci_mode=False)
+    assert env["ACCESSIBILITY_PAGES"] == "/,/about"
+
+
+def test_build_env_preserves_caller_pages(monkeypatch):
+    monkeypatch.setenv("ACCESSIBILITY_PAGES", "/preset")
+    monkeypatch.setattr(accessibility, "_discover_pages", lambda: "/should-not-use")
+    env = accessibility._build_env("https://example.com", ci_mode=False)
+    assert env["ACCESSIBILITY_PAGES"] == "/preset"
+
+
+def test_build_env_does_not_set_ci_when_default(isolated_cwd, monkeypatch):
+    monkeypatch.setattr(accessibility, "_discover_pages", lambda: None)
+    caller_ci = os.environ.get("CI")
+    env = accessibility._build_env("https://example.com", ci_mode=False)
+    assert env.get("CI") == caller_ci
+
+
+def test_build_env_sets_ci_when_ci_mode(isolated_cwd, monkeypatch):
+    monkeypatch.setattr(accessibility, "_discover_pages", lambda: None)
+    env = accessibility._build_env("https://example.com", ci_mode=True)
+    assert env["CI"] == "true"
+
+
+def test_build_cmd_default_reporter():
+    cmd = accessibility._build_cmd(ci_mode=False)
+    assert cmd[0] == "npx"
+    assert "playwright" in cmd
+    assert "--reporter=list" in cmd
+    assert str(accessibility.SPEC_PATH) in cmd
+
+
+def test_build_cmd_ci_uses_list_html_reporter():
+    cmd = accessibility._build_cmd(ci_mode=True)
+    assert "--reporter=list,html" in cmd
+
+
+# ── subprocess / runtime ─────────────────────────────────────────
+
+
+def test_npx_available_via_which(monkeypatch):
+    monkeypatch.setattr(accessibility.shutil, "which", lambda _: "/usr/bin/npx")
+    assert accessibility._npx_available() is True
+    monkeypatch.setattr(accessibility.shutil, "which", lambda _: None)
+    assert accessibility._npx_available() is False
+
+
+def test_run_returns_one_when_npx_missing(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.setattr(accessibility, "_npx_available", lambda: False)
+    rc = accessibility.run()
+    assert rc == 1
+    assert "npx is not available" in capsys.readouterr().out
+
+
+def test_run_returns_one_when_url_missing(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.setattr(accessibility, "_npx_available", lambda: True)
+    monkeypatch.delenv("ACCESSIBILITY_TEST_URL", raising=False)
+    monkeypatch.delenv("SMOKE_TEST_URL", raising=False)
+    rc = accessibility.run([])
+    assert rc == 1
+    assert "accessibility target URL is required" in capsys.readouterr().out
+
+
+def test_run_returns_one_when_spec_missing(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.setattr(accessibility, "_npx_available", lambda: True)
+    rc = accessibility.run(["--url", "https://example.com"])
+    assert rc == 1
+    assert "Accessibility spec not found" in capsys.readouterr().out
+
+
+def test_run_invokes_playwright(monkeypatch, isolated_cwd):
+    accessibility.SPEC_PATH.parent.mkdir(parents=True, exist_ok=True)
+    accessibility.SPEC_PATH.write_text("// fake spec")
+
+    captured: dict = {}
+
+    def fake_run(cmd, env, check):
+        captured["cmd"] = cmd
+        captured["env"] = env
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(accessibility, "_npx_available", lambda: True)
+    monkeypatch.setattr(accessibility, "_discover_pages", lambda: None)
+    monkeypatch.setattr(accessibility.subprocess, "run", fake_run)
+
+    rc = accessibility.run(["--url", "https://example.com"])
+    assert rc == 0
+    assert captured["cmd"][:2] == ["npx", "playwright"]
+    assert "--reporter=list" in captured["cmd"]
+    assert captured["env"]["ACCESSIBILITY_TEST_URL"] == "https://example.com"
+
+
+def test_run_ci_mode_threads_html_reporter(monkeypatch, isolated_cwd):
+    accessibility.SPEC_PATH.parent.mkdir(parents=True, exist_ok=True)
+    accessibility.SPEC_PATH.write_text("// fake spec")
+
+    captured: dict = {}
+
+    def fake_run(cmd, env, check):
+        captured["cmd"] = cmd
+        captured["env"] = env
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(accessibility, "_npx_available", lambda: True)
+    monkeypatch.setattr(accessibility, "_discover_pages", lambda: None)
+    monkeypatch.setattr(accessibility.subprocess, "run", fake_run)
+
+    rc = accessibility.run(["--url", "https://example.com", "--ci"])
+    assert rc == 0
+    assert "--reporter=list,html" in captured["cmd"]
+    assert captured["env"]["CI"] == "true"
+
+
+def test_run_propagates_playwright_failure(monkeypatch, isolated_cwd):
+    accessibility.SPEC_PATH.parent.mkdir(parents=True, exist_ok=True)
+    accessibility.SPEC_PATH.write_text("// fake spec")
+
+    monkeypatch.setattr(accessibility, "_npx_available", lambda: True)
+    monkeypatch.setattr(accessibility, "_discover_pages", lambda: None)
+    monkeypatch.setattr(
+        accessibility.subprocess, "run",
+        lambda cmd, env, check: subprocess.CompletedProcess(cmd, 1),
+    )
+
+    rc = accessibility.run(["--url", "https://example.com"])
+    assert rc == 1


### PR DESCRIPTION
## Summary

- Ports the bash `reliability:accessibility` flow (`npx playwright test --config=.ss/playwright.config.js .ss/tests/accessibility.spec.ts`) into `cli/slopstopper/checks/accessibility.py`.
- First reliability port that needs **discover-pages.py** subprocess-invocation — preserves the bash-side behaviour of resolving `pages.accessibility` from `.slopstopper.yml` via the shared script. (Lifting `discover-pages.py` into the CLI package is queued as part of the "ship .ss/ artifacts as package data" follow-up.)
- Threads `ACCESSIBILITY_TEST_URL` via `--url` flag or env, falling back to `SMOKE_TEST_URL` to match the bash flow.

## Licensing

Playwright is Apache-2.0, axe-core is MPL-2.0 (file-level copyleft, no contagion to subprocess callers). slopstopper-cli wheel ships zero code from either — both bind in via the adopter's node_modules.

## Why excluded from parity

| Reason | Detail |
| --- | --- |
| No diffable reports | Playwright emits HTML/list reporter output to `.ss/playwright-report/`, not `.ss/reports/*-report.{md,json}` files we can byte-diff. |
| Non-determinism | Live URL probing + first-paint timing flicker. |
| Test surface | The CLI port is a thin launch envelope; args / env / discover-pages plumbing is unit-tested (23 tests). |

## Status

| | Check | Tests | Parity |
| --- | --- | --- | --- |
| 1–6 | hygiene suite | ✅ | ✅ |
| 7 | `security:secrets` | ✅ | ✅ md + json |
| 8 | `security:sast` | ✅ | ✅ md (JSON volatile) |
| 9 | `security:dependencies` | ✅ | ✅ md (JSON volatile) |
| 10 | `security:dast` | ✅ | ⏭️ excluded |
| 11 | `reliability:smoke` | ✅ | ⏭️ excluded |
| 12 | `reliability:cwv` | ✅ | ⏭️ excluded |
| 13 | `reliability:accessibility` | ✅ | ⏭️ excluded |

259 tests pass.

## Remaining

- `reliability:seo` — different shape from the others (Python script `check-seo-metatags.py`, not Playwright). Will need subprocess-invoking the bash-side script for now, with full port deferred to the package-data follow-up.
- `reliability:broken-links` — last Playwright wrapper, near-identical to this one.

## Test plan

- [x] `task -t cli/Taskfile.yml test` — 259 passed (CI=true env tested)
- [x] `slopstopper run reliability:accessibility -- --url URL` — args plumbed
- [ ] CI `pytest` job green
- [ ] CI `bash↔cli parity` job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)