### PR TITLE
feat(cli): lift discover-pages.py into the CLI package (Phase 2 begins)

### DIFF
--- a/cli/slopstopper/checks/accessibility.py
+++ b/cli/slopstopper/checks/accessibility.py
@@ -33,12 +33,12 @@ import argparse
 import os
 import shutil
 import subprocess
-import sys
 from pathlib import Path
+
+from slopstopper import discovery
 
 SPEC_PATH = Path(".ss/tests/accessibility.spec.ts")
 PLAYWRIGHT_CONFIG = Path(".ss/playwright.config.js")
-DISCOVER_PAGES = Path(".ss/scripts/discover-pages.py")
 
 
 def _parse_args(args: list[str] | None) -> argparse.Namespace:
@@ -64,26 +64,15 @@ def _resolve_url(parsed_url: str | None) -> str | None:
 
 
 def _discover_pages() -> str | None:
-    """Subprocess discover-pages.py to resolve pages.accessibility from config.
-
-    Mirrors the bash behaviour: only runs if discover-pages.py exists; on
-    any failure, returns None and lets the spec fall back to its default.
+    """Resolve pages.accessibility from .slopstopper.yml via the in-CLI
+    discovery module. Returns None on internal failure so the spec falls
+    back to its built-in default.
     """
-    if not DISCOVER_PAGES.exists():
-        return None
     try:
-        result = subprocess.run(
-            [sys.executable, str(DISCOVER_PAGES), "accessibility", "--event=local"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if result.returncode != 0:
-            return None
-        out = result.stdout.strip()
-        return out or None
-    except OSError:
+        paths = discovery.discover("accessibility", "local")
+    except Exception:
         return None
+    return ",".join(paths) if paths else None
 
 
 def _build_env(url: str, ci_mode: bool) -> dict[str, str]:

--- a/cli/slopstopper/checks/broken_links.py
+++ b/cli/slopstopper/checks/broken_links.py
@@ -32,12 +32,12 @@ import argparse
 import os
 import shutil
 import subprocess
-import sys
 from pathlib import Path
+
+from slopstopper import discovery
 
 SPEC_PATH = Path(".ss/tests/broken-links.spec.ts")
 PLAYWRIGHT_CONFIG = Path(".ss/playwright.config.js")
-DISCOVER_PAGES = Path(".ss/scripts/discover-pages.py")
 
 
 def _parse_args(args: list[str] | None) -> argparse.Namespace:
@@ -63,21 +63,12 @@ def _resolve_url(parsed_url: str | None) -> str | None:
 
 
 def _discover_pages() -> str | None:
-    if not DISCOVER_PAGES.exists():
-        return None
+    """Resolve pages.broken_links via the in-CLI discovery module."""
     try:
-        result = subprocess.run(
-            [sys.executable, str(DISCOVER_PAGES), "broken_links", "--event=local"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if result.returncode != 0:
-            return None
-        out = result.stdout.strip()
-        return out or None
-    except OSError:
+        paths = discovery.discover("broken_links", "local")
+    except Exception:
         return None
+    return ",".join(paths) if paths else None
 
 
 def _build_env(url: str, ci_mode: bool) -> dict[str, str]:

--- a/cli/slopstopper/checks/seo.py
+++ b/cli/slopstopper/checks/seo.py
@@ -40,8 +40,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+from slopstopper import discovery
+
 SCRIPT_PATH = Path(".ss/scripts/check-seo-metatags.py")
-DISCOVER_PAGES = Path(".ss/scripts/discover-pages.py")
 
 
 def _parse_args(args: list[str] | None) -> argparse.Namespace:
@@ -69,21 +70,12 @@ def _resolve_url(parsed_url: str | None) -> str | None:
 
 
 def _discover_pages() -> str | None:
-    if not DISCOVER_PAGES.exists():
-        return None
+    """Resolve pages.seo via the in-CLI discovery module."""
     try:
-        result = subprocess.run(
-            [sys.executable, str(DISCOVER_PAGES), "seo", "--event=local"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if result.returncode != 0:
-            return None
-        out = result.stdout.strip()
-        return out or None
-    except OSError:
+        paths = discovery.discover("seo", "local")
+    except Exception:
         return None
+    return ",".join(paths) if paths else None
 
 
 def _build_env(parsed: argparse.Namespace, url: str) -> dict[str, str]:

--- a/cli/slopstopper/discovery.py
+++ b/cli/slopstopper/discovery.py
@@ -1,0 +1,366 @@
+"""Page-discovery orchestrator for the reliability gates.
+
+Lifted from .ss/scripts/discover-pages.py during Phase 2 of the CLI
+pivot. The bash-side script remains in place for adopters who haven't
+upgraded yet; the reliability check ports under cli/slopstopper/checks/
+now import this module directly instead of subprocess-invoking it.
+
+Resolves "which paths should I audit?" for a given check (accessibility,
+SEO, broken-links, smoke) and CI event (pr, main, cron, local).
+
+Resolution order (first hit wins):
+    1. Env-var override — if <CHECK>_PAGES is set, pass through.
+    2. reliability.coverage.<event> in .slopstopper.yml:
+         - "sitemap" → parse dist/client/sitemap-index.xml (or sibling
+           fallbacks), return every <loc> URL's path.
+         - "changed" (PR only) → git diff origin/main...HEAD, map each
+           changed source file to its output URL via framework-specific
+           rules (Astro / Next / SvelteKit auto-detected).
+         - "<path,path>" → comma-separated explicit list.
+    3. pages.<check> in .slopstopper.yml — existing hand-list behaviour.
+    4. Default → "/".
+
+Stdlib only — keeps the no-deps invariant.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Optional, Sequence
+from urllib.parse import urlparse
+
+from slopstopper import config
+
+
+CHECKS = ("smoke", "accessibility", "seo", "broken_links")
+EVENTS = ("pr", "main", "cron", "local")
+
+ENV_VAR_BY_CHECK = {
+    "smoke": "SMOKE_PAGES",
+    "accessibility": "ACCESSIBILITY_PAGES",
+    "seo": "SEO_PAGES",
+    "broken_links": "BROKEN_LINKS_PAGES",
+}
+
+SITEMAP_CANDIDATES = (
+    "dist/client/sitemap-index.xml",
+    "dist/sitemap-index.xml",
+    "dist/sitemap.xml",
+    "dist/sitemap-0.xml",
+    "build/sitemap.xml",
+    "out/sitemap.xml",
+    "public/sitemap.xml",
+)
+
+SITEMAP_NS = "{http://www.sitemaps.org/schemas/sitemap/0.9}"
+
+
+# ── Per-framework source-to-URL rules ─────────────────────────────────
+
+ASTRO_RULES: tuple[tuple[str, str], ...] = (
+    (r"^src/content/blog/(?P<slug>[^/]+)\.md$", "/blog/$slug/"),
+    (r"^src/content/blog/(?P<slug>[^/]+)\.mdx$", "/blog/$slug/"),
+    (r"^src/content/(?P<col>[^/]+)/(?P<slug>[^/]+)\.md$", "/$col/$slug/"),
+    (r"^src/content/(?P<col>[^/]+)/(?P<slug>[^/]+)\.mdx$", "/$col/$slug/"),
+    (r"^src/pages/index\.astro$", "/"),
+    (r"^src/pages/(?P<page>[^/]+)/index\.astro$", "/$page/"),
+    (r"^src/pages/(?P<page>[^/]+)\.astro$", "/$page/"),
+)
+
+NEXT_PAGES_RULES: tuple[tuple[str, str], ...] = (
+    (r"^pages/index\.tsx?$", "/"),
+    (r"^pages/index\.jsx?$", "/"),
+    (r"^pages/(?P<page>[^/]+)/index\.tsx?$", "/$page/"),
+    (r"^pages/(?P<page>[^/]+)/index\.jsx?$", "/$page/"),
+    (r"^pages/(?P<page>[^/]+)\.tsx?$", "/$page/"),
+    (r"^pages/(?P<page>[^/]+)\.jsx?$", "/$page/"),
+)
+
+NEXT_APP_RULES: tuple[tuple[str, str], ...] = (
+    (r"^app/page\.tsx?$", "/"),
+    (r"^app/page\.jsx?$", "/"),
+    (r"^app/(?P<route>[^/]+)/page\.tsx?$", "/$route/"),
+    (r"^app/(?P<route>[^/]+)/page\.jsx?$", "/$route/"),
+)
+
+SVELTEKIT_RULES: tuple[tuple[str, str], ...] = (
+    (r"^src/routes/\+page\.svelte$", "/"),
+    (r"^src/routes/(?P<route>[^/]+)/\+page\.svelte$", "/$route/"),
+)
+
+
+def _detect_framework_rules() -> tuple[tuple[str, str], ...]:
+    if any(Path(f).exists() for f in ("astro.config.mjs", "astro.config.js", "astro.config.ts")):
+        return ASTRO_RULES
+    if any(Path(f).exists() for f in ("next.config.mjs", "next.config.js", "next.config.ts")):
+        return NEXT_PAGES_RULES + NEXT_APP_RULES
+    if any(Path(f).exists() for f in ("svelte.config.js", "svelte.config.mjs")):
+        return SVELTEKIT_RULES
+    return ASTRO_RULES
+
+
+def log(msg: str) -> None:
+    """Stderr log — never pollutes the stdout payload the caller consumes."""
+    print(msg, file=sys.stderr)
+
+
+# ── Sitemap parsing ─────────────────────────────────────────────────
+
+
+def _find_sitemap_path() -> Optional[Path]:
+    for candidate in SITEMAP_CANDIDATES:
+        path = Path(candidate)
+        if path.exists():
+            return path
+    return None
+
+
+def _resolve_child_sitemap(parent: Path, loc: str) -> Optional[Path]:
+    candidate = parent.parent / Path(urlparse(loc).path).name
+    if candidate.exists():
+        return candidate
+    return None
+
+
+def _extract_paths_from_sitemap_xml(path: Path, seen: set[Path]) -> list[str]:
+    """Read a sitemap XML file; recurse into sitemap-index files.
+
+    The sitemap is local trusted build output produced by the adopter's
+    own build process — never adversary-controlled. Stdlib ElementTree's
+    default parser since Python 3.7.1 does not resolve external entities,
+    so XXE is moot. Defusedxml is avoided to keep the no-deps invariant.
+    """
+    if path in seen:
+        return []
+    seen.add(path)
+    try:
+        # nosemgrep: python.lang.security.use-defused-xml-parse.use-defused-xml-parse
+        tree = ET.parse(path)  # nosec B314
+    except ET.ParseError as e:
+        log(f"⚠️  Failed to parse sitemap {path}: {e}")
+        return []
+    root = tree.getroot()
+    if root.tag == f"{SITEMAP_NS}sitemapindex":
+        return _collect_from_index(root, path, seen)
+    if root.tag == f"{SITEMAP_NS}urlset":
+        return _collect_from_urlset(root)
+    return []
+
+
+def _collect_from_index(root: ET.Element, path: Path, seen: set[Path]) -> list[str]:
+    paths: list[str] = []
+    for sitemap_el in root.findall(f"{SITEMAP_NS}sitemap"):
+        loc = sitemap_el.find(f"{SITEMAP_NS}loc")
+        if loc is None or not loc.text:
+            continue
+        child = _resolve_child_sitemap(path, loc.text.strip())
+        if child is not None:
+            paths.extend(_extract_paths_from_sitemap_xml(child, seen))
+    return paths
+
+
+def _collect_from_urlset(root: ET.Element) -> list[str]:
+    paths: list[str] = []
+    for url_el in root.findall(f"{SITEMAP_NS}url"):
+        loc = url_el.find(f"{SITEMAP_NS}loc")
+        if loc is None or not loc.text:
+            continue
+        parsed = urlparse(loc.text.strip())
+        paths.append(parsed.path or "/")
+    return paths
+
+
+def _dedupe(paths: list[str]) -> list[str]:
+    seen: set[str] = set()
+    return [p for p in paths if not (p in seen or seen.add(p))]
+
+
+def _from_sitemap() -> list[str]:
+    path = _find_sitemap_path()
+    if path is None:
+        log(
+            "❌ sitemap mode: no sitemap found at any of: "
+            + ", ".join(SITEMAP_CANDIDATES)
+        )
+        log("   Run `npm run build` (or your build command) first.")
+        return []
+    log(f"📄 Sitemap discovered: {path}")
+    unique = _dedupe(_extract_paths_from_sitemap_xml(path, set()))
+    log(f"   → {len(unique)} unique paths")
+    return unique
+
+
+# ── Changed-pages mode ───────────────────────────────────────────────
+
+
+def _git_diff_files(base_ref: str) -> Optional[list[str]]:
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        log(f"⚠️  git diff failed: {e}")
+        log(
+            "   Hint: set `fetch-depth: 0` on actions/checkout for this workflow."
+        )
+        return None
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _file_matches_any_glob(file_path: str, patterns: Sequence[str]) -> bool:
+    return any(fnmatch.fnmatchcase(file_path, p) for p in patterns)
+
+
+def _expand_url_template(template: str, match: re.Match) -> str:
+    def replace(m: re.Match) -> str:
+        name = m.group(1) or m.group(2)
+        return match.groupdict().get(name, "") or ""
+
+    return re.sub(r"\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}|\$([a-zA-Z_][a-zA-Z0-9_]*)", replace, template)
+
+
+def _map_file_to_urls(file_path: str, rules: Sequence[tuple[str, str]]) -> list[str]:
+    urls: list[str] = []
+    for pattern, template in rules:
+        try:
+            match = re.match(pattern, file_path)
+        except re.error as e:
+            log(f"⚠️  bad framework regex {pattern!r}: {e}")
+            continue
+        if match:
+            urls.append(_expand_url_template(template, match))
+    return urls
+
+
+def _resolve_base_ref() -> str:
+    base_ref = os.environ.get("GITHUB_BASE_REF") or "origin/main"
+    if not base_ref.startswith("origin/") and "/" not in base_ref:
+        base_ref = f"origin/{base_ref}"
+    return base_ref
+
+
+def _any_cross_cutting_change(files: list[str]) -> Optional[str]:
+    cross_cutting = list(config.get("reliability.coverage.cross_cutting_paths", []) or [])
+    for file_path in files:
+        if _file_matches_any_glob(file_path, cross_cutting):
+            return file_path
+    return None
+
+
+def _map_changed_files(files: list[str]) -> tuple[list[str], list[str]]:
+    rules = _detect_framework_rules()
+    urls: list[str] = []
+    unmapped: list[str] = []
+    for file_path in files:
+        mapped = _map_file_to_urls(file_path, rules)
+        if mapped:
+            urls.extend(mapped)
+        else:
+            unmapped.append(file_path)
+    return urls, unmapped
+
+
+def _from_changed_pages() -> list[str]:
+    files = _git_diff_files(_resolve_base_ref())
+    if files is None:
+        log("   → falling back to sitemap mode")
+        return _from_sitemap()
+
+    trigger = _any_cross_cutting_change(files)
+    if trigger:
+        log(f"🎯 Cross-cutting change detected: {trigger} matches cross_cutting_paths")
+        log("   → escalating to sitemap sweep")
+        return _from_sitemap()
+
+    urls, unmapped = _map_changed_files(files)
+    if unmapped:
+        log(f"ℹ️  {len(unmapped)} changed file(s) had no source_to_url match (permissive)")
+
+    unique = _dedupe(urls)
+    if not unique:
+        log("   → changed-pages produced empty set, falling through to sitemap")
+        return _from_sitemap()
+    log(f"   → {len(unique)} changed page(s) selected from {len(files)} file(s)")
+    return unique
+
+
+# ── Resolution orchestrator ───────────────────────────────────────────
+
+
+def _from_env(check: str) -> Optional[list[str]]:
+    env_name = ENV_VAR_BY_CHECK[check]
+    raw = os.environ.get(env_name)
+    if raw is None:
+        return None
+    paths = [p.strip() for p in raw.split(",") if p.strip()]
+    if paths:
+        log(f"🔁 {env_name} preset in environment ({len(paths)} path(s))")
+        return paths
+    return None
+
+
+def _coverage_mode_str(event: str) -> Optional[str]:
+    raw = config.get(f"reliability.coverage.{event}")
+    if isinstance(raw, str):
+        return raw.strip() or None
+    if isinstance(raw, list):
+        items = [str(p).strip() for p in raw if str(p).strip()]
+        if items:
+            return ",".join(items)
+    return None
+
+
+def _from_coverage_mode(event: str) -> Optional[list[str]]:
+    mode = _coverage_mode_str(event)
+    if mode is None:
+        return None
+    if mode == "sitemap":
+        return _from_sitemap()
+    if mode == "changed":
+        if event != "pr":
+            log(f"⚠️  changed mode only valid for --event=pr (got {event}); skipping")
+            return None
+        return _from_changed_pages()
+    paths = [p.strip() for p in mode.split(",") if p.strip()]
+    if paths:
+        log(f"📋 explicit list from reliability.coverage.{event} ({len(paths)} path(s))")
+        return paths
+    return None
+
+
+def _from_pages_list(check: str) -> Optional[list[str]]:
+    raw = config.get(f"pages.{check}")
+    if raw is None:
+        return None
+    if isinstance(raw, list):
+        paths = [str(p).strip() for p in raw if str(p).strip()]
+    else:
+        paths = [p.strip() for p in str(raw).split(",") if p.strip()]
+    if paths:
+        log(f"📜 pages.{check} ({len(paths)} path(s))")
+        return paths
+    return None
+
+
+def discover(check: str, event: str = "local") -> list[str]:
+    env_paths = _from_env(check)
+    if env_paths:
+        return env_paths
+    if event in {"pr", "main", "cron"}:
+        coverage_paths = _from_coverage_mode(event)
+        if coverage_paths:
+            return coverage_paths
+    pages_paths = _from_pages_list(check)
+    if pages_paths:
+        return pages_paths
+    log("ℹ️  no discovery hit; defaulting to /")
+    return ["/"]

