### PR TITLE
feat(cli): port reliability:seo as fifteenth (and final) CLI check

### DIFF
--- a/cli/Taskfile.yml
+++ b/cli/Taskfile.yml
@@ -269,6 +269,17 @@ tasks:
         # / env / discover-pages plumbing is unit-tested in
         # cli/tests/checks/test_broken_links.py (22 tests).
 
+        # reliability:seo — intentionally NOT parity-tested. The CLI
+        # subprocess-invokes .ss/scripts/check-seo-metatags.py, which
+        # writes diffable .ss/reports/seo/*.{md,json} reports — but
+        # the underlying audit hits live URLs and HEAD-checks
+        # og:image hosts, so two back-to-back runs can disagree on
+        # transient network state. Args / env / discover-pages
+        # plumbing is unit-tested in cli/tests/checks/test_seo.py
+        # (18 tests). When the SEO script is lifted into the CLI
+        # package (next phase), this can become a true parity-eligible
+        # check if we standardise the URL fixture.
+
         echo ""
         if [ "$FAILED" -eq 0 ]; then
           echo "All parity checks passed."

--- a/cli/slopstopper/checks/__init__.py
+++ b/cli/slopstopper/checks/__init__.py
@@ -18,6 +18,7 @@ from slopstopper.checks import (
     entry_files,
     sast,
     secrets,
+    seo,
     smoke,
 )
 
