### PR TITLE
feat(cli): slopstopper emit foundation (PR comments + issues via gh CLI)

### DIFF
--- a/cli/slopstopper/checks/docs_size.py
+++ b/cli/slopstopper/checks/docs_size.py
@@ -22,6 +22,19 @@ ARCHIVE_PREFIX = Path("docs/archive")
 REPORT_DIR = Path(".ss/reports/docs")
 REPORT_FILE = REPORT_DIR / "docs-size-report.md"
 
+# Consumed by `slopstopper emit hygiene:docs-size --target {pr-comment,issue}`.
+# Strings are byte-for-byte identical to the discriminator / title / labels
+# the legacy actions/github-script@v7 block in
+# .github/workflows/ss-hygiene-docs-size-check.yml used, so the same bot
+# comments/issues are matched after the workflow flip.
+META = {
+    "report_path": str(REPORT_FILE),
+    "comment_discriminator": "📚 Documentation Size Report",
+    "issue_title": "📚 Documentation Size Exceeds Thresholds",
+    "issue_labels": ["documentation-size", "maintenance"],
+    "issue_followup": "🔔 Documentation size thresholds exceeded again in commit",
+}
+
 DEFAULT_MAX_TOTAL_SIZE_KB = 150
 DEFAULT_MAX_FILE_SIZE_KB = 20
 DEFAULT_MAX_FILES = 25

--- a/cli/slopstopper/cli.py
+++ b/cli/slopstopper/cli.py
@@ -1,15 +1,21 @@
 """Command dispatcher for the slopstopper CLI.
 
-Today: one subcommand, `run <check>`, which dispatches to the check
-registry under `slopstopper.checks`. Future: `init`, `inspect`, `emit`.
+Subcommands today:
+  run <check>                       — run a check, write reports under .ss/reports/
+  emit <check> --target {pr-comment,issue}
+                                    — post the report MD to the current PR
+                                      or create/update a tracking issue on main
+
+Future: init, inspect.
 """
 
 from __future__ import annotations
 
 import argparse
+import importlib
 import sys
 
-from slopstopper import __version__
+from slopstopper import __version__, emit as emit_mod
 from slopstopper.checks import REGISTRY
 
 
@@ -35,10 +41,27 @@ def main(argv: list[str] | None = None) -> int:
         help="Extra args forwarded to the check (e.g. --target URL for dast)",
     )
 
+    emit_parser = sub.add_parser(
+        "emit",
+        help="Emit a previously-run check's report to GitHub (PR comment / issue)",
+    )
+    emit_parser.add_argument(
+        "check",
+        help="Check name in 'category:name' form whose report to emit",
+    )
+    emit_parser.add_argument(
+        "--target",
+        required=True,
+        choices=["pr-comment", "issue"],
+        help="Where to send the report",
+    )
+
     args = parser.parse_args(argv)
 
     if args.command == "run":
         return _dispatch_run(args.check, args.check_args)
+    if args.command == "emit":
+        return _dispatch_emit(args.check, args.target)
 
     parser.error(f"unknown command: {args.command}")
     return 2
@@ -50,3 +73,24 @@ def _dispatch_run(check_name: str, check_args: list[str]) -> int:
         print(f"   known checks: {', '.join(sorted(REGISTRY))}", file=sys.stderr)
         return 2
     return REGISTRY[check_name](check_args)
+
+
+def _dispatch_emit(check_name: str, target: str) -> int:
+    """Look up the check's META dict (from its module) and emit."""
+    if check_name not in REGISTRY:
+        print(f"❌ unknown check: {check_name}", file=sys.stderr)
+        return 2
+    module_name = "slopstopper.checks." + check_name.split(":")[1].replace("-", "_")
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as e:
+        print(f"❌ cannot import {module_name}: {e}", file=sys.stderr)
+        return 2
+    meta = getattr(module, "META", None)
+    if not meta:
+        print(
+            f"❌ {check_name} has no META — emit is not yet wired up for this check",
+            file=sys.stderr,
+        )
+        return 2
+    return emit_mod.emit(target, meta)