--- a/cli/tests/checks/test_accessibility.py
+++ b/cli/tests/checks/test_accessibility.py
@@ -47,31 +47,21 @@ def test_resolve_url_none_when_neither_set(monkeypatch):
     assert accessibility._resolve_url(None) is None
 
 
-def test_discover_pages_returns_none_when_script_missing(isolated_cwd):
-    assert accessibility._discover_pages() is None
+def test_discover_pages_defaults_to_root_when_unconfigured(isolated_cwd):
+    # No .slopstopper.yml, no env vars — discovery falls through to "/"
+    assert accessibility._discover_pages() == "/"
 
 
-def test_discover_pages_returns_stdout_when_script_succeeds(monkeypatch, isolated_cwd):
-    accessibility.DISCOVER_PAGES.parent.mkdir(parents=True, exist_ok=True)
-    accessibility.DISCOVER_PAGES.write_text("# stub")
-
-    def fake_run(cmd, capture_output, text, check):
-        return subprocess.CompletedProcess(cmd, 0, stdout="/,/blog\n", stderr="")
-
-    monkeypatch.setattr(accessibility.subprocess, "run", fake_run)
+def test_discover_pages_returns_joined_paths(monkeypatch, isolated_cwd):
+    monkeypatch.setattr(accessibility.discovery, "discover", lambda check, event: ["/", "/blog"])
     assert accessibility._discover_pages() == "/,/blog"
 
 
