### PR TITLE
feat(cli): lift Playwright + Lighthouse templates as package data

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -40,6 +40,12 @@ Source = "https://github.com/hungovercoders/slopstopper"
 [tool.hatch.build.targets.wheel]
 packages = ["slopstopper"]
 
+# Bundle Playwright specs + configs and the Lighthouse CI config inside
+# the wheel. The reliability checks resolve to these by default; an
+# adopter can still override by writing the same-named file under .ss/.
+[tool.hatch.build.targets.wheel.force-include]
+"slopstopper/data" = "slopstopper/data"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q"

--- a/cli/slopstopper/checks/accessibility.py
+++ b/cli/slopstopper/checks/accessibility.py
@@ -33,12 +33,10 @@ import argparse
 import os
 import shutil
 import subprocess
-from pathlib import Path
 
-from slopstopper import discovery
+from slopstopper import discovery, templates
 
-SPEC_PATH = Path(".ss/tests/accessibility.spec.ts")
-PLAYWRIGHT_CONFIG = Path(".ss/playwright.config.js")
+SPEC_NAME = "accessibility"
 
 
 def _parse_args(args: list[str] | None) -> argparse.Namespace:
@@ -91,8 +89,8 @@ def _build_cmd(ci_mode: bool) -> list[str]:
     reporter = "list,html" if ci_mode else "list"
     return [
         "npx", "playwright", "test",
-        f"--config={PLAYWRIGHT_CONFIG}",
-        str(SPEC_PATH),
+        f"--config={templates.playwright_config()}",
+        str(templates.playwright_spec(SPEC_NAME)),
         f"--reporter={reporter}",
     ]
 
@@ -111,8 +109,9 @@ def run(args: list[str] | None = None) -> int:
         print("  ACCESSIBILITY_TEST_URL=https://your-site slopstopper run reliability:accessibility")
         return 1
 
-    if not SPEC_PATH.exists():
-        print(f"❌ Accessibility spec not found at {SPEC_PATH}")
+    spec = templates.playwright_spec(SPEC_NAME)
+    if not spec.exists():
+        print(f"❌ Accessibility spec not found at {spec}")
         print("   The spec is vendored under .ss/tests/ by the installer.")
         return 1
 

--- a/cli/slopstopper/checks/broken_links.py
+++ b/cli/slopstopper/checks/broken_links.py
@@ -32,12 +32,10 @@ import argparse
 import os
 import shutil
 import subprocess
-from pathlib import Path
 
-from slopstopper import discovery
+from slopstopper import discovery, templates
 
-SPEC_PATH = Path(".ss/tests/broken-links.spec.ts")
-PLAYWRIGHT_CONFIG = Path(".ss/playwright.config.js")
+SPEC_NAME = "broken-links"
 
 
 def _parse_args(args: list[str] | None) -> argparse.Namespace:
@@ -87,8 +85,8 @@ def _build_cmd(ci_mode: bool) -> list[str]:
     reporter = "list,html" if ci_mode else "list"
     return [
         "npx", "playwright", "test",
-        f"--config={PLAYWRIGHT_CONFIG}",
-        str(SPEC_PATH),
+        f"--config={templates.playwright_config()}",
+        str(templates.playwright_spec(SPEC_NAME)),
         f"--reporter={reporter}",
     ]
 
@@ -107,9 +105,9 @@ def run(args: list[str] | None = None) -> int:
         print("  BROKEN_LINKS_TEST_URL=https://your-site slopstopper run reliability:broken-links")
         return 1
 
-    if not SPEC_PATH.exists():
-        print(f"❌ Broken-links spec not found at {SPEC_PATH}")
-        print("   The spec is vendored under .ss/tests/ by the installer.")
+    spec = templates.playwright_spec(SPEC_NAME)
+    if not spec.exists():
+        print(f"❌ Broken-links spec not found at {spec}")
         return 1
 
     print(f"🔗 Running broken-link checks against: {url}")

--- a/cli/slopstopper/checks/cwv.py
+++ b/cli/slopstopper/checks/cwv.py
@@ -26,7 +26,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
-LHCI_CONFIG = Path(".ss/lighthouserc.json")
+from slopstopper import templates
 
 
 def _parse_args(args: list[str] | None) -> argparse.Namespace:
@@ -34,8 +34,9 @@ def _parse_args(args: list[str] | None) -> argparse.Namespace:
     p.add_argument("--url", default=None, help="Site URL to audit (else $CWV_URL)")
     p.add_argument(
         "--config",
-        default=str(LHCI_CONFIG),
-        help=f"Lighthouse CI config path (default: {LHCI_CONFIG})",
+        default=None,
+        help="Lighthouse CI config path (default: resolves via templates "
+        "module — .ss/lighthouserc.json override, else package data)",
     )
     p.add_argument("--help", "-h", action="help")
     return p.parse_args(args or [])