--- a/cli/slopstopper/emit.py
+++ b/cli/slopstopper/emit.py
@@ -1,0 +1,258 @@
+"""GitHub PR-comment and issue emission for checks.
+
+Centralises the find-or-create logic that lives, today, as duplicated
+`actions/github-script@v7` blocks in every `ss-*-check.yml` workflow.
+The plan called this out as the load-bearing simplification — once the
+emit logic lives here, workflows shrink from ~50 lines of YAML +
+embedded JS to a single shell line:
+
+  - run: slopstopper run hygiene:docs-size
+  - run: slopstopper emit hygiene:docs-size --target pr-comment
+    if: github.event_name == 'pull_request'
+  - run: slopstopper emit hygiene:docs-size --target issue
+    if: github.event_name == 'push' && steps.check.outcome == 'failure'
+
+Subprocess-invokes the `gh` CLI — already on every GitHub Actions
+runner and already authed via $GITHUB_TOKEN. Same licensing-boundary
+pattern as the other external tools (gitleaks, trivy, semgrep, zap):
+slopstopper-cli wheel ships zero gh code.
+
+Each check that wants to emit declares a META dict beside its `run()`:
+
+    META = {
+        "report_path": ".ss/reports/.../*.md",
+        "comment_discriminator": "📚 ...",   # substring uniquely on the bot's PR comment
+        "issue_title": "📚 ... Exceeds Thresholds",
+        "issue_labels": ["...", "maintenance"],
+        "issue_followup": "🔔 Thresholds exceeded again in commit",
+    }
+
+PR-comment update path: `gh api PATCH .../issues/comments/{id}` —
+`gh` doesn't have a direct edit-comment command.
+Issue path: `gh issue list | gh issue {create,edit,comment}`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _gh_available() -> bool:
+    return shutil.which("gh") is not None
+
+
+def _repo_slug() -> str | None:
+    """GitHub-Actions-supplied $GITHUB_REPOSITORY = owner/name."""
+    return os.environ.get("GITHUB_REPOSITORY")
+
+
+def _pr_number_from_event() -> int | None:
+    """Read the PR number from the workflow event payload.
+
+    Works for `pull_request` triggers. Returns None on push / workflow_dispatch.
+    """
+    path = os.environ.get("GITHUB_EVENT_PATH")
+    if not path:
+        return None
+    try:
+        event = json.loads(Path(path).read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    pr = event.get("pull_request")
+    if isinstance(pr, dict) and isinstance(pr.get("number"), int):
+        return pr["number"]
+    return None
+
+
+def _gh(*args: str, capture: bool = False) -> subprocess.CompletedProcess[str]:
+    """Run `gh` with stdout/stderr passthrough (or captured)."""
+    cmd = ["gh", *args]
+    if capture:
+        return subprocess.run(cmd, check=False, capture_output=True, text=True)
+    return subprocess.run(cmd, check=False)
+
+
+# ── PR comment emission ──────────────────────────────────────────
+
+
+def _list_pr_comments(repo: str, pr: int) -> list[dict]:
+    result = _gh("api", f"repos/{repo}/issues/{pr}/comments", capture=True)
+    if result.returncode != 0:
+        return []
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return []
+    return data if isinstance(data, list) else []
+
+
+def _find_existing_pr_comment(comments: list[dict], discriminator: str) -> int | None:
+    """Return the comment id whose body contains the discriminator and was posted by a bot."""
+    for comment in comments:
+        if not isinstance(comment, dict):
+            continue
+        user = comment.get("user") or {}
+        if user.get("type") != "Bot":
+            continue
+        body = comment.get("body") or ""
+        if discriminator in body:
+            cid = comment.get("id")
+            if isinstance(cid, int):
+                return cid
+    return None
+
+
+def _update_pr_comment(repo: str, comment_id: int, body_path: Path) -> int:
+    """gh api PATCH .../issues/comments/<id> -F body=@<path>."""
+    result = _gh(
+        "api", "-X", "PATCH",
+        f"repos/{repo}/issues/comments/{comment_id}",
+        "-F", f"body=@{body_path}",
+        capture=True,
+    )
+    return result.returncode
+
+
+def _create_pr_comment(pr: int, body_path: Path) -> int:
+    result = _gh("pr", "comment", str(pr), "--body-file", str(body_path))
+    return result.returncode
+
+
+def emit_pr_comment(report_path: Path, discriminator: str) -> int:
+    """Post the report as a PR comment, updating any prior bot comment with the same discriminator."""
+    if not _gh_available():
+        print("❌ gh CLI is not available — needed for --target pr-comment", file=sys.stderr)
+        return 1
+    if not report_path.exists():
+        print(f"❌ Report not found at {report_path}", file=sys.stderr)
+        return 1
+
+    repo = _repo_slug()
+    pr = _pr_number_from_event()
+    if not repo:
+        print("❌ $GITHUB_REPOSITORY is not set", file=sys.stderr)
+        return 1
+    if pr is None:
+        print("❌ No PR detected from the event payload — skipping PR comment", file=sys.stderr)
+        return 1
+
+    comments = _list_pr_comments(repo, pr)
+    existing = _find_existing_pr_comment(comments, discriminator)
+    if existing is not None:
+        print(f"↻ Updating existing PR comment {existing}")
+        return _update_pr_comment(repo, existing, report_path)
+    print(f"+ Creating new PR comment on #{pr}")
+    return _create_pr_comment(pr, report_path)
+
+
+# ── Issue emission ───────────────────────────────────────────────
+
+
+def _find_existing_issue(labels: list[str]) -> int | None:
+    """Return the first open issue number that has every label."""
+    label_args: list[str] = []
+    for lbl in labels:
+        label_args += ["--label", lbl]
+    result = _gh(
+        "issue", "list",
+        "--state", "open",
+        *label_args,
+        "--json", "number",
+        capture=True,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        data = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, list) or not data:
+        return None
+    first = data[0]
+    if isinstance(first, dict) and isinstance(first.get("number"), int):
+        return first["number"]
+    return None
+
+
+def _create_issue(title: str, body_path: Path, labels: list[str]) -> int:
+    cmd: list[str] = ["issue", "create", "--title", title, "--body-file", str(body_path)]
+    for lbl in labels:
+        cmd += ["--label", lbl]
+    return _gh(*cmd).returncode
+
+
+def _update_issue_body(number: int, body_path: Path) -> int:
+    return _gh("issue", "edit", str(number), "--body-file", str(body_path)).returncode
+
+
+def _comment_issue(number: int, body: str) -> int:
+    return _gh("issue", "comment", str(number), "--body", body).returncode
+
+
+def _commit_sha() -> str:
+    return os.environ.get("GITHUB_SHA", "")
+
+
+def emit_issue(
+    report_path: Path,
+    title: str,
+    labels: list[str],
+    followup: str,
+) -> int:
+    """Create a new issue with the report, or update the existing one and post a follow-up comment.
+
+    The body is the report content with a `Commit: <sha>` footer; the
+    follow-up comment is `<followup> <sha>` so re-occurrences show up
+    in the issue timeline rather than as a fresh issue.
+    """
+    if not _gh_available():
+        print("❌ gh CLI is not available — needed for --target issue", file=sys.stderr)
+        return 1
+    if not report_path.exists():
+        print(f"❌ Report not found at {report_path}", file=sys.stderr)
+        return 1
+
+    sha = _commit_sha()
+    body = report_path.read_text()
+    footer = f"\n\n---\n*Commit: {sha}*\n" if sha else "\n"
+    body_with_footer = body + footer
+
+    body_path = report_path.with_suffix(".issue-body.md")
+    body_path.write_text(body_with_footer)
+
+    existing = _find_existing_issue(labels)
+    if existing is not None:
+        print(f"↻ Updating existing issue #{existing}")
+        rc = _update_issue_body(existing, body_path)
+        if rc == 0 and sha:
+            _comment_issue(existing, f"{followup} {sha}")
+        return rc
+    print("+ Creating new issue")
+    return _create_issue(title, body_path, labels)
+
+
+# ── public dispatcher ────────────────────────────────────────────
+
+
+def emit(target: str, meta: dict) -> int:
+    """Route --target {pr-comment, issue} to the corresponding emitter.
+
+    meta is the check's META dict (see module docstring).
+    """
+    report_path = Path(meta["report_path"])
+    if target == "pr-comment":
+        return emit_pr_comment(report_path, meta["comment_discriminator"])
+    if target == "issue":
+        return emit_issue(
+            report_path,
+            meta["issue_title"],
+            meta["issue_labels"],
+            meta["issue_followup"],
+        )
+    print(f"❌ Unknown emit target: {target!r}", file=sys.stderr)
+    return 2

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -27,3 +27,44 @@ def test_no_command_errors(capsys):
     with pytest.raises(SystemExit) as exc:
         cli.main([])
     assert exc.value.code != 0
+
+
+# ── emit subcommand ──────────────────────────────────────────────
+
+
+def test_emit_unknown_check_returns_2(capsys):
+    rc = cli.main(["emit", "no-such:check", "--target", "pr-comment"])
+    assert rc == 2
+    assert "unknown check" in capsys.readouterr().err
+
+
+def test_emit_no_meta_returns_2(monkeypatch, capsys):
+    # Pick a check that has no META yet — accessibility currently doesn't.
+    rc = cli.main(["emit", "reliability:accessibility", "--target", "pr-comment"])
+    assert rc == 2
+    assert "has no META" in capsys.readouterr().err
+
+
+def test_emit_routes_to_emit_module(monkeypatch):
+    """When the check has META, the dispatcher hands off to emit.emit
+    with the target and the META dict."""
+    called: dict = {}
+
+    def fake_emit(target, meta):
+        called["target"] = target
+        called["meta"] = meta
+        return 0
+
+    monkeypatch.setattr(cli.emit_mod, "emit", fake_emit)
+    rc = cli.main(["emit", "hygiene:docs-size", "--target", "issue"])
+    assert rc == 0
+    assert called["target"] == "issue"
+    assert "comment_discriminator" in called["meta"]
+
+
+def test_emit_requires_target_flag(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["emit", "hygiene:docs-size"])
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "required" in err or "--target" in err

--- a/cli/tests/test_emit.py
+++ b/cli/tests/test_emit.py
@@ -1,0 +1,282 @@
+"""Tests for slopstopper.emit — PR comment + issue emission via gh CLI."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from slopstopper import emit
+
+
+SAMPLE_META = {
+    "report_path": "report.md",
+    "comment_discriminator": "📚 Test Report",
+    "issue_title": "📚 Test Thresholds Exceeded",
+    "issue_labels": ["test-label", "maintenance"],
+    "issue_followup": "🔔 Test thresholds exceeded again in commit",
+}
+
+
+# ── helpers ──────────────────────────────────────────────────────
+
+
+def test_gh_available_via_which(monkeypatch):
+    monkeypatch.setattr(emit.shutil, "which", lambda _: "/usr/bin/gh")
+    assert emit._gh_available() is True
+    monkeypatch.setattr(emit.shutil, "which", lambda _: None)
+    assert emit._gh_available() is False
+
+
+def test_repo_slug_reads_env(monkeypatch):
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    assert emit._repo_slug() == "owner/repo"
+
+
+def test_repo_slug_none_when_unset(monkeypatch):
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    assert emit._repo_slug() is None
+
+
+def test_pr_number_from_event_reads_payload(monkeypatch, tmp_path):
+    event = tmp_path / "event.json"
+    event.write_text(json.dumps({"pull_request": {"number": 42}}))
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event))
+    assert emit._pr_number_from_event() == 42
+
+
+def test_pr_number_from_event_none_for_push(monkeypatch, tmp_path):
+    event = tmp_path / "event.json"
+    event.write_text(json.dumps({"ref": "refs/heads/main"}))
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event))
+    assert emit._pr_number_from_event() is None
+
+
+def test_pr_number_from_event_none_when_path_unset(monkeypatch):
+    monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+    assert emit._pr_number_from_event() is None
+
+
+def test_pr_number_from_event_handles_malformed_json(monkeypatch, tmp_path):
+    event = tmp_path / "event.json"
+    event.write_text("not json")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event))
+    assert emit._pr_number_from_event() is None
+
+
+# ── PR comment ───────────────────────────────────────────────────
+
+
+def test_find_existing_pr_comment_matches_bot_discriminator():
+    comments = [
+        {"id": 1, "user": {"type": "User"}, "body": "📚 Test Report (human-typed)"},
+        {"id": 2, "user": {"type": "Bot"}, "body": "Some other bot comment"},
+        {"id": 3, "user": {"type": "Bot"}, "body": "📚 Test Report\nfull body…"},
+    ]
+    assert emit._find_existing_pr_comment(comments, "📚 Test Report") == 3
+
+
+def test_find_existing_pr_comment_returns_none_when_no_match():
+    comments = [{"id": 1, "user": {"type": "Bot"}, "body": "different content"}]
+    assert emit._find_existing_pr_comment(comments, "missing") is None
+
+
+def test_emit_pr_comment_fails_when_gh_missing(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.setattr(emit, "_gh_available", lambda: False)
+    rc = emit.emit_pr_comment(Path("report.md"), "discrim")
+    assert rc == 1
+    assert "gh CLI is not available" in capsys.readouterr().err
+
+
+def test_emit_pr_comment_fails_when_report_missing(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.setattr(emit, "_gh_available", lambda: True)
+    rc = emit.emit_pr_comment(Path("nonexistent.md"), "discrim")
+    assert rc == 1
+    assert "Report not found" in capsys.readouterr().err
+
+
+def test_emit_pr_comment_fails_when_no_pr_number(monkeypatch, isolated_cwd, capsys):
+    Path("report.md").write_text("body")
+    monkeypatch.setattr(emit, "_gh_available", lambda: True)
+    monkeypatch.setattr(emit, "_repo_slug", lambda: "owner/repo")
+    monkeypatch.setattr(emit, "_pr_number_from_event", lambda: None)
+    rc = emit.emit_pr_comment(Path("report.md"), "discrim")
+    assert rc == 1
+    assert "No PR detected" in capsys.readouterr().err
+
+
+def test_emit_pr_comment_creates_new_when_no_existing(monkeypatch, isolated_cwd, capsys):
+    Path("report.md").write_text("body")
+    monkeypatch.setattr(emit, "_gh_available", lambda: True)
+    monkeypatch.setattr(emit, "_repo_slug", lambda: "owner/repo")
+    monkeypatch.setattr(emit, "_pr_number_from_event", lambda: 99)
+    monkeypatch.setattr(emit, "_list_pr_comments", lambda r, p: [])
+
+    captured: dict = {}
+
+    def fake_gh(*args, capture=False):
+        captured["args"] = args
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(emit, "_gh", fake_gh)
+    rc = emit.emit_pr_comment(Path("report.md"), "discrim")
+    assert rc == 0
+    assert "pr" in captured["args"] and "comment" in captured["args"]
+    out = capsys.readouterr().out
+    assert "Creating new PR comment on #99" in out
+
+
+def test_emit_pr_comment_updates_existing(monkeypatch, isolated_cwd, capsys):
+    Path("report.md").write_text("body")
+    monkeypatch.setattr(emit, "_gh_available", lambda: True)
+    monkeypatch.setattr(emit, "_repo_slug", lambda: "owner/repo")
+    monkeypatch.setattr(emit, "_pr_number_from_event", lambda: 99)
+    monkeypatch.setattr(
+        emit, "_list_pr_comments",
+        lambda r, p: [{"id": 555, "user": {"type": "Bot"}, "body": "📚 Test Report\nold body"}],
+    )
+
+    captured: dict = {}
+
+    def fake_gh(*args, capture=False):
+        captured["args"] = args
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(emit, "_gh", fake_gh)
+    rc = emit.emit_pr_comment(Path("report.md"), "📚 Test Report")
+    assert rc == 0
+    assert "PATCH" in captured["args"]
+    assert "repos/owner/repo/issues/comments/555" in captured["args"]
+    out = capsys.readouterr().out
+    assert "Updating existing PR comment 555" in out
+
+
+# ── issue ────────────────────────────────────────────────────────
+
+
+def test_find_existing_issue_returns_first_number(monkeypatch):
+    def fake_gh(*args, capture=False):
+        return subprocess.CompletedProcess(
+            args, 0,
+            stdout=json.dumps([{"number": 7}, {"number": 8}]),
+            stderr="",
+        )
+
+    monkeypatch.setattr(emit, "_gh", fake_gh)
+    assert emit._find_existing_issue(["test-label"]) == 7
+
+
+def test_find_existing_issue_returns_none_on_empty(monkeypatch):
+    monkeypatch.setattr(
+        emit, "_gh",
+        lambda *a, capture=False: subprocess.CompletedProcess(a, 0, stdout="[]", stderr=""),
+    )
+    assert emit._find_existing_issue(["test-label"]) is None
+
+
+def test_find_existing_issue_returns_none_on_gh_failure(monkeypatch):
+    monkeypatch.setattr(
+        emit, "_gh",
+        lambda *a, capture=False: subprocess.CompletedProcess(a, 1, stdout="", stderr="error"),
+    )
+    assert emit._find_existing_issue(["test-label"]) is None
+
+
+def test_emit_issue_creates_new(monkeypatch, isolated_cwd, capsys):
+    Path("report.md").write_text("body")
+    monkeypatch.setattr(emit, "_gh_available", lambda: True)
+    monkeypatch.setattr(emit, "_find_existing_issue", lambda labels: None)
+    monkeypatch.setenv("GITHUB_SHA", "abc123")
+
+    captured: dict = {}
+
+    def fake_gh(*args, capture=False):
+        captured.setdefault("calls", []).append(args)
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(emit, "_gh", fake_gh)
+    rc = emit.emit_issue(
+        Path("report.md"),
+        "Test Title",
+        ["test-label"],
+        "🔔 followup",
+    )
+    assert rc == 0
+    call = captured["calls"][0]
+    assert "issue" in call and "create" in call
+    assert "--title" in call and "Test Title" in call
+    # Body file should contain the report content + sha footer
+    body_file = next(arg for arg in call if "issue-body" in str(arg))
+    body_text = Path(body_file).read_text()
+    assert "body" in body_text
+    assert "abc123" in body_text
+
+
+def test_emit_issue_updates_existing_and_comments(monkeypatch, isolated_cwd, capsys):
+    Path("report.md").write_text("body")
+    monkeypatch.setattr(emit, "_gh_available", lambda: True)
+    monkeypatch.setattr(emit, "_find_existing_issue", lambda labels: 42)
+    monkeypatch.setenv("GITHUB_SHA", "deadbeef")
+
+    captured: dict = {}
+
+    def fake_gh(*args, capture=False):
+        captured.setdefault("calls", []).append(args)
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(emit, "_gh", fake_gh)
+    rc = emit.emit_issue(
+        Path("report.md"),
+        "Test Title",
+        ["test-label"],
+        "🔔 followup",
+    )
+    assert rc == 0
+    edit_call = captured["calls"][0]
+    assert "edit" in edit_call and "42" in edit_call
+    comment_call = captured["calls"][1]
+    assert "comment" in comment_call and "42" in comment_call
+    assert any("deadbeef" in str(a) for a in comment_call)
+
+
+def test_emit_issue_fails_when_gh_missing(monkeypatch, isolated_cwd, capsys):
+    monkeypatch.setattr(emit, "_gh_available", lambda: False)
+    rc = emit.emit_issue(Path("nope.md"), "T", ["L"], "F")
+    assert rc == 1
+    assert "gh CLI is not available" in capsys.readouterr().err
+
+
+# ── public dispatcher ────────────────────────────────────────────
+
+
+def test_emit_routes_pr_comment(monkeypatch):
+    called: dict = {}
+
+    def fake_pr(report_path, discrim):
+        called["pr"] = (report_path, discrim)
+        return 0
+
+    monkeypatch.setattr(emit, "emit_pr_comment", fake_pr)
+    rc = emit.emit("pr-comment", SAMPLE_META)
+    assert rc == 0
+    assert called["pr"][1] == "📚 Test Report"
+
+
+def test_emit_routes_issue(monkeypatch):
+    called: dict = {}
+
+    def fake_issue(report_path, title, labels, followup):
+        called["issue"] = (report_path, title, labels, followup)
+        return 0
+
+    monkeypatch.setattr(emit, "emit_issue", fake_issue)
+    rc = emit.emit("issue", SAMPLE_META)
+    assert rc == 0
+    assert called["issue"][1] == "📚 Test Thresholds Exceeded"
+    assert called["issue"][2] == ["test-label", "maintenance"]
+
+
+def test_emit_rejects_unknown_target(capsys):
+    rc = emit.emit("slack", SAMPLE_META)
+    assert rc == 2
+    assert "Unknown emit target" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

**Fifth Phase-2 PR.** Adds the surface that will eventually absorb the ~15 duplicated `actions/github-script@v7` blocks across `ss-*-check.yml` workflows — the plan called this out as the load-bearing payoff of the CLI pivot.

**This PR adds the surface only; no workflows are flipped yet.** Follow-up PRs will swap GH-script blocks for `slopstopper emit` one workflow at a time, starting with hygiene:docs-size (the only check with META in this PR).

## New module: `cli/slopstopper/emit.py`

- `emit_pr_comment(report_path, discriminator)`
  - Lists existing PR comments via `gh api`
  - Finds the bot's comment matching the discriminator substring
  - Updates via `gh api -X PATCH` if found, creates via `gh pr comment` otherwise
- `emit_issue(report_path, title, labels, followup)`
  - Looks up open issues by label via `gh issue list`
  - Updates body + adds follow-up comment if found, creates new with title + labels otherwise
  - Footer with `$GITHUB_SHA` appended to issue body
- `emit(target, meta)` — public dispatcher

## New subcommand

```
slopstopper emit <check> --target {pr-comment,issue}
```

Looks up `META` on the check module, then calls `emit.emit(target, meta)`. Returns 2 if no META (check not yet wired up).

## META on docs-size

Byte-identical discriminator, issue title and labels to what the legacy `actions/github-script@v7` block uses, so the same bot comments and issues are matched after the workflow flip.

```python
META = {
    "report_path": ".ss/reports/docs/docs-size-report.md",
    "comment_discriminator": "📚 Documentation Size Report",
    "issue_title": "📚 Documentation Size Exceeds Thresholds",
    "issue_labels": ["documentation-size", "maintenance"],
    "issue_followup": "🔔 Documentation size thresholds exceeded again in commit",
}
```

## Workflow shape under the new surface

```yaml
- run: slopstopper run hygiene:docs-size
  id: check
- run: slopstopper emit hygiene:docs-size --target pr-comment
  if: github.event_name == 'pull_request'
  env: { GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} }
- run: slopstopper emit hygiene:docs-size --target issue
  if: github.event_name == 'push' && steps.check.outcome == 'failure'
  env: { GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} }
```

vs. today's ~50 lines of YAML + embedded JS per workflow per emit type.

## Boundary discipline

Subprocess-invokes `gh` only (already on every GH Actions runner, authed via `$GITHUB_TOKEN`). slopstopper-cli wheel ships zero gh code. Same pattern as gitleaks/trivy/semgrep/zap.

## Tests

- `cli/tests/test_emit.py` — 18 tests covering: gh availability, repo + PR detection, event-payload parsing, PR-comment find/update/create paths, issue find/update/create + follow-up comment, public dispatcher routing, unknown-target rejection.
- `cli/tests/test_cli.py` — 4 new tests covering the emit subcommand surface (unknown check, missing META, routes to emit module, --target is required).

**380 tests pass** (was 353).

## Phase 2 remaining

- ✅ Lift `discover-pages.py` (#204)
- ✅ Lift `check-seo-metatags.py` (#205)
- ✅ Lift Playwright / Lighthouse templates (#206)
- ✅ Templates-sync gate (#207)
- ✅ Emit foundation (this PR)
- Flip workflow #1: `ss-hygiene-docs-size-check.yml` to use `slopstopper emit`
- Add META + flip workflows for the remaining 14 checks (one PR each)
- Delete the bash scripts
- Publish to PyPI as `slopstopper-cli`
- Rewrite the skill trio

## Test plan

- [x] `task -t cli/Taskfile.yml test` — 380 passed
- [x] CCN clean on `emit.py` (max 7) and `cli.py` (max 7)
- [ ] CI `pytest` green
- [ ] CI `templates-sync` green
- [ ] CI `bash↔cli parity` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)