-def test_discover_pages_returns_none_on_non_zero_exit(monkeypatch, isolated_cwd):
-    accessibility.DISCOVER_PAGES.parent.mkdir(parents=True, exist_ok=True)
-    accessibility.DISCOVER_PAGES.write_text("# stub")
+def test_discover_pages_returns_none_on_discovery_failure(monkeypatch, isolated_cwd):
+    def boom(check, event):
+        raise RuntimeError("boom")
 
-    monkeypatch.setattr(
-        accessibility.subprocess, "run",
-        lambda cmd, capture_output, text, check: subprocess.CompletedProcess(
-            cmd, 1, stdout="should ignore", stderr="error"
-        ),
-    )
+    monkeypatch.setattr(accessibility.discovery, "discover", boom)
     assert accessibility._discover_pages() is None
 
 

--- a/cli/tests/checks/test_broken_links.py
+++ b/cli/tests/checks/test_broken_links.py
@@ -44,33 +44,20 @@ def test_resolve_url_none_when_neither_set(monkeypatch):
     assert broken_links._resolve_url(None) is None
 
 
-def test_discover_pages_returns_none_when_script_missing(isolated_cwd):
-    assert broken_links._discover_pages() is None
+def test_discover_pages_defaults_to_root_when_unconfigured(isolated_cwd):
+    assert broken_links._discover_pages() == "/"
 
 
-def test_discover_pages_returns_stdout_when_script_succeeds(monkeypatch, isolated_cwd):
-    broken_links.DISCOVER_PAGES.parent.mkdir(parents=True, exist_ok=True)
-    broken_links.DISCOVER_PAGES.write_text("# stub")
-
-    monkeypatch.setattr(
-        broken_links.subprocess, "run",
-        lambda cmd, capture_output, text, check: subprocess.CompletedProcess(
-            cmd, 0, stdout="/,/blog\n", stderr=""
-        ),
-    )
+def test_discover_pages_returns_joined_paths(monkeypatch, isolated_cwd):
+    monkeypatch.setattr(broken_links.discovery, "discover", lambda check, event: ["/", "/blog"])
     assert broken_links._discover_pages() == "/,/blog"
 
 