@@ -71,10 +72,9 @@ def run(args: list[str] | None = None) -> int:
         print("  CWV_URL=https://your-site slopstopper run reliability:cwv")
         return 1
 
-    config_path = Path(parsed.config)
+    config_path = Path(parsed.config) if parsed.config else templates.lighthouserc()
     if not config_path.exists():
         print(f"❌ Lighthouse CI config not found at {config_path}")
-        print("   The config is vendored under .ss/ by the installer.")
         return 1
 
     print(f"🚦 Running Core Web Vitals audit against: {url}")

--- a/cli/slopstopper/checks/smoke.py
+++ b/cli/slopstopper/checks/smoke.py
@@ -30,12 +30,10 @@ import argparse
 import os
 import shutil
 import subprocess
-from pathlib import Path
 
-from slopstopper import config
+from slopstopper import config, templates
 
-SPEC_PATH = Path(".ss/tests/smoke.spec.ts")
-PLAYWRIGHT_CONFIG = Path(".ss/playwright.config.js")
+SPEC_NAME = "smoke"
 
 
 def _parse_args(args: list[str] | None) -> argparse.Namespace:
@@ -68,8 +66,8 @@ def _build_cmd(ci_mode: bool) -> list[str]:
     reporter = "list,html" if ci_mode else "list"
     return [
         "npx", "playwright", "test",
-        f"--config={PLAYWRIGHT_CONFIG}",
-        str(SPEC_PATH),
+        f"--config={templates.playwright_config()}",
+        str(templates.playwright_spec(SPEC_NAME)),
         f"--reporter={reporter}",
     ]
 
@@ -86,11 +84,6 @@ def run(args: list[str] | None = None) -> int:
         print("Usage:")
         print("  slopstopper run reliability:smoke -- --url https://your-site.example.com")
         print("  SMOKE_TEST_URL=https://your-site slopstopper run reliability:smoke")
-        return 1
-
-    if not SPEC_PATH.exists():
-        print(f"❌ Smoke spec not found at {SPEC_PATH}")
-        print("   The spec is vendored under .ss/tests/ by the installer.")
         return 1
 
     print(f"🔍 Running smoke tests against: {url}")

