### PR TITLE
feat(cli): port reliability:broken-links as fourteenth CLI check

### DIFF
--- a/cli/Taskfile.yml
+++ b/cli/Taskfile.yml
@@ -259,6 +259,16 @@ tasks:
         # subprocess. Args / env / discover-pages plumbing is unit-
         # tested in cli/tests/checks/test_accessibility.py (23 tests).
 
+        # reliability:broken-links — intentionally NOT parity-tested.
+        # Same shape as reliability:accessibility (Playwright spec
+        # against a live URL). Live HEAD probes are network-dependent;
+        # results vary with target uptime, redirects, third-party
+        # outbound link availability. Port plumbs --url,
+        # BROKEN_LINKS_TEST_URL / SMOKE_TEST_URL fallback, and
+        # BROKEN_LINKS_PAGES via discover-pages.py subprocess. Args
+        # / env / discover-pages plumbing is unit-tested in
+        # cli/tests/checks/test_broken_links.py (22 tests).
+
         echo ""
         if [ "$FAILED" -eq 0 ]; then
           echo "All parity checks passed."

--- a/cli/slopstopper/checks/__init__.py
+++ b/cli/slopstopper/checks/__init__.py
@@ -6,6 +6,7 @@ from typing import Callable, Optional
 
 from slopstopper.checks import (
     accessibility,
+    broken_links,
     complexity,
     csp_exceptions,
     cwv,
@@ -28,6 +29,7 @@ REGISTRY: dict[str, Callable[[Optional[list[str]]], int]] = {
     "hygiene:docs-structure": docs_structure.run,
     "hygiene:entry-files": entry_files.run,
     "reliability:accessibility": accessibility.run,
+    "reliability:broken-links": broken_links.run,
     "reliability:cwv": cwv.run,
     "reliability:smoke": smoke.run,
     "security:dast": dast.run,

--- a/cli/slopstopper/checks/broken_links.py
+++ b/cli/slopstopper/checks/broken_links.py
@@ -1,0 +1,128 @@
+"""Broken-link checks (Playwright wrapper).
+
+Ports the bash reliability:links flow:
+
+  task ss:reliability:links -- https://your-site.example.com
+
+  which is, under the covers:
+
+  BROKEN_LINKS_PAGES=$(python3 .ss/scripts/discover-pages.py
+                              broken_links --event=local)
+  BROKEN_LINKS_TEST_URL=...
+  npx playwright test --config=.ss/playwright.config.js
+                      .ss/tests/broken-links.spec.ts
+                      --reporter=list[,html]
+
+Subprocess-invokes `npx playwright`. Playwright is Apache-2.0; the
+slopstopper-cli wheel ships zero Playwright code. discover-pages.py
+is still adopter-vendored today (subprocess-invoked here for parity);
+lifting it into the package is a follow-up.
+
+Falls back to SMOKE_TEST_URL when BROKEN_LINKS_TEST_URL is unset,
+matching the bash flow exactly.
+
+Exit codes:
+  0 — playwright tests passed
+  non-zero — playwright tests failed, or URL/spec missing
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+SPEC_PATH = Path(".ss/tests/broken-links.spec.ts")
+PLAYWRIGHT_CONFIG = Path(".ss/playwright.config.js")
+DISCOVER_PAGES = Path(".ss/scripts/discover-pages.py")
+
+
+def _parse_args(args: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="slopstopper run reliability:broken-links", add_help=False
+    )
+    p.add_argument("--url", default=None, help="Site URL to scan")
+    p.add_argument("--ci", action="store_true", help="CI mode: html reporter, CI=true")
+    p.add_argument("--help", "-h", action="help")
+    return p.parse_args(args or [])
+
+
+def _npx_available() -> bool:
+    return shutil.which("npx") is not None
+
+
+def _resolve_url(parsed_url: str | None) -> str | None:
+    return (
+        parsed_url
+        or os.environ.get("BROKEN_LINKS_TEST_URL")
+        or os.environ.get("SMOKE_TEST_URL")
+    )
+
+
+def _discover_pages() -> str | None:
+    if not DISCOVER_PAGES.exists():
+        return None
+    try:
+        result = subprocess.run(
+            [sys.executable, str(DISCOVER_PAGES), "broken_links", "--event=local"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+        out = result.stdout.strip()
+        return out or None
+    except OSError:
+        return None
+
+
+def _build_env(url: str, ci_mode: bool) -> dict[str, str]:
+    env = dict(os.environ)
+    env["BROKEN_LINKS_TEST_URL"] = url
+    if "BROKEN_LINKS_PAGES" not in env:
+        pages = _discover_pages()
+        if pages is not None:
+            env["BROKEN_LINKS_PAGES"] = pages
+    if ci_mode:
+        env["CI"] = "true"
+    return env
+
+
+def _build_cmd(ci_mode: bool) -> list[str]:
+    reporter = "list,html" if ci_mode else "list"
+    return [
+        "npx", "playwright", "test",
+        f"--config={PLAYWRIGHT_CONFIG}",
+        str(SPEC_PATH),
+        f"--reporter={reporter}",
+    ]
+
+
+def run(args: list[str] | None = None) -> int:
+    if not _npx_available():
+        print("❌ npx is not available — install Node.js to run Playwright tests")
+        return 1
+
+    parsed = _parse_args(args)
+    url = _resolve_url(parsed.url)
+    if not url:
+        print("❌ Error: broken-links target URL is required")
+        print("Usage:")
+        print("  slopstopper run reliability:broken-links -- --url https://your-site.example.com")
+        print("  BROKEN_LINKS_TEST_URL=https://your-site slopstopper run reliability:broken-links")
+        return 1
+
+    if not SPEC_PATH.exists():
+        print(f"❌ Broken-links spec not found at {SPEC_PATH}")
+        print("   The spec is vendored under .ss/tests/ by the installer.")
+        return 1
+
+    print(f"🔗 Running broken-link checks against: {url}")
+    env = _build_env(url, parsed.ci)
+    cmd = _build_cmd(parsed.ci)
+    result = subprocess.run(cmd, env=env, check=False)
+    return result.returncode

--- a/cli/tests/checks/test_broken_links.py
+++ b/cli/tests/checks/test_broken_links.py
@@ -1,0 +1,209 @@
+"""Tests for the reliability:broken-links check (Playwright wrapper)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+from slopstopper.checks import broken_links
+
+
+def test_parse_args_defaults():
+    parsed = broken_links._parse_args(None)
+    assert parsed.url is None
+    assert parsed.ci is False
+
+
+def test_parse_args_explicit():
+    parsed = broken_links._parse_args(["--url", "https://example.com", "--ci"])
+    assert parsed.url == "https://example.com"
+    assert parsed.ci is True
+
+
+def test_resolve_url_prefers_flag(monkeypatch):
+    monkeypatch.setenv("BROKEN_LINKS_TEST_URL", "https://from-bl")
+    monkeypatch.setenv("SMOKE_TEST_URL", "https://from-smoke")
+    assert broken_links._resolve_url("https://from-flag") == "https://from-flag"
+
+
+def test_resolve_url_falls_through_bl_env(monkeypatch):
+    monkeypatch.setenv("BROKEN_LINKS_TEST_URL", "https://from-bl")
+    monkeypatch.setenv("SMOKE_TEST_URL", "https://from-smoke")
+    assert broken_links._resolve_url(None) == "https://from-bl"
+
+
+def test_resolve_url_falls_through_smoke_env(monkeypatch):
+    monkeypatch.delenv("BROKEN_LINKS_TEST_URL", raising=False)
+    monkeypatch.setenv("SMOKE_TEST_URL", "https://from-smoke")
+    assert broken_links._resolve_url(None) == "https://from-smoke"
+
+
+def test_resolve_url_none_when_neither_set(monkeypatch):
+    monkeypatch.delenv("BROKEN_LINKS_TEST_URL", raising=False)
+    monkeypatch.delenv("SMOKE_TEST_URL", raising=False)
+    assert broken_links._resolve_url(None) is None
+
+
+def test_discover_pages_returns_none_when_script_missing(isolated_cwd):
+    assert broken_links._discover_pages() is None
+
+
+def test_discover_pages_returns_stdout_when_script_succeeds(monkeypatch, isolated_cwd):
+    broken_links.DISCOVER_PAGES.parent.mkdir(parents=True, exist_ok=True)
+    broken_links.DISCOVER_PAGES.write_text("# stub")
+
+    monkeypatch.setattr(
+        broken_links.subprocess, "run",
+        lambda cmd, capture_output, text, check: subprocess.CompletedProcess(
+            cmd, 0, stdout="/,/blog\n", stderr=""
+        ),
+    )
+    assert broken_links._discover_pages() == "/,/blog"
+
+
+def test_discover_pages_returns_none_on_non_zero_exit(monkeypatch, isolated_cwd):
+    broken_links.DISCOVER_PAGES.parent.mkdir(parents=True, exist_ok=True)
+    broken_links.DISCOVER_PAGES.write_text("# stub")
+
+    monkeypatch.setattr(
+        broken_links.subprocess, "run",
+        lambda cmd, capture_output, text, check: subprocess.CompletedProcess(
+            cmd, 1, stdout="ignore", stderr="error"
+        ),
+    )
+    assert broken_links._discover_pages() is None
+
+
+def test_build_env_threads_url(isolated_cwd, monkeypatch):
+    monkeypatch.delenv("BROKEN_LINKS_PAGES", raising=False)
+    monkeypatch.setattr(broken_links, "_discover_pages", lambda: None)
+    env = broken_links._build_env("https://example.com", ci_mode=False)
+    assert env["BROKEN_LINKS_TEST_URL"] == "https://example.com"
+
+
+def test_build_env_calls_discover_pages_when_unset(isolated_cwd, monkeypatch):
+    monkeypatch.delenv("BROKEN_LINKS_PAGES", raising=False)
+    monkeypatch.setattr(broken_links, "_discover_pages", lambda: "/,/about")
+    env = broken_links._build_env("https://example.com", ci_mode=False)
+    assert env["BROKEN_LINKS_PAGES"] == "/,/about"
+
+
+def test_build_env_preserves_caller_pages(monkeypatch):
+    monkeypatch.setenv("BROKEN_LINKS_PAGES", "/preset")
+    monkeypatch.setattr(broken_links, "_discover_pages", lambda: "/should-not-use")
+    env = broken_links._build_env("https://example.com", ci_mode=False)
+    assert env["BROKEN_LINKS_PAGES"] == "/preset"
+
+
+def test_build_env_does_not_set_ci_when_default(isolated_cwd, monkeypatch):
+    monkeypatch.setattr(broken_links, "_discover_pages", lambda: None)
+    caller_ci = os.environ.get("CI")
+    env = broken_links._build_env("https://example.com", ci_mode=False)
+    assert env.get("CI") == caller_ci
+
+
+def test_build_env_sets_ci_when_ci_mode(isolated_cwd, monkeypatch):
+    monkeypatch.setattr(broken_links, "_discover_pages", lambda: None)
+    env = broken_links._build_env("https://example.com", ci_mode=True)
+    assert env["CI"] == "true"
+
+
+def test_build_cmd_default_reporter():
+    cmd = broken_links._build_cmd(ci_mode=False)
+    assert cmd[0] == "npx"
+    assert "playwright" in cmd
+    assert "--reporter=list" in cmd
+    assert str(broken_links.SPEC_PATH) in cmd
+
+
+def test_build_cmd_ci_uses_list_html_reporter():
+    cmd = broken_links._build_cmd(ci_mode=True)
+    assert "--reporter=list,html" in cmd
+
+
+def test_npx_available_via_which(monkeypatch):
+    monkeypatch.setattr(broken_links.shutil, "which", lambda _: "/usr/bin/npx")
+    assert broken_links._npx_available() is True
+    monkeypatch.setattr(broken_links.shutil, "which", lambda _: None)
+    assert broken_links._npx_available() is False
+
+
+def test_run_returns_one_when_npx_missing(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.setattr(broken_links, "_npx_available", lambda: False)
+    rc = broken_links.run()
+    assert rc == 1
+    assert "npx is not available" in capsys.readouterr().out
+
+
+def test_run_returns_one_when_url_missing(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.setattr(broken_links, "_npx_available", lambda: True)
+    monkeypatch.delenv("BROKEN_LINKS_TEST_URL", raising=False)
+    monkeypatch.delenv("SMOKE_TEST_URL", raising=False)
+    rc = broken_links.run([])
+    assert rc == 1
+    assert "broken-links target URL is required" in capsys.readouterr().out
+
+
+def test_run_returns_one_when_spec_missing(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.setattr(broken_links, "_npx_available", lambda: True)
+    rc = broken_links.run(["--url", "https://example.com"])
+    assert rc == 1
+    assert "Broken-links spec not found" in capsys.readouterr().out
+
+
+def test_run_invokes_playwright(monkeypatch, isolated_cwd):
+    broken_links.SPEC_PATH.parent.mkdir(parents=True, exist_ok=True)
+    broken_links.SPEC_PATH.write_text("// fake spec")
+
+    captured: dict = {}
+
+    def fake_run(cmd, env, check):
+        captured["cmd"] = cmd
+        captured["env"] = env
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(broken_links, "_npx_available", lambda: True)
+    monkeypatch.setattr(broken_links, "_discover_pages", lambda: None)
+    monkeypatch.setattr(broken_links.subprocess, "run", fake_run)
+
+    rc = broken_links.run(["--url", "https://example.com"])
+    assert rc == 0
+    assert captured["cmd"][:2] == ["npx", "playwright"]
+    assert "--reporter=list" in captured["cmd"]
+    assert captured["env"]["BROKEN_LINKS_TEST_URL"] == "https://example.com"
+
+
+def test_run_ci_mode_threads_html_reporter(monkeypatch, isolated_cwd):
+    broken_links.SPEC_PATH.parent.mkdir(parents=True, exist_ok=True)
+    broken_links.SPEC_PATH.write_text("// fake spec")
+
+    captured: dict = {}
+
+    def fake_run(cmd, env, check):
+        captured["cmd"] = cmd
+        captured["env"] = env
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(broken_links, "_npx_available", lambda: True)
+    monkeypatch.setattr(broken_links, "_discover_pages", lambda: None)
+    monkeypatch.setattr(broken_links.subprocess, "run", fake_run)
+
+    rc = broken_links.run(["--url", "https://example.com", "--ci"])
+    assert rc == 0
+    assert "--reporter=list,html" in captured["cmd"]
+    assert captured["env"]["CI"] == "true"
+
+
+def test_run_propagates_playwright_failure(monkeypatch, isolated_cwd):
+    broken_links.SPEC_PATH.parent.mkdir(parents=True, exist_ok=True)
+    broken_links.SPEC_PATH.write_text("// fake spec")
+
+    monkeypatch.setattr(broken_links, "_npx_available", lambda: True)
+    monkeypatch.setattr(broken_links, "_discover_pages", lambda: None)
+    monkeypatch.setattr(
+        broken_links.subprocess, "run",
+        lambda cmd, env, check: subprocess.CompletedProcess(cmd, 1),
+    )
+
+    rc = broken_links.run(["--url", "https://example.com"])
+    assert rc == 1


### PR DESCRIPTION
## Summary

Mirror of the accessibility port — same Playwright shape, different spec:
- Subprocess-invokes `npx playwright test --config=.ss/playwright.config.js .ss/tests/broken-links.spec.ts`
- Threads `BROKEN_LINKS_TEST_URL` via `--url` or env, with `SMOKE_TEST_URL` fallback.
- Resolves `BROKEN_LINKS_PAGES` via `discover-pages.py` subprocess.
- `--ci` toggles `list,html` reporter and `CI=true`.

## Excluded from parity

Same reasons as smoke / cwv / accessibility: live URL probing is non-deterministic, results in `.ss/playwright-report/`, no `.ss/reports/*-report.*` files to byte-diff. 22 unit tests cover args / env / discover-pages plumbing instead.

## Status

| | Check | Tests | Parity |
| --- | --- | --- | --- |
| 1–6 | hygiene suite | ✅ | ✅ |
| 7–10 | security suite | ✅ | ✅ × 3, ⏭️ dast |
| 11 | `reliability:smoke` | ✅ | ⏭️ |
| 12 | `reliability:cwv` | ✅ | ⏭️ |
| 13 | `reliability:accessibility` | ✅ | ⏭️ |
| 14 | `reliability:broken-links` | ✅ | ⏭️ |

282 tests pass.

## Remaining

- `reliability:seo` — last one. Different shape: 434-line Python script `check-seo-metatags.py`, not Playwright. Will subprocess-invoke the script for now, full port deferred to the package-data lift.

## Test plan

- [x] `task -t cli/Taskfile.yml test` — 282 passed (CI=true env tested)
- [x] `slopstopper run reliability:broken-links -- --url URL` — args plumbed
- [ ] CI `pytest` green
- [ ] CI `bash↔cli parity` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)