-def test_discover_pages_returns_none_on_non_zero_exit(monkeypatch, isolated_cwd):
-    broken_links.DISCOVER_PAGES.parent.mkdir(parents=True, exist_ok=True)
-    broken_links.DISCOVER_PAGES.write_text("# stub")
+def test_discover_pages_returns_none_on_discovery_failure(monkeypatch, isolated_cwd):
+    def boom(check, event):
+        raise RuntimeError("boom")
 
-    monkeypatch.setattr(
-        broken_links.subprocess, "run",
-        lambda cmd, capture_output, text, check: subprocess.CompletedProcess(
-            cmd, 1, stdout="ignore", stderr="error"
-        ),
-    )
+    monkeypatch.setattr(broken_links.discovery, "discover", boom)
     assert broken_links._discover_pages() is None
 
 

--- a/cli/tests/checks/test_seo.py
+++ b/cli/tests/checks/test_seo.py
@@ -47,33 +47,20 @@ def test_resolve_url_none_when_neither_set(monkeypatch):
     assert seo._resolve_url(None) is None
 
 
-def test_discover_pages_returns_none_when_script_missing(isolated_cwd):
-    assert seo._discover_pages() is None
+def test_discover_pages_defaults_to_root_when_unconfigured(isolated_cwd):
+    assert seo._discover_pages() == "/"
 
 
-def test_discover_pages_returns_stdout_when_script_succeeds(monkeypatch, isolated_cwd):
-    seo.DISCOVER_PAGES.parent.mkdir(parents=True, exist_ok=True)
-    seo.DISCOVER_PAGES.write_text("# stub")
-
-    monkeypatch.setattr(
-        seo.subprocess, "run",
-        lambda cmd, capture_output, text, check: subprocess.CompletedProcess(
-            cmd, 0, stdout="/,/blog\n", stderr=""
-        ),
-    )
+def test_discover_pages_returns_joined_paths(monkeypatch, isolated_cwd):
+    monkeypatch.setattr(seo.discovery, "discover", lambda check, event: ["/", "/blog"])
     assert seo._discover_pages() == "/,/blog"
 
 
