### PR TITLE
feat(workflows): flip ss-hygiene-docs-size to slopstopper emit (Phase 2)

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -49,6 +49,10 @@ on:
       - '.ss/tests/smoke.spec.ts'
       - '.ss/tests/accessibility.spec.ts'
       - '.ss/tests/broken-links.spec.ts'
+      # Flipped ss-*-check.yml workflows — changes here depend on the
+      # CLI's `slopstopper run` and `slopstopper emit` working, so the
+      # CLI tests must run too. As more workflows flip, add them here.
+      - '.github/workflows/ss-hygiene-docs-size-check.yml'
   push:
     branches: [ main ]
     paths:
@@ -73,6 +77,10 @@ on:
       - '.ss/tests/smoke.spec.ts'
       - '.ss/tests/accessibility.spec.ts'
       - '.ss/tests/broken-links.spec.ts'
+      # Flipped ss-*-check.yml workflows — changes here depend on the
+      # CLI's `slopstopper run` and `slopstopper emit` working, so the
+      # CLI tests must run too. As more workflows flip, add them here.
+      - '.github/workflows/ss-hygiene-docs-size-check.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ss-hygiene-docs-size-check.yml
+++ b/.github/workflows/ss-hygiene-docs-size-check.yml
@@ -9,11 +9,13 @@ on:
   pull_request:
     paths:
       - 'docs/**'
+      - '.github/workflows/ss-hygiene-docs-size-check.yml'
   push:
     branches:
       - main
     paths:
       - 'docs/**'
+      - '.github/workflows/ss-hygiene-docs-size-check.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ss-hygiene-docs-size-check.yml
+++ b/.github/workflows/ss-hygiene-docs-size-check.yml
@@ -1,5 +1,10 @@
 name: SlopStopper · Documentation Size Monitor
 
+# CLI-flipped workflow (Phase 2). Replaces the legacy task ss:hygiene:docs-size
+# + ~50 lines of duplicated actions/github-script@v7 with two `slopstopper emit`
+# steps. The check itself runs via the CLI (lifted from .ss/scripts/) and
+# writes the canonical report at .ss/reports/docs/docs-size-report.md.
+
 on:
   pull_request:
     paths:
@@ -19,126 +24,64 @@ permissions:
 jobs:
   check-docs-size:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
-      - name: Install Task
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install slopstopper-cli
         run: |
-          sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
-      
+          # Pre-PyPI dogfood install. slopstopper.dev installs editable
+          # from local source; adopters (no cli/ dir) install from git.
+          # Once published, both branches collapse into:
+          #   pipx install slopstopper-cli==<pinned-version>
+          if [ -f cli/pyproject.toml ]; then
+            pip install -e ./cli
+          else
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+          fi
+
       - name: Run documentation size check
         id: check
         run: |
-          # Run the task and capture output
-          task ss:hygiene:docs-size
-          
-          # Check if alerts were triggered (report contains "exceeds thresholds")
+          slopstopper run hygiene:docs-size
+          # The report is canonical (.ss/reports/docs/docs-size-report.md).
+          # We set has_alerts from the report content — the check itself
+          # is non-blocking and always exits 0; the workflow's gating is
+          # what surfaces them.
           if grep -q "❌" .ss/reports/docs/docs-size-report.md; then
-            echo "has_alerts=true" >> $GITHUB_OUTPUT
+            echo "has_alerts=true" >> "$GITHUB_OUTPUT"
           else
-            echo "has_alerts=false" >> $GITHUB_OUTPUT
+            echo "has_alerts=false" >> "$GITHUB_OUTPUT"
           fi
