### PR TITLE
feat(workflows): flip ss-hygiene-entry-files to slopstopper emit (Phase 2)

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -53,6 +53,7 @@ on:
       # CLI's `slopstopper run` and `slopstopper emit` working, so the
       # CLI tests must run too. As more workflows flip, add them here.
       - '.github/workflows/ss-hygiene-docs-size-check.yml'
+      - '.github/workflows/ss-hygiene-entry-files-check.yml'
   push:
     branches: [ main ]
     paths:
@@ -81,6 +82,7 @@ on:
       # CLI's `slopstopper run` and `slopstopper emit` working, so the
       # CLI tests must run too. As more workflows flip, add them here.
       - '.github/workflows/ss-hygiene-docs-size-check.yml'
+      - '.github/workflows/ss-hygiene-entry-files-check.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ss-hygiene-entry-files-check.yml
+++ b/.github/workflows/ss-hygiene-entry-files-check.yml
@@ -1,12 +1,17 @@
 name: SlopStopper · Hygiene - Entry-File Budget Check
 
+# CLI-flipped workflow (Phase 2). Replaces task ss:hygiene:entry-files
+# + ~50 lines of duplicated actions/github-script@v7 with a single
+# `slopstopper emit` step. The check itself runs via the CLI and the
+# workflow's failure surfaces over-budget files on main; no separate
+# main-branch issue is created (the check's exit-code gate is enough).
+
 on:
   pull_request:
     paths:
       - 'README.md'
       - 'AGENTS.md'
       - 'CLAUDE.md'
-      - '.ss/scripts/check-entry-file-size.py'
       - '.github/workflows/ss-hygiene-entry-files-check.yml'
   push:
     branches: [main]
@@ -14,7 +19,6 @@ on:
       - 'README.md'
       - 'AGENTS.md'
       - 'CLAUDE.md'
-      - '.ss/scripts/check-entry-file-size.py'
       - '.github/workflows/ss-hygiene-entry-files-check.yml'
   workflow_dispatch:
 
@@ -36,14 +40,21 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install Task
+      - name: Install slopstopper-cli
         run: |
-          curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
-          task --version
+          # Pre-PyPI dogfood install. slopstopper.dev installs editable
+          # from local source; adopters (no cli/ dir) install from git.
+          # Once published, both branches collapse into:
+          #   pipx install slopstopper-cli==<pinned-version>
+          if [ -f cli/pyproject.toml ]; then
+            pip install -e ./cli
+          else
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+          fi
 
       - name: Run entry-file budget check
         id: check
-        run: task ss:hygiene:entry-files
+        run: slopstopper run hygiene:entry-files
 
       - name: Upload report
         if: always()
@@ -54,49 +65,8 @@ jobs:
           retention-days: 30
           if-no-files-found: ignore
 
-      - name: Comment on PR with budget summary
+      - name: Emit PR comment
         if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@v7
         env:
-          JOB_STATUS: ${{ job.status }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        with:
-          script: |
-            const fs = require('fs');
-            const status = process.env.JOB_STATUS === 'success' ? '✅ PASSED' : '❌ FAILED';
-            const runUrl = process.env.RUN_URL;
-
-            let body = `## 📏 Entry-File Budget Check ${status}\n\n`;
-            body += 'Agent entry files (`README.md`, `AGENTS.md`, `CLAUDE.md`) load into every conversation. This check enforces the <2k-token budget declared in `docs/index.md` with a 1,500-word cap.\n\n';
-
-            try {
-              const report = fs.readFileSync('.ss/reports/entry-files/entry-file-size-report.md', 'utf8');
-              body += '<details><summary>Full report</summary>\n\n' + report + '\n</details>\n\n';
-            } catch (e) {
-              body += '_Report unavailable._\n\n';
-            }
-
-            body += `[View workflow run](${runUrl})\n`;
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const marker = '📏 Entry-File Budget Check';
-            const existing = comments.find(c => c.user.type === 'Bot' && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body
-              });
-            }
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: slopstopper emit hygiene:entry-files --target pr-comment

--- a/cli/slopstopper/checks/entry_files.py
+++ b/cli/slopstopper/checks/entry_files.py
@@ -36,6 +36,16 @@ REPORT_DIR = Path(".ss/reports/entry-files")
 REPORT_MD = REPORT_DIR / "entry-file-size-report.md"
 REPORT_JSON = REPORT_DIR / "entry-file-size-report.json"
 
+# Consumed by `slopstopper emit hygiene:entry-files --target pr-comment`.
+# The discriminator is byte-identical to the marker the legacy
+# actions/github-script@v7 block matched on, so the same bot comment
+# is reused after the workflow flip. No issue keys: the workflow gates
+# main with the check's own exit code, no main-branch issue is created.
+META = {
+    "report_path": str(REPORT_MD),
+    "comment_discriminator": "📏 Entry-File Budget Check",
+}
+
 _WORD_RE = re.compile(r"\S+")
 
 


### PR DESCRIPTION
## Summary

- Adds \`META\` to \`cli/slopstopper/checks/entry_files.py\` (report path + comment discriminator only — no main-branch issue).
- Rewrites \`ss-hygiene-entry-files-check.yml\` to install slopstopper-cli (editable in-repo / git for adopters), \`slopstopper run hygiene:entry-files\`, then \`slopstopper emit hygiene:entry-files --target pr-comment\`. Net -38 lines, identical bot-comment behaviour (the discriminator is byte-identical to the legacy marker so the same comment is reused on update).
- Registers the workflow path in \`ci-cli.yml\` so CLI tests gate any change to its emit shape (same pattern as #209 docs-size).

## Why no \`--target issue\`?

The pre-flip workflow only commented on PRs and let the run step's non-zero exit fail the workflow on main. No \`actions/github-script\` issue-create block existed, so there's nothing to port. META omits the issue keys deliberately.

## Test plan

- [x] \`task -t cli/Taskfile.yml test\` — all 380 pass
- [x] \`task -t cli/Taskfile.yml parity\` — bash↔CLI byte-identical on all parity-eligible checks (entry-files included)
- [x] \`slopstopper run hygiene:entry-files\` locally — all three entry files within budget
- [ ] CI green: pytest + parity + templates-sync + the dogfooded entry-files workflow
- [ ] PR bot-comment renders the report and updates (not duplicates) on subsequent pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)