--- a/cli/slopstopper/data/lighthouserc.json
+++ b/cli/slopstopper/data/lighthouserc.json
@@ -1,0 +1,20 @@
+{
+  "ci": {
+    "collect": {
+      "numberOfRuns": 3
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.7 }],
+        "categories:seo": ["error", { "minScore": 0.9 }],
+        "largest-contentful-paint": ["error", { "maxNumericValue": 4000 }],
+        "total-blocking-time": ["error", { "maxNumericValue": 600 }],
+        "cumulative-layout-shift": ["error", { "maxNumericValue": 0.25 }],
+        "first-contentful-paint": ["warn", { "maxNumericValue": 3000 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/cli/slopstopper/data/playwright.config.js
+++ b/cli/slopstopper/data/playwright.config.js
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * SlopStopper portable Playwright config.
+ *
+ * testDir is `./tests` relative to this file, so specs under `.ss/tests/`
+ * are picked up regardless of what the consumer has under their own
+ * `tests/` directory.
+ *
+ * No webServer block — the consumer (or task) is responsible for ensuring
+ * the target URL is reachable before tests run. The base URL is taken from
+ * one of: ACCESSIBILITY_TEST_URL, SMOKE_TEST_URL, BASE_URL, or
+ * http://localhost:8080 as a final fallback.
+ */
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL:
+      process.env.BROKEN_LINKS_TEST_URL ||
+      process.env.ACCESSIBILITY_TEST_URL ||
+      process.env.SMOKE_TEST_URL ||
+      process.env.BASE_URL ||
+      'http://localhost:8080',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/cli/slopstopper/data/tests/accessibility.spec.ts
+++ b/cli/slopstopper/data/tests/accessibility.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+/**
+ * Accessibility Tests
+ *
+ * Uses axe-core to audit pages for WCAG 2.1 AA violations.
+ *
+ * Configuration:
+ *   ACCESSIBILITY_TEST_URL  - Base URL to audit (falls back to SMOKE_TEST_URL / BASE_URL / localhost)
+ *   ACCESSIBILITY_PAGES     - Comma-separated list of paths to audit (default: '/')
+ *                             e.g. '/,/features.html,/tools.html'
+ *   ACCESSIBILITY_THRESHOLD - Maximum allowed violations before failing (default: 0)
+ *   ACCESSIBILITY_IMPACT    - Minimum impact level to flag: critical|serious|moderate|minor (default: serious)
+ *
+ * Run locally:
+ *   task ss:reliability:accessibility
+ *   ACCESSIBILITY_TEST_URL=https://your-site.example.com \
+ *     ACCESSIBILITY_PAGES='/,/about' task ss:reliability:accessibility
+ */
+
+const targetUrl =
+  process.env.ACCESSIBILITY_TEST_URL ||
+  process.env.SMOKE_TEST_URL ||
+  process.env.BASE_URL ||
+  'http://localhost:8080';
+
+// Impact levels to report as violations (everything at or above this level fails)
+const IMPACT_LEVELS = ['minor', 'moderate', 'serious', 'critical'] as const;
+type ImpactLevel = typeof IMPACT_LEVELS[number];
+
+const rawImpact = (process.env.ACCESSIBILITY_IMPACT || 'serious').toLowerCase() as ImpactLevel;
+const minImpact: ImpactLevel = IMPACT_LEVELS.includes(rawImpact) ? rawImpact : 'serious';
+const impactThreshold = IMPACT_LEVELS.indexOf(minImpact);
+
+// Maximum number of violations allowed before the test fails
+const maxViolations = parseInt(process.env.ACCESSIBILITY_THRESHOLD || '0', 10);
+
+const pagesToAudit = (process.env.ACCESSIBILITY_PAGES ?? '/')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean)
+  .map((path) => ({ path, label: path === '/' ? 'homepage' : path }));
+
+test.describe('Accessibility Audit', () => {
+  test.use({ baseURL: targetUrl });
+
+  for (const { path, label } of pagesToAudit) {
+    test(`${label} meets accessibility threshold`, async ({ page }) => {
+      await page.goto(path);
+      await page.waitForLoadState('networkidle');
+
+      const results = await new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21aa'])
+        .analyze();
+
+      // Filter to violations at or above the configured impact level
+      const flaggedViolations = results.violations.filter((v) => {
+        const idx = IMPACT_LEVELS.indexOf((v.impact ?? 'minor') as ImpactLevel);
+        return idx >= impactThreshold;
+      });
+
+      if (flaggedViolations.length > 0) {
+        const summary = flaggedViolations
+          .map(
+            (v) =>
+              `[${v.impact?.toUpperCase()}] ${v.id}: ${v.description}\n` +
+              v.nodes
+                .slice(0, 3)
+                .map((n) => `  - ${n.target.join(', ')}`)
+                .join('\n'),
+          )
+          .join('\n\n');
+
+        console.log(
+          `\n♿ Accessibility violations on ${label} (${flaggedViolations.length} at or above "${minImpact}" impact):\n\n${summary}\n`,
+        );
+      }
+
+      expect(
+        flaggedViolations.length,
+        `${label}: expected ≤${maxViolations} violations at "${minImpact}" impact or above, ` +
+          `but found ${flaggedViolations.length}`,
+      ).toBeLessThanOrEqual(maxViolations);
+    });
+  }
+});

--- a/cli/slopstopper/data/tests/broken-links.spec.ts
+++ b/cli/slopstopper/data/tests/broken-links.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+
+const targetUrl =
+  process.env.BROKEN_LINKS_TEST_URL ||
+  process.env.SMOKE_TEST_URL ||
+  process.env.BASE_URL ||
+  'http://localhost:8080';
+
+const pagesToScan = (process.env.BROKEN_LINKS_PAGES ?? '/')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+test.describe('Broken Link Checks', () => {
+  test.use({ baseURL: targetUrl });
+
+  test('internal links return successful responses', async ({ page, request, baseURL }) => {
+    const base = new URL(baseURL!);
+    const links = new Set<string>();
+
+    for (const path of pagesToScan) {
+      await page.goto(path);
+      const hrefs = await page.locator('a[href]').evaluateAll((anchors) =>
+        anchors
+          .map((a) => a.getAttribute('href'))
+          .filter((href): href is string => Boolean(href)),
+      );
+
+      for (const href of hrefs) {
+        if (/^(#|mailto:|tel:|javascript:|data:|vbscript:)/i.test(href)) {
+          continue;
+        }
+
+        const resolved = new URL(href, base);
+        if (resolved.origin !== base.origin) {
+          continue;
+        }
+
+        // Fragments do not affect HTTP retrieval, so only pathname+query are checked.
+        links.add(`${resolved.pathname}${resolved.search}`);
+      }
+    }
+
+    const brokenLinks: string[] = [];
+    for (const linkPath of links) {
+      const response = await request.get(linkPath);
+      if (response.status() >= 400) {
+        brokenLinks.push(`${linkPath} returned ${response.status()}`);
+      }
+    }
+
+    expect(brokenLinks, brokenLinks.join('\n')).toEqual([]);
+  });
+});

--- a/cli/slopstopper/data/tests/smoke.spec.ts
+++ b/cli/slopstopper/data/tests/smoke.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Portable smoke tests for any web app.
+ *
+ * Checks each page returns 200, loads without console errors, and responds
+ * within an acceptable time. No site-specific assertions (title, selectors)
+ * — accessibility audits cover content correctness; this just proves the
+ * pages are reachable and don't crash.
+ *
+ * Configuration:
+ *   SMOKE_TEST_URL  — base URL to hit (required when running outside a repo
+ *                     with its own webServer config)
+ *   SMOKE_PAGES     — comma-separated list of paths to check, default '/'
+ *                     e.g. '/,/about,/pricing'
+ *   SMOKE_TIMEOUT   — per-request timeout in ms, default 5000
+ *
+ * Usage:
+ *   SMOKE_TEST_URL=https://your-site task ss:reliability:smoke
+ *   SMOKE_TEST_URL=https://your-site SMOKE_PAGES='/,/login' task ss:reliability:smoke
+ */
+
+const targetUrl = process.env.SMOKE_TEST_URL || process.env.BASE_URL || 'http://localhost:8080';
+
+const pagesToCheck = (process.env.SMOKE_PAGES ?? '/')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const maxLoadMs = parseInt(process.env.SMOKE_TIMEOUT || '5000', 10);
+
+test.describe('Smoke Tests', () => {
+  test.use({ baseURL: targetUrl });
+
+  for (const path of pagesToCheck) {
+    test(`${path} returns 200 and loads cleanly`, async ({ page }) => {
+      const errors: Error[] = [];
+      page.on('pageerror', (e) => errors.push(e));
+
+      const startTime = Date.now();
+      const response = await page.goto(path);
+      const loadTime = Date.now() - startTime;
+
+      expect(response, `${path}: navigation returned no response`).not.toBeNull();
+      expect(response!.status(), `${path} should return 200`).toBe(200);
+
+      await page.waitForLoadState('networkidle');
+
+      expect(errors, `${path}: page emitted JS errors: ${errors.map((e) => e.message).join('; ')}`)
+        .toHaveLength(0);
+
+      expect(loadTime, `${path}: load took ${loadTime}ms (limit ${maxLoadMs}ms)`)
+        .toBeLessThan(maxLoadMs);
+    });
+  }
+
+  test('homepage has at least one stylesheet linked', async ({ page }) => {
+    await page.goto(pagesToCheck[0]);
+    const stylesheets = await page.locator('link[rel="stylesheet"]').count();
+    expect(stylesheets, 'expected at least one <link rel="stylesheet"> on the homepage')
+      .toBeGreaterThan(0);
+  });
+
+  // Opt-in via SMOKE_OG_IMAGE_PATH (default: /og-image.png for backward compat).
+  // Set to empty string in your .slopstopper.yml under smoke.og_image_path to
+  // disable — use this if you ship per-post share images instead of one
+  // site-wide image.
+  const ogImagePath = process.env.SMOKE_OG_IMAGE_PATH ?? '/og-image.png';
+  if (ogImagePath) {
+    test(`og image (${ogImagePath}) is publicly shareable`, async ({ request }) => {
+      const response = await request.get(ogImagePath);
+      expect(response.status(), `expected ${ogImagePath} to return 200`).toBe(200);
+      expect(response.headers()['content-type']).toContain('image/png');
+      expect(response.headers()['cross-origin-resource-policy']).toBe('cross-origin');
+    });
+  }
+});

--- a/cli/slopstopper/templates.py
+++ b/cli/slopstopper/templates.py
@@ -1,0 +1,67 @@
+"""Template-file resolution for the reliability checks.
+
+The CLI ships Playwright specs, the Playwright config and the Lighthouse
+CI config as package data under cli/slopstopper/data/. Adopters can
+still override any of these by writing the same-named file under .ss/
+in their repo — the resolver looks at the override path first and falls
+back to the package-data copy.
+
+This means adopters who want defaults don't have to vendor those files
+into their repo at all; the CLI brings them. Adopters who want to
+customise drop a file under .ss/ and the resolver picks it up.
+
+Single source of truth: cli/slopstopper/data/. The .ss/ copies that
+slopstopper.dev (this repo) carries are dual-purposed today —
+backwards-compat for adopters still on bash workflows, and the override
+fixtures for our own dogfood CI. A separate hygiene gate keeps them in
+sync with package data via cli/.../data/.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PACKAGE_DATA_DIR = Path(__file__).resolve().parent / "data"
+
+PLAYWRIGHT_CONFIG_NAME = "playwright.config.js"
+LIGHTHOUSERC_NAME = "lighthouserc.json"
+
+
+def _override_dir() -> Path:
+    """Adopter-side override root.
+
+    Anything written under .ss/<same-name> wins over the package-data copy.
+    Looked up at call time, not import time, so tests using `isolated_cwd`
+    pick up the temporary cwd.
+    """
+    return Path(".ss")
+
+
+def playwright_config() -> Path:
+    """Resolve the Playwright config path: .ss/playwright.config.js override
+    or fall back to the bundled package-data copy."""
+    override = _override_dir() / PLAYWRIGHT_CONFIG_NAME
+    if override.exists():
+        return override
+    return PACKAGE_DATA_DIR / PLAYWRIGHT_CONFIG_NAME
+
+
+def lighthouserc() -> Path:
+    """Resolve the Lighthouse CI config path."""
+    override = _override_dir() / LIGHTHOUSERC_NAME
+    if override.exists():
+        return override
+    return PACKAGE_DATA_DIR / LIGHTHOUSERC_NAME
+
+
+def playwright_spec(name: str) -> Path:
+    """Resolve a Playwright spec by basename (without extension).
+
+    Looks for .ss/tests/<name>.spec.ts first, then falls back to the
+    bundled package-data spec.
+    """
+    filename = f"{name}.spec.ts"
+    override = _override_dir() / "tests" / filename
+    if override.exists():
+        return override
+    return PACKAGE_DATA_DIR / "tests" / filename

--- a/cli/tests/checks/test_accessibility.py
+++ b/cli/tests/checks/test_accessibility.py
@@ -104,7 +104,7 @@ def test_build_cmd_default_reporter():
     assert cmd[0] == "npx"
     assert "playwright" in cmd
     assert "--reporter=list" in cmd
-    assert str(accessibility.SPEC_PATH) in cmd
+    assert any("accessibility.spec.ts" in arg for arg in cmd)
 
 
 def test_build_cmd_ci_uses_list_html_reporter():
@@ -138,17 +138,7 @@ def test_run_returns_one_when_url_missing(monkeypatch, isolated_cwd, capsys):
     assert "accessibility target URL is required" in capsys.readouterr().out
 
 
-def test_run_returns_one_when_spec_missing(monkeypatch, isolated_cwd, capsys):
-    monkeypatch.setattr(accessibility, "_npx_available", lambda: True)
-    rc = accessibility.run(["--url", "https://example.com"])
-    assert rc == 1
-    assert "Accessibility spec not found" in capsys.readouterr().out
-
-
 def test_run_invokes_playwright(monkeypatch, isolated_cwd):
-    accessibility.SPEC_PATH.parent.mkdir(parents=True, exist_ok=True)
-    accessibility.SPEC_PATH.write_text("// fake spec")
-
     captured: dict = {}
 
     def fake_run(cmd, env, check):
@@ -168,9 +158,6 @@ def test_run_invokes_playwright(monkeypatch, isolated_cwd):
 
 
 def test_run_ci_mode_threads_html_reporter(monkeypatch, isolated_cwd):
-    accessibility.SPEC_PATH.parent.mkdir(parents=True, exist_ok=True)
-    accessibility.SPEC_PATH.write_text("// fake spec")
-
     captured: dict = {}
 
     def fake_run(cmd, env, check):
@@ -189,9 +176,6 @@ def test_run_ci_mode_threads_html_reporter(monkeypatch, isolated_cwd):
 
 
 def test_run_propagates_playwright_failure(monkeypatch, isolated_cwd):
-    accessibility.SPEC_PATH.parent.mkdir(parents=True, exist_ok=True)
-    accessibility.SPEC_PATH.write_text("// fake spec")
-
     monkeypatch.setattr(accessibility, "_npx_available", lambda: True)
     monkeypatch.setattr(accessibility, "_discover_pages", lambda: None)
     monkeypatch.setattr(

--- a/cli/tests/checks/test_broken_links.py
+++ b/cli/tests/checks/test_broken_links.py
@@ -100,7 +100,7 @@ def test_build_cmd_default_reporter():
     assert cmd[0] == "npx"
     assert "playwright" in cmd
     assert "--reporter=list" in cmd
-    assert str(broken_links.SPEC_PATH) in cmd
+    assert any("broken-links.spec.ts" in arg for arg in cmd)
 
 
 def test_build_cmd_ci_uses_list_html_reporter():
@@ -131,17 +131,7 @@ def test_run_returns_one_when_url_missing(monkeypatch, isolated_cwd, capsys):
     assert "broken-links target URL is required" in capsys.readouterr().out
 
 
-def test_run_returns_one_when_spec_missing(monkeypatch, isolated_cwd, capsys):
-    monkeypatch.setattr(broken_links, "_npx_available", lambda: True)
-    rc = broken_links.run(["--url", "https://example.com"])
-    assert rc == 1
-    assert "Broken-links spec not found" in capsys.readouterr().out
-
-
 def test_run_invokes_playwright(monkeypatch, isolated_cwd):
-    broken_links.SPEC_PATH.parent.mkdir(parents=True, exist_ok=True)
-    broken_links.SPEC_PATH.write_text("// fake spec")
-
     captured: dict = {}
 
     def fake_run(cmd, env, check):
@@ -161,9 +151,6 @@ def test_run_invokes_playwright(monkeypatch, isolated_cwd):
 
 
 def test_run_ci_mode_threads_html_reporter(monkeypatch, isolated_cwd):
-    broken_links.SPEC_PATH.parent.mkdir(parents=True, exist_ok=True)
-    broken_links.SPEC_PATH.write_text("// fake spec")
-
     captured: dict = {}
 
     def fake_run(cmd, env, check):
@@ -182,9 +169,6 @@ def test_run_ci_mode_threads_html_reporter(monkeypatch, isolated_cwd):
 
 
 def test_run_propagates_playwright_failure(monkeypatch, isolated_cwd):
-    broken_links.SPEC_PATH.parent.mkdir(parents=True, exist_ok=True)
-    broken_links.SPEC_PATH.write_text("// fake spec")
-
     monkeypatch.setattr(broken_links, "_npx_available", lambda: True)
     monkeypatch.setattr(broken_links, "_discover_pages", lambda: None)
     monkeypatch.setattr(

--- a/cli/tests/checks/test_cwv.py
+++ b/cli/tests/checks/test_cwv.py
@@ -13,7 +13,8 @@ from slopstopper.checks import cwv
 def test_parse_args_defaults():
     parsed = cwv._parse_args(None)
     assert parsed.url is None
-    assert parsed.config == str(cwv.LHCI_CONFIG)
+    # config defaults to None — resolution happens in run() via templates
+    assert parsed.config is None
 
 
 def test_parse_args_explicit():
@@ -69,17 +70,17 @@ def test_run_returns_one_when_url_missing(monkeypatch, isolated_cwd, capsys):
     assert "CWV target URL is required" in capsys.readouterr().out
 
 
-def test_run_returns_one_when_config_missing(monkeypatch, isolated_cwd, capsys):
+def test_run_returns_one_when_explicit_config_missing(monkeypatch, isolated_cwd, capsys):
+    """An explicit --config that doesn't exist still errors out. The
+    default (no --config flag) resolves via templates and always finds
+    something."""
     monkeypatch.setattr(cwv, "_npx_available", lambda: True)
-    rc = cwv.run(["--url", "https://example.com"])
+    rc = cwv.run(["--url", "https://example.com", "--config", "missing.json"])
     assert rc == 1
     assert "Lighthouse CI config not found" in capsys.readouterr().out
 
 
 def test_run_invokes_lhci_with_expected_args(monkeypatch, isolated_cwd):
-    cwv.LHCI_CONFIG.parent.mkdir(parents=True, exist_ok=True)
-    cwv.LHCI_CONFIG.write_text("{}")
-
     captured: dict = {}
 
     def fake_run(cmd, check):
@@ -93,13 +94,11 @@ def test_run_invokes_lhci_with_expected_args(monkeypatch, isolated_cwd):
     assert rc == 0
     assert captured["cmd"][:3] == ["npx", "lhci", "autorun"]
     assert "--collect.url=https://example.com" in captured["cmd"]
-    assert f"--config={cwv.LHCI_CONFIG}" in captured["cmd"]
+    # default resolution lands on the bundled lighthouserc.json
+    assert any("lighthouserc.json" in arg for arg in captured["cmd"])
 
 
 def test_run_propagates_lhci_failure(monkeypatch, isolated_cwd):
-    cwv.LHCI_CONFIG.parent.mkdir(parents=True, exist_ok=True)
-    cwv.LHCI_CONFIG.write_text("{}")
-
     monkeypatch.setattr(cwv, "_npx_available", lambda: True)
     monkeypatch.setattr(
         cwv.subprocess, "run",

--- a/cli/tests/checks/test_smoke.py
+++ b/cli/tests/checks/test_smoke.py
@@ -84,7 +84,9 @@ def test_build_cmd_default_reporter():
     assert "playwright" in cmd
     assert "test" in cmd
     assert "--reporter=list" in cmd
-    assert str(smoke.SPEC_PATH) in cmd
+    # The resolved spec path is whatever templates.playwright_spec returns
+    # (override under .ss/ or the bundled package-data file).
+    assert any("smoke.spec.ts" in arg for arg in cmd)
 
 
 def test_build_cmd_ci_uses_list_html_reporter():
@@ -118,17 +120,7 @@ def test_run_returns_one_when_url_missing(monkeypatch, isolated_cwd, capsys):
     assert "smoke target URL is required" in out
 
 
-def test_run_returns_one_when_spec_missing(monkeypatch, isolated_cwd, capsys):
-    monkeypatch.setattr(smoke, "_npx_available", lambda: True)
-    rc = smoke.run(["--url", "https://example.com"])
-    assert rc == 1
-    assert "Smoke spec not found" in capsys.readouterr().out
-
-
 def test_run_invokes_playwright_with_expected_args(monkeypatch, isolated_cwd):
-    smoke.SPEC_PATH.parent.mkdir(parents=True, exist_ok=True)
-    smoke.SPEC_PATH.write_text("// fake spec")
-
     captured: dict = {}
 
     def fake_run(cmd, env, check):
@@ -147,9 +139,6 @@ def test_run_invokes_playwright_with_expected_args(monkeypatch, isolated_cwd):
 
 
 def test_run_ci_mode_threads_html_reporter_and_ci_env(monkeypatch, isolated_cwd):
-    smoke.SPEC_PATH.parent.mkdir(parents=True, exist_ok=True)
-    smoke.SPEC_PATH.write_text("// fake spec")
-
     captured: dict = {}
 
     def fake_run(cmd, env, check):
@@ -167,9 +156,6 @@ def test_run_ci_mode_threads_html_reporter_and_ci_env(monkeypatch, isolated_cwd)
 
 
 def test_run_propagates_playwright_failure(monkeypatch, isolated_cwd):
-    smoke.SPEC_PATH.parent.mkdir(parents=True, exist_ok=True)
-    smoke.SPEC_PATH.write_text("// fake spec")
-
     monkeypatch.setattr(smoke, "_npx_available", lambda: True)
     monkeypatch.setattr(
         smoke.subprocess, "run",

--- a/cli/tests/test_templates.py
+++ b/cli/tests/test_templates.py
@@ -1,0 +1,94 @@
+"""Tests for the templates resolver (Playwright + Lighthouse configs and
+spec files: .ss/ override → package-data fallback)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from slopstopper import templates
+
+
+# ── package-data presence ────────────────────────────────────────
+
+
+def test_package_data_dir_exists():
+    assert templates.PACKAGE_DATA_DIR.exists()
+    assert templates.PACKAGE_DATA_DIR.is_dir()
+
+
+def test_bundled_playwright_config_exists():
+    assert (templates.PACKAGE_DATA_DIR / templates.PLAYWRIGHT_CONFIG_NAME).exists()
+
+
+def test_bundled_lighthouserc_exists():
+    assert (templates.PACKAGE_DATA_DIR / templates.LIGHTHOUSERC_NAME).exists()
+
+
+def test_bundled_spec_files_present():
+    tests_dir = templates.PACKAGE_DATA_DIR / "tests"
+    assert (tests_dir / "smoke.spec.ts").exists()
+    assert (tests_dir / "accessibility.spec.ts").exists()
+    assert (tests_dir / "broken-links.spec.ts").exists()
+
+
+# ── fallback to package data ─────────────────────────────────────
+
+
+def test_playwright_config_falls_back_to_package_data(isolated_cwd):
+    assert templates.playwright_config() == (
+        templates.PACKAGE_DATA_DIR / templates.PLAYWRIGHT_CONFIG_NAME
+    )
+
+
+def test_lighthouserc_falls_back_to_package_data(isolated_cwd):
+    assert templates.lighthouserc() == (
+        templates.PACKAGE_DATA_DIR / templates.LIGHTHOUSERC_NAME
+    )
+
+
+def test_playwright_spec_falls_back_to_package_data(isolated_cwd):
+    assert templates.playwright_spec("smoke") == (
+        templates.PACKAGE_DATA_DIR / "tests" / "smoke.spec.ts"
+    )
+
+
+# ── .ss/ override wins ───────────────────────────────────────────
+
+
+def test_playwright_config_override_wins(isolated_cwd):
+    override = isolated_cwd / ".ss" / "playwright.config.js"
+    override.parent.mkdir(parents=True, exist_ok=True)
+    override.write_text("// custom config")
+    resolved = templates.playwright_config()
+    assert resolved == Path(".ss/playwright.config.js")
+
+
+def test_lighthouserc_override_wins(isolated_cwd):
+    override = isolated_cwd / ".ss" / "lighthouserc.json"
+    override.parent.mkdir(parents=True, exist_ok=True)
+    override.write_text("{}")
+    resolved = templates.lighthouserc()
+    assert resolved == Path(".ss/lighthouserc.json")
+
+
+def test_playwright_spec_override_wins(isolated_cwd):
+    override = isolated_cwd / ".ss" / "tests" / "smoke.spec.ts"
+    override.parent.mkdir(parents=True, exist_ok=True)
+    override.write_text("// custom spec")
+    resolved = templates.playwright_spec("smoke")
+    assert resolved == Path(".ss/tests/smoke.spec.ts")
+
+
+def test_playwright_spec_override_only_for_named_check(isolated_cwd):
+    # An override for `smoke` doesn't affect `accessibility`
+    override = isolated_cwd / ".ss" / "tests" / "smoke.spec.ts"
+    override.parent.mkdir(parents=True, exist_ok=True)
+    override.write_text("// custom smoke spec")
+
+    smoke_resolved = templates.playwright_spec("smoke")
+    a11y_resolved = templates.playwright_spec("accessibility")
+
+    assert smoke_resolved == Path(".ss/tests/smoke.spec.ts")
+    assert a11y_resolved == (
+        templates.PACKAGE_DATA_DIR / "tests" / "accessibility.spec.ts"
+    )


### PR DESCRIPTION
## Summary

**Third Phase-2 PR.** Ships `.ss/tests/*.spec.ts`, `.ss/playwright.config.js`, and `.ss/lighthouserc.json` inside the slopstopper-cli wheel under `cli/slopstopper/data/`. Adopters who install the CLI no longer need any of those files vendored in their repo.

This closes the loop on "adopter can `pipx install slopstopper-cli` and not vendor `.ss/scripts/` or `.ss/tests/`". After this:

- `.ss/scripts/discover-pages.py` — lifted ✅ (#204)
- `.ss/scripts/check-seo-metatags.py` — lifted ✅ (#205)
- `.ss/tests/*.spec.ts` — lifted ✅ (this PR)
- `.ss/playwright.config.js` — lifted ✅ (this PR)
- `.ss/lighthouserc.json` — lifted ✅ (this PR)

The CLI is now functionally self-contained for every check. The `.ss/` copies remain in this repo for backwards-compat with the bash workflows and as our own dogfood override fixtures.

## Resolution pattern

`.ss/` override → package-data fallback. Adopter writes `.ss/playwright.config.js` → CLI uses it. Adopter writes nothing → CLI uses the bundled copy. Same for `lighthouserc.json` and `.ss/tests/<name>.spec.ts`.

## New module

`cli/slopstopper/templates.py` — single resolver:

```python
templates.playwright_config() -> Path
templates.lighthouserc() -> Path
templates.playwright_spec(name) -> Path
```

## Check refactors

`smoke`, `accessibility`, `broken-links`, `cwv`:
- Drop `SPEC_PATH` / `PLAYWRIGHT_CONFIG` / `LHCI_CONFIG` constants.
- Drop "spec missing" / "config missing" error branches for the default path — the package-data file always exists.
- `cwv --config` default flips from `str(LHCI_CONFIG)` to `None`; resolution happens in `run()` via `templates.lighthouserc()`.

## Source-of-truth contract for this repo

| Path | Role |
| --- | --- |
| `cli/slopstopper/data/` | **Authoritative** — ships in the wheel |
| `.ss/playwright.config.js`, `.ss/tests/*`, `.ss/lighthouserc.json` | Kept for backwards-compat with bash workflows + our own dogfood override fixtures |

A hygiene gate to enforce equality between the two is queued for a follow-up.

## Tests

- `cli/tests/test_templates.py` — 11 tests (package-data presence, override-wins, scoped override)
- 19 reliability check tests updated for the new resolver API.

**353 tests pass** (was 345).

## pyproject.toml

```toml
[tool.hatch.build.targets.wheel.force-include]
"slopstopper/data" = "slopstopper/data"
```

## Phase 2 remaining

- ✅ Lift `discover-pages.py` (#204)
- ✅ Lift `check-seo-metatags.py` (#205)
- ✅ Lift Playwright / Lighthouse templates (this PR)
- `--emit=pr-comment\|issue` to absorb duplicated GH-script JS
- Flip workflows to `slopstopper run`
- Hygiene gate: `.ss/` copies must equal `cli/slopstopper/data/`
- Delete the bash scripts
- Publish to PyPI as `slopstopper-cli`
- Rewrite the skill trio

## Test plan

- [x] `task -t cli/Taskfile.yml test` — 353 passed
- [x] `task -t cli/Taskfile.yml parity` — all 9 parity-eligible checks green
- [ ] CI `pytest` green
- [ ] CI `bash↔cli parity` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)