-      
-      - name: Copy report for workflow
-        run: cp .ss/reports/docs/docs-size-report.md docs-report.md
-      
-      - name: Comment on PR
+
+      - name: Emit PR comment
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const report = fs.readFileSync('docs-report.md', 'utf8');
-            
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            
-            const botComment = comments.find(comment => 
-              comment.user.type === 'Bot' && 
-              comment.body.includes('📚 Documentation Size Report')
-            );
-            
-            const commentBody = report;
-            
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: commentBody
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: commentBody
-              });
-            }
-      
-      - name: Create or update issue on main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: slopstopper emit hygiene:docs-size --target pr-comment
+
+      - name: Emit issue on main (if thresholds exceeded)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.check.outputs.has_alerts == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const report = fs.readFileSync('docs-report.md', 'utf8');
-            
-            // Check for existing open issue
-            const { data: issues } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'documentation-size'
-            });
-            
-            const title = '📚 Documentation Size Exceeds Thresholds';
-            const body = `${report}\n\n---\n*This issue was automatically created by the Documentation Size Monitor workflow.*\n*Commit: ${context.sha}*`;
-            
-            if (issues.length > 0) {
-              // Update existing issue
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issues[0].number,
-                body: body
-              });
-              
-              // Add comment about new violation
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issues[0].number,
-                body: `🔔 Documentation size thresholds exceeded again in commit ${context.sha}`
-              });
-            } else {
-              // Create new issue
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: title,
-                body: body,
-                labels: ['documentation-size', 'maintenance']
-              });
-            }
-      
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: slopstopper emit hygiene:docs-size --target issue
+
       - name: Warn if thresholds exceeded on main
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.check.outputs.has_alerts == 'true'
         run: |
           echo "::warning::Documentation size thresholds exceeded! An issue has been created."
-          # Don't fail the workflow, just warn
-          exit 0
-      
+
       - name: Upload report
         uses: actions/upload-artifact@v4
         with:
           name: documentation-size-report
-          path: docs-report.md
+          path: .ss/reports/docs/docs-size-report.md
           retention-days: 30


### PR DESCRIPTION
## Summary

**First workflow flip.** Replaces ~50 lines of duplicated `actions/github-script@v7` (PR comment update-or-create + issue create-or-update + follow-up comment) with two `slopstopper emit` invocations backed by the foundation merged in #208.

**Net diff: -101 / +44.** This same shape will repeat across the remaining 14 `ss-*-check.yml` workflows once each check gets a META dict and the emit semantics are validated here.

## Install path is portable

```yaml
- name: Install slopstopper-cli
  run: |
    if [ -f cli/pyproject.toml ]; then
      pip install -e ./cli
    else
      pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
    fi
```

- slopstopper.dev (has `cli/` locally) → editable install
- Adopter repos (no `cli/`) → install from git

Once slopstopper-cli is on PyPI both branches collapse to a single `pipx install slopstopper-cli==<pinned>` line.

## Behaviour preserved

- Same discriminator string, same issue title, same labels, same follow-up message (META on `docs_size.py` was authored from this workflow's literal strings in #208 — byte-identical).
- `has_alerts` gating is identical (grep `❌` on the canonical report).
- Upload-artifact step keeps the report (path updated to `.ss/reports/docs/docs-size-report.md`, the canonical location, so we don't need the intermediate `cp` step the bash flow had).

## What this PR does NOT change

- The bash `task ss:hygiene:docs-size` flow is untouched. Adopters still on the old workflow shape keep working.
- The parity job in `cli/Taskfile.yml` continues to diff bash↔CLI on docs-size, so any logic drift surfaces immediately.
- `install.sh` still seeds this workflow file as-is. Adopters re-running install.sh get the CLI-flipped version; the git install in the workflow handles them transparently.

## Verification

- This PR's `paths:` filter (`docs/**`) won't trigger the workflow on this branch, so post-merge verification requires either touching `docs/` on a follow-up PR or `workflow_dispatch`. The CLI parity job in CI still exercises both flows on every PR that touches the docs-size paths.
- I'll trigger workflow_dispatch after merge to confirm an end-to-end emit on a real PR/issue.

## Phase 2 progress

- ✅ Lift `discover-pages.py` (#204)
- ✅ Lift `check-seo-metatags.py` (#205)
- ✅ Lift Playwright / Lighthouse templates (#206)
- ✅ Templates-sync gate (#207)
- ✅ Emit foundation (#208)
- ✅ Flip workflow #1: `ss-hygiene-docs-size-check.yml` (this PR)
- Add META + flip remaining 14 workflows (one per PR)
- Delete the bash scripts
- Publish to PyPI as `slopstopper-cli`
- Rewrite the skill trio

## Test plan

- [x] Workflow YAML is valid (lint-clean)
- [ ] CI all jobs pass
- [ ] After merge: workflow_dispatch this workflow on main to verify end-to-end emit (issue path will fire because docs are over threshold per current state)
- [ ] After merge: open a docs-touching PR to verify the PR comment emit

🤖 Generated with [Claude Code](https://claude.com/claude-code)