@@ -31,6 +32,7 @@ REGISTRY: dict[str, Callable[[Optional[list[str]]], int]] = {
     "reliability:accessibility": accessibility.run,
     "reliability:broken-links": broken_links.run,
     "reliability:cwv": cwv.run,
+    "reliability:seo": seo.run,
     "reliability:smoke": smoke.run,
     "security:dast": dast.run,
     "security:dependencies": dependencies.run,

--- a/cli/slopstopper/checks/seo.py
+++ b/cli/slopstopper/checks/seo.py
@@ -1,0 +1,129 @@
+"""SEO + social-share metatag audit (subprocess wrapper).
+
+Ports the bash reliability:seo flow:
+
+  task ss:reliability:seo -- https://your-site.example.com
+
+  which is, under the covers:
+
+  SEO_TEST_URL=...
+  SEO_PAGES=$(python3 .ss/scripts/discover-pages.py seo --event=local)
+  python3 .ss/scripts/check-seo-metatags.py
+
+Unlike the Playwright reliability checks, this one wraps a stdlib-only
+Python script (.ss/scripts/check-seo-metatags.py, 434 lines) — no
+external tool dep beyond Python itself. The slopstopper-cli wheel
+still ships zero copy of the script today; it's adopter-vendored.
+Lifting check-seo-metatags.py and discover-pages.py into the CLI
+package (so adopters un-vendor .ss/scripts/) is the next phase.
+
+The wrapped script writes .ss/reports/seo/seo-metatags-report.{md,json}
+— real diffable reports — but SEO is still NOT parity-tested in CI
+because it hits live URLs (network-dependent, OG-image HEAD-checks
+can transiently fail).
+
+Threads SEO_TEST_URL via --url flag or env. Optional flags:
+  --pages, --no-require-og-image, --no-verify-og-image, --og-image-base
+all map onto the env vars the script already reads.
+
+Exit codes:
+  0 — all pages passed (or script reported pass)
+  1 — failures detected, or URL/script missing
+  other — propagated from the wrapped script
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_PATH = Path(".ss/scripts/check-seo-metatags.py")
+DISCOVER_PAGES = Path(".ss/scripts/discover-pages.py")
+
+
+def _parse_args(args: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="slopstopper run reliability:seo", add_help=False)
+    p.add_argument("--url", default=None, help="Site URL to audit")
+    p.add_argument("--pages", default=None, help="Comma-separated paths (default: /)")
+    p.add_argument(
+        "--no-require-og-image", action="store_true",
+        help="Skip og:image presence check",
+    )
+    p.add_argument(
+        "--no-verify-og-image", action="store_true",
+        help="Skip HEAD-fetching og:image",
+    )
+    p.add_argument(
+        "--og-image-base", default=None,
+        help="Rewrite og:image/twitter:image origin to this base before HEAD",
+    )
+    p.add_argument("--help", "-h", action="help")
+    return p.parse_args(args or [])
+
+
+def _resolve_url(parsed_url: str | None) -> str | None:
+    return parsed_url or os.environ.get("SEO_TEST_URL")
+
+
+def _discover_pages() -> str | None:
+    if not DISCOVER_PAGES.exists():
+        return None
+    try:
+        result = subprocess.run(
+            [sys.executable, str(DISCOVER_PAGES), "seo", "--event=local"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+        out = result.stdout.strip()
+        return out or None
+    except OSError:
+        return None
+
+
+def _build_env(parsed: argparse.Namespace, url: str) -> dict[str, str]:
+    env = dict(os.environ)
+    env["SEO_TEST_URL"] = url
+    if parsed.pages is not None:
+        env["SEO_PAGES"] = parsed.pages
+    elif "SEO_PAGES" not in env:
+        pages = _discover_pages()
+        if pages is not None:
+            env["SEO_PAGES"] = pages
+    if parsed.no_require_og_image:
+        env["SEO_REQUIRE_OG_IMAGE"] = "0"
+    if parsed.no_verify_og_image:
+        env["SEO_VERIFY_OG_IMAGE"] = "0"
+    if parsed.og_image_base is not None:
+        env["SEO_OG_IMAGE_BASE"] = parsed.og_image_base
+    return env
+
+
+def run(args: list[str] | None = None) -> int:
+    parsed = _parse_args(args)
+    url = _resolve_url(parsed.url)
+    if not url:
+        print("❌ Error: SEO target URL is required")
+        print("Usage:")
+        print("  slopstopper run reliability:seo -- --url https://your-site.example.com")
+        print("  SEO_TEST_URL=https://your-site slopstopper run reliability:seo")
+        return 1
+
+    if not SCRIPT_PATH.exists():
+        print(f"❌ SEO script not found at {SCRIPT_PATH}")
+        print("   The script is vendored under .ss/scripts/ by the installer.")
+        return 1
+
+    print(f"🔎 Running SEO metatag audit against: {url}")
+    env = _build_env(parsed, url)
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH)],
+        env=env,
+        check=False,
+    )
+    return result.returncode

--- a/cli/tests/checks/test_seo.py
+++ b/cli/tests/checks/test_seo.py
@@ -1,0 +1,184 @@
+"""Tests for the reliability:seo check (subprocess wrapper around
+check-seo-metatags.py)."""
+
+from __future__ import annotations
+
+import subprocess
+
+from slopstopper.checks import seo
+
+
+def test_parse_args_defaults():
+    parsed = seo._parse_args(None)
+    assert parsed.url is None
+    assert parsed.pages is None
+    assert parsed.no_require_og_image is False
+    assert parsed.no_verify_og_image is False
+    assert parsed.og_image_base is None
+
+
+def test_parse_args_explicit():
+    parsed = seo._parse_args([
+        "--url", "https://example.com",
+        "--pages", "/,/blog",
+        "--no-require-og-image",
+        "--no-verify-og-image",
+        "--og-image-base", "http://localhost:8080",
+    ])
+    assert parsed.url == "https://example.com"
+    assert parsed.pages == "/,/blog"
+    assert parsed.no_require_og_image is True
+    assert parsed.no_verify_og_image is True
+    assert parsed.og_image_base == "http://localhost:8080"
+
+
+def test_resolve_url_prefers_flag(monkeypatch):
+    monkeypatch.setenv("SEO_TEST_URL", "https://from-env")
+    assert seo._resolve_url("https://from-flag") == "https://from-flag"
+
+
+def test_resolve_url_falls_back_to_env(monkeypatch):
+    monkeypatch.setenv("SEO_TEST_URL", "https://from-env")
+    assert seo._resolve_url(None) == "https://from-env"
+
+
+def test_resolve_url_none_when_neither_set(monkeypatch):
+    monkeypatch.delenv("SEO_TEST_URL", raising=False)
+    assert seo._resolve_url(None) is None
+
+
+def test_discover_pages_returns_none_when_script_missing(isolated_cwd):
+    assert seo._discover_pages() is None
+
+
+def test_discover_pages_returns_stdout_when_script_succeeds(monkeypatch, isolated_cwd):
+    seo.DISCOVER_PAGES.parent.mkdir(parents=True, exist_ok=True)
+    seo.DISCOVER_PAGES.write_text("# stub")
+
+    monkeypatch.setattr(
+        seo.subprocess, "run",
+        lambda cmd, capture_output, text, check: subprocess.CompletedProcess(
+            cmd, 0, stdout="/,/blog\n", stderr=""
+        ),
+    )
+    assert seo._discover_pages() == "/,/blog"
+
+
+def test_discover_pages_returns_none_on_non_zero_exit(monkeypatch, isolated_cwd):
+    seo.DISCOVER_PAGES.parent.mkdir(parents=True, exist_ok=True)
+    seo.DISCOVER_PAGES.write_text("# stub")
+
+    monkeypatch.setattr(
+        seo.subprocess, "run",
+        lambda cmd, capture_output, text, check: subprocess.CompletedProcess(
+            cmd, 1, stdout="ignore", stderr="error"
+        ),
+    )
+    assert seo._discover_pages() is None
+
+
+def test_build_env_threads_url(isolated_cwd, monkeypatch):
+    monkeypatch.delenv("SEO_PAGES", raising=False)
+    monkeypatch.setattr(seo, "_discover_pages", lambda: None)
+    parsed = seo._parse_args(["--url", "https://example.com"])
+    env = seo._build_env(parsed, "https://example.com")
+    assert env["SEO_TEST_URL"] == "https://example.com"
+
+
+def test_build_env_pages_flag_overrides_discovery(isolated_cwd, monkeypatch):
+    monkeypatch.setattr(seo, "_discover_pages", lambda: "/should-not-use")
+    parsed = seo._parse_args(["--url", "https://example.com", "--pages", "/explicit"])
+    env = seo._build_env(parsed, "https://example.com")
+    assert env["SEO_PAGES"] == "/explicit"
+
+
+def test_build_env_uses_discover_pages_when_unset(isolated_cwd, monkeypatch):
+    monkeypatch.delenv("SEO_PAGES", raising=False)
+    monkeypatch.setattr(seo, "_discover_pages", lambda: "/,/from-discover")
+    parsed = seo._parse_args(["--url", "https://example.com"])
+    env = seo._build_env(parsed, "https://example.com")
+    assert env["SEO_PAGES"] == "/,/from-discover"
+
+
+def test_build_env_preserves_caller_pages(monkeypatch):
+    monkeypatch.setenv("SEO_PAGES", "/preset")
+    monkeypatch.setattr(seo, "_discover_pages", lambda: "/should-not-use")
+    parsed = seo._parse_args(["--url", "https://example.com"])
+    env = seo._build_env(parsed, "https://example.com")
+    assert env["SEO_PAGES"] == "/preset"
+
+
+def test_build_env_threads_og_image_flags(isolated_cwd, monkeypatch):
+    monkeypatch.setattr(seo, "_discover_pages", lambda: None)
+    parsed = seo._parse_args([
+        "--url", "https://example.com",
+        "--no-require-og-image",
+        "--no-verify-og-image",
+        "--og-image-base", "http://local",
+    ])
+    env = seo._build_env(parsed, "https://example.com")
+    assert env["SEO_REQUIRE_OG_IMAGE"] == "0"
+    assert env["SEO_VERIFY_OG_IMAGE"] == "0"
+    assert env["SEO_OG_IMAGE_BASE"] == "http://local"
+
+
+def test_build_env_omits_og_image_flags_by_default(isolated_cwd, monkeypatch):
+    monkeypatch.delenv("SEO_REQUIRE_OG_IMAGE", raising=False)
+    monkeypatch.delenv("SEO_VERIFY_OG_IMAGE", raising=False)
+    monkeypatch.delenv("SEO_OG_IMAGE_BASE", raising=False)
+    monkeypatch.setattr(seo, "_discover_pages", lambda: None)
+    parsed = seo._parse_args(["--url", "https://example.com"])
+    env = seo._build_env(parsed, "https://example.com")
+    assert "SEO_REQUIRE_OG_IMAGE" not in env
+    assert "SEO_VERIFY_OG_IMAGE" not in env
+    assert "SEO_OG_IMAGE_BASE" not in env
+
+
+# ── subprocess / runtime ─────────────────────────────────────────
+
+
+def test_run_returns_one_when_url_missing(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.delenv("SEO_TEST_URL", raising=False)
+    rc = seo.run([])
+    assert rc == 1
+    assert "SEO target URL is required" in capsys.readouterr().out
+
+
+def test_run_returns_one_when_script_missing(monkeypatch, isolated_cwd, capsys):
+    rc = seo.run(["--url", "https://example.com"])
+    assert rc == 1
+    assert "SEO script not found" in capsys.readouterr().out
+
+
+def test_run_invokes_seo_script(monkeypatch, isolated_cwd):
+    seo.SCRIPT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    seo.SCRIPT_PATH.write_text("# stub")
+
+    captured: dict = {}
+
+    def fake_run(cmd, env, check):
+        captured["cmd"] = cmd
+        captured["env"] = env
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(seo, "_discover_pages", lambda: None)
+    monkeypatch.setattr(seo.subprocess, "run", fake_run)
+
+    rc = seo.run(["--url", "https://example.com"])
+    assert rc == 0
+    assert str(seo.SCRIPT_PATH) in captured["cmd"]
+    assert captured["env"]["SEO_TEST_URL"] == "https://example.com"
+
+
+def test_run_propagates_script_failure(monkeypatch, isolated_cwd):
+    seo.SCRIPT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    seo.SCRIPT_PATH.write_text("# stub")
+
+    monkeypatch.setattr(seo, "_discover_pages", lambda: None)
+    monkeypatch.setattr(
+        seo.subprocess, "run",
+        lambda cmd, env, check: subprocess.CompletedProcess(cmd, 1),
+    )
+
+    rc = seo.run(["--url", "https://example.com"])
+    assert rc == 1


### PR DESCRIPTION
## Summary

🎉 **Final port.** All 15 existing slopstopper checks now have CLI implementations.

SEO has a different shape from the other reliability ports — it wraps the **stdlib-only Python script** `.ss/scripts/check-seo-metatags.py` (434 lines, no external tool dep), not a Playwright spec or external binary. The CLI port is a thin env-builder + subprocess that maps CLI flags onto the env vars the script already reads.

## Surface

```
slopstopper run reliability:seo -- \
  --url https://your-site.example.com \
  [--pages /,/blog] \
  [--no-require-og-image] \
  [--no-verify-og-image] \
  [--og-image-base http://localhost:8080]
```

Threads `SEO_TEST_URL` via `--url` flag or env; resolves `SEO_PAGES` via `discover-pages.py` subprocess; the rest map onto `SEO_REQUIRE_OG_IMAGE`, `SEO_VERIFY_OG_IMAGE`, `SEO_OG_IMAGE_BASE`.

## Why not parity-tested

The wrapped script writes `.ss/reports/seo/*.{md,json}` — real diffable reports — but the audit hits live URLs and HEAD-checks og:image hosts. Two back-to-back runs can disagree on transient network state. Once the SEO script is lifted into the CLI package (next phase), this can become a parity-eligible check if we standardise the URL fixture.

## All 15 checks complete

| Category | Checks |
| --- | --- |
| hygiene | docs-size, entry-files, docs-structure, docs-accuracy, complexity, csp-exceptions |
| security | secrets, sast, dependencies, dast |
| reliability | smoke, cwv, accessibility, broken-links, seo |

300 tests pass. 9 parity-eligible checks green in CI; 6 excluded by design (live-URL / Docker / non-deterministic outputs).

## What's next (post-merge)

This PR finishes **Phase 1** of the CLI pivot: every check is callable via `slopstopper run <category>:<name>`. The big remaining architectural changes:

1. **Lift `.ss/` artifacts into the CLI package** — move `.ss/scripts/*.py`, `.ss/tests/*.spec.ts`, `.ss/playwright.config.js`, `.ss/lighthouserc.json` into `cli/slopstopper/data/` and ship as package data. Adopters can then un-vendor `.ss/scripts/` and `.ss/tests/` entirely.
2. **Flip workflows to call the CLI** — `task ss:<...>` → `slopstopper run <...>` in `.github/workflows/ss-*.yml`. Add `--emit=pr-comment|issue` to absorb the duplicated `actions/github-script@v7` JS blocks.
3. **Delete the bash scripts** — `.ss/scripts/*.py`, `.ss/scripts/*.sh` go away once CI is on the CLI and adopters have upgraded.
4. **Publish to PyPI** — `pipx install slopstopper-cli`.
5. **Rewrite the skill trio** against the new CLI shape (`slopstopper inspect check <name>` for triage).

## Test plan

- [x] `task -t cli/Taskfile.yml test` — 300 passed (CI=true env tested)
- [x] `slopstopper run reliability:seo -- --url URL` — args plumbed via REMAINDER passthrough
- [ ] CI `pytest` green
- [ ] CI `bash↔cli parity` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)