-def test_discover_pages_returns_none_on_non_zero_exit(monkeypatch, isolated_cwd):
-    seo.DISCOVER_PAGES.parent.mkdir(parents=True, exist_ok=True)
-    seo.DISCOVER_PAGES.write_text("# stub")
+def test_discover_pages_returns_none_on_discovery_failure(monkeypatch, isolated_cwd):
+    def boom(check, event):
+        raise RuntimeError("boom")
 
-    monkeypatch.setattr(
-        seo.subprocess, "run",
-        lambda cmd, capture_output, text, check: subprocess.CompletedProcess(
-            cmd, 1, stdout="ignore", stderr="error"
-        ),
-    )
+    monkeypatch.setattr(seo.discovery, "discover", boom)
     assert seo._discover_pages() is None
 
 

--- a/cli/tests/test_discovery.py
+++ b/cli/tests/test_discovery.py
@@ -1,0 +1,200 @@
+"""Tests for the in-CLI discovery module (lifted from
+.ss/scripts/discover-pages.py)."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from slopstopper import discovery
+
+
+SITEMAP_INDEX = """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://example.com/sitemap-0.xml</loc></sitemap>
+</sitemapindex>
+"""
+
+SITEMAP_URLSET = """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/</loc></url>
+  <url><loc>https://example.com/blog/</loc></url>
+  <url><loc>https://example.com/about/</loc></url>
+</urlset>
+"""
+
+
+# ── env-var override ──────────────────────────────────────────────
+
+
+def test_env_var_override_takes_precedence(isolated_cwd, monkeypatch, write_config):
+    write_config("pages:\n  smoke: /from-config\n")
+    monkeypatch.setenv("SMOKE_PAGES", "/from-env,/x")
+    assert discovery.discover("smoke", "local") == ["/from-env", "/x"]
+
+
+def test_env_var_empty_value_falls_through(isolated_cwd, monkeypatch, write_config):
+    write_config("pages:\n  smoke: /from-config\n")
+    monkeypatch.setenv("SMOKE_PAGES", "  ,  ")
+    assert discovery.discover("smoke", "local") == ["/from-config"]
+
+
+# ── pages.<check> ─────────────────────────────────────────────────
+
+
+def test_pages_list_comma_separated_string(isolated_cwd, write_config):
+    write_config("pages:\n  accessibility: /,/about\n")
+    assert discovery.discover("accessibility", "local") == ["/", "/about"]
+
+
+def test_pages_list_empty_falls_through_to_root(isolated_cwd, write_config):
+    write_config("pages: {}\n")
+    assert discovery.discover("accessibility", "local") == ["/"]
+
+
+def test_no_config_defaults_to_root(isolated_cwd):
+    assert discovery.discover("seo", "local") == ["/"]
+
+
+# ── coverage modes ────────────────────────────────────────────────
+
+
+def test_coverage_explicit_list_used_for_pr(isolated_cwd, write_config):
+    write_config(
+        "reliability:\n  coverage:\n    pr: /,/changed\n"
+        "pages:\n  smoke: /not-used\n"
+    )
+    assert discovery.discover("smoke", "pr") == ["/", "/changed"]
+
+
+def test_local_event_skips_coverage_modes(isolated_cwd, write_config):
+    write_config(
+        "reliability:\n  coverage:\n    pr: /coverage-only\n"
+        "pages:\n  smoke: /from-pages\n"
+    )
+    # event=local must NOT consult reliability.coverage.* — only pages.*
+    assert discovery.discover("smoke", "local") == ["/from-pages"]
+
+
+def test_changed_mode_outside_pr_skipped(isolated_cwd, write_config):
+    write_config(
+        "reliability:\n  coverage:\n    main: changed\n"
+        "pages:\n  smoke: /fallback\n"
+    )
+    assert discovery.discover("smoke", "main") == ["/fallback"]
+
+
+# ── sitemap parsing ──────────────────────────────────────────────
+
+
+def test_sitemap_mode_reads_urlset(isolated_cwd, write_config):
+    sitemap = Path("dist/sitemap.xml")
+    sitemap.parent.mkdir(parents=True, exist_ok=True)
+    sitemap.write_text(SITEMAP_URLSET)
+    write_config("reliability:\n  coverage:\n    main: sitemap\n")
+    paths = discovery.discover("smoke", "main")
+    assert "/" in paths
+    assert "/blog/" in paths
+    assert "/about/" in paths
+
+
+def test_sitemap_index_recurses_into_children(isolated_cwd, write_config):
+    Path("dist").mkdir(parents=True, exist_ok=True)
+    Path("dist/sitemap-index.xml").write_text(SITEMAP_INDEX)
+    Path("dist/sitemap-0.xml").write_text(SITEMAP_URLSET)
+    write_config("reliability:\n  coverage:\n    main: sitemap\n")
+    paths = discovery.discover("smoke", "main")
+    assert "/blog/" in paths
+
+
+def test_sitemap_missing_returns_empty(isolated_cwd, write_config):
+    write_config("reliability:\n  coverage:\n    main: sitemap\n")
+    # No sitemap files anywhere; coverage produces []. Falls through to
+    # pages.<check>, then to "/".
+    assert discovery.discover("smoke", "main") == ["/"]
+
+
+def test_sitemap_strips_to_path_component():
+    root = ET.fromstring(SITEMAP_URLSET)
+    paths = discovery._collect_from_urlset(root)
+    # Each <loc> URL is reduced to its path component
+    assert paths == ["/", "/blog/", "/about/"]
+
+
+# ── changed-pages mode ───────────────────────────────────────────
+
+
+def test_map_file_to_urls_with_astro_blog_md():
+    # Astro rules intentionally double-match blog content (specific + generic
+    # collection rule) — upstream _dedupe collapses these. We just confirm
+    # the URL is produced.
+    urls = discovery._map_file_to_urls("src/content/blog/hello.md", discovery.ASTRO_RULES)
+    assert "/blog/hello/" in urls
+
+
+def test_map_file_to_urls_with_astro_page():
+    # `index.astro` double-matches the specific and generic page rules in
+    # the original bash flow; just confirm the homepage URL is produced.
+    urls = discovery._map_file_to_urls("src/pages/index.astro", discovery.ASTRO_RULES)
+    assert "/" in urls
+
+
+def test_map_file_to_urls_with_next_pages_router():
+    urls = discovery._map_file_to_urls("pages/about.tsx", discovery.NEXT_PAGES_RULES)
+    assert urls == ["/about/"]
+
+
+def test_map_file_to_urls_with_next_app_router():
+    urls = discovery._map_file_to_urls("app/dashboard/page.tsx", discovery.NEXT_APP_RULES)
+    assert urls == ["/dashboard/"]
+
+
+def test_map_file_to_urls_unmapped_returns_empty():
+    urls = discovery._map_file_to_urls("README.md", discovery.ASTRO_RULES)
+    assert urls == []
+
+
+def test_detect_framework_default_to_astro(isolated_cwd):
+    # No framework config files — defaults to Astro rules
+    assert discovery._detect_framework_rules() == discovery.ASTRO_RULES
+
+
+def test_detect_framework_next(isolated_cwd):
+    Path("next.config.mjs").write_text("export default {}")
+    assert discovery._detect_framework_rules() == (
+        discovery.NEXT_PAGES_RULES + discovery.NEXT_APP_RULES
+    )
+
+
+def test_detect_framework_sveltekit(isolated_cwd):
+    Path("svelte.config.js").write_text("export default {}")
+    assert discovery._detect_framework_rules() == discovery.SVELTEKIT_RULES
+
+
+def test_cross_cutting_change_glob_match(isolated_cwd, write_config):
+    write_config(
+        "reliability:\n"
+        "  coverage:\n"
+        "    cross_cutting_paths:\n"
+        "      - 'src/layouts/*.astro'\n"
+        "      - 'package.json'\n"
+    )
+    trigger = discovery._any_cross_cutting_change(["src/layouts/Base.astro"])
+    assert trigger == "src/layouts/Base.astro"
+
+
+def test_cross_cutting_no_match(isolated_cwd, write_config):
+    write_config(
+        "reliability:\n  coverage:\n    cross_cutting_paths: ['package.json']\n"
+    )
+    assert discovery._any_cross_cutting_change(["docs/CHANGELOG.md"]) is None
+
+
+def test_expand_url_template_substitutes_named_groups():
+    import re
+    match = re.match(r"^(?P<slug>[^/]+)$", "hello")
+    assert discovery._expand_url_template("/blog/$slug/", match) == "/blog/hello/"
+
+
+def test_dedupe_preserves_order():
+    assert discovery._dedupe(["/", "/a", "/", "/b", "/a"]) == ["/", "/a", "/b"]


### PR DESCRIPTION
## Summary

**First Phase-2 PR.** Phase 1 closed out the CLI port for every check, but three reliability checks still subprocess-called `.ss/scripts/discover-pages.py`. This PR lifts that script into the CLI package as `cli/slopstopper/discovery.py` and refactors accessibility / broken-links / seo to import it directly.

The bash script `.ss/scripts/discover-pages.py` stays in place for adopters who haven't upgraded yet, but it is **no longer a CLI runtime dep** — adopters running purely off the CLI could delete it once they're on the new shape.

## What moved

| Aspect | Before | After |
| --- | --- | --- |
| Location | `.ss/scripts/discover-pages.py` (adopter-vendored) | `cli/slopstopper/discovery.py` (package data) |
| Config import | `import load_config` (sys.path hack) | `from slopstopper import config` (clean module) |
| Invocation | `subprocess.run([python, script, check, --event=local])` | `discovery.discover(check, event)` |
| Entry point | `main(argv)` + `if __name__ == "__main__"` | None (internal library) |

All logic preserved verbatim: sitemap parsing (urlset + sitemap-index recursion), framework rule detection (Astro / Next pages / Next app / SvelteKit), changed-pages git-diff mode, env-var override (`<CHECK>_PAGES`), coverage-mode resolution (`reliability.coverage.<event>`).

## Test additions

- `cli/tests/test_discovery.py` — **24 new tests** covering:
  - env-var override (precedence + empty fall-through)
  - `pages.<check>` (comma-string + missing)
  - coverage modes (`sitemap`, `changed`, explicit list, local-event skip)
  - sitemap urlset + sitemap-index recursion
  - framework auto-detection (default Astro, Next, SvelteKit)
  - source-to-URL mapping per framework
  - cross-cutting `fnmatch` glob detection
- `cli/tests/checks/test_{accessibility,broken_links,seo}.py` — rewrote 9 tests that monkeypatched the subprocess call to instead monkeypatch `discovery.discover()`.

## Status

324 tests pass (up from 300).

## Phase 2 remaining

- **Lift `check-seo-metatags.py` (434 lines)** into the CLI — last `.ss/scripts/*.py` subprocess dep.
- **Lift Playwright specs + config + Lighthouse config** as package data, with a `slopstopper sync-templates` command that writes them into `.ss/` for `npx` to find.
- **`--emit=pr-comment|issue`** to absorb the duplicated `actions/github-script@v7` JS blocks.
- **Flip workflows** to call `slopstopper run` instead of `task ss:*`.
- **Delete the bash scripts** once CI and adopters are on the new CLI.
- **Publish to PyPI** as `slopstopper-cli`.
- **Rewrite the skill trio** against the new CLI shape.

## Test plan

- [x] `task -t cli/Taskfile.yml test` — 324 passed
- [x] `task -t cli/Taskfile.yml parity` — all 9 parity-eligible checks green (lifted discovery doesn't affect parity-tested checks)
- [ ] CI `pytest` green
- [ ] CI `bash↔cli parity` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)