### PR TITLE
feat(workflows): flip ss-hygiene-docs-structure to slopstopper emit (Phase 2)

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -54,6 +54,7 @@ on:
       # CLI tests must run too. As more workflows flip, add them here.
       - '.github/workflows/ss-hygiene-docs-size-check.yml'
       - '.github/workflows/ss-hygiene-entry-files-check.yml'
+      - '.github/workflows/ss-hygiene-docs-structure-check.yml'
   push:
     branches: [ main ]
     paths:
@@ -83,6 +84,7 @@ on:
       # CLI tests must run too. As more workflows flip, add them here.
       - '.github/workflows/ss-hygiene-docs-size-check.yml'
       - '.github/workflows/ss-hygiene-entry-files-check.yml'
+      - '.github/workflows/ss-hygiene-docs-structure-check.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ss-hygiene-docs-structure-check.yml
+++ b/.github/workflows/ss-hygiene-docs-structure-check.yml
@@ -1,16 +1,23 @@
 name: SlopStopper · Hygiene - Documentation Structure Check
 
+# CLI-flipped workflow (Phase 2). Replaces task ss:hygiene:docs-structure
+# + two `actions/github-script@v7` blocks (PR comment + main-branch
+# issue) with two `slopstopper emit` steps. The check exits non-zero
+# when violations are found, so `steps.check.outcome` gates emission.
+
 on:
   pull_request:
     paths:
       - 'docs/**'
       - 'docs/index.md'
+      - '.github/workflows/ss-hygiene-docs-structure-check.yml'
   push:
     branches:
       - main
     paths:
       - 'docs/**'
       - 'docs/index.md'
+      - '.github/workflows/ss-hygiene-docs-structure-check.yml'
   workflow_dispatch:
 
 permissions:
@@ -21,154 +28,47 @@ permissions:
 jobs:
   check-docs-structure:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      
-      - name: Install Task
+
+      - name: Install slopstopper-cli
         run: |
-          curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
-          task --version
-      
-      - name: Run documentation structure check
-        id: structure
-        run: |
-          task ss:hygiene:docs-structure
-          
-          # Parse violation count from JSON report
-          if [ -f .ss/reports/docs/docs-structure-report.json ]; then
-            VIOLATION_COUNT=$(python3 -c "import json; data=json.load(open('.ss/reports/docs/docs-structure-report.json')); print(data.get('violation_count', 0))" 2>/dev/null || echo "0")
-            echo "violation_count=$VIOLATION_COUNT" >> $GITHUB_OUTPUT
-            
-            if [ "$VIOLATION_COUNT" -gt 0 ]; then
-              echo "has_violations=true" >> $GITHUB_OUTPUT
-            else
-              echo "has_violations=false" >> $GITHUB_OUTPUT
-            fi
+          # Pre-PyPI dogfood install. slopstopper.dev installs editable
+          # from local source; adopters (no cli/ dir) install from git.
+          # Once published, both branches collapse into:
+          #   pipx install slopstopper-cli==<pinned-version>
+          if [ -f cli/pyproject.toml ]; then
+            pip install -e ./cli
+          else
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
           fi
-      
-      - name: Copy report for workflow
-        run: cp .ss/reports/docs/docs-structure-report.md docs-structure-report.md || true
-      
-      - name: Comment on PR with structure report
-        if: github.event_name == 'pull_request' && steps.structure.outputs.has_violations == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            
-            let reportContent = '';
-            try {
-              reportContent = fs.readFileSync('docs-structure-report.md', 'utf8');
-            } catch (e) {
-              reportContent = '❌ Failed to read structure report';
-            }
-            
-            const commentBody = reportContent;
-            
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            
-            const botComment = comments.find(comment => 
-              comment.user.type === 'Bot' && 
-              comment.body.includes('📋 Documentation Structure')
-            );
-            
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: commentBody
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: commentBody
-              });
-            }
-      
-      - name: Create or update issue on main when structure fails
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.structure.outputs.has_violations == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            
-            let reportContent = 'Unable to read structure report';
-            try {
-              reportContent = fs.readFileSync('docs-structure-report.md', 'utf8');
-            } catch (e) {
-              console.log('Report not found:', e.message);
-            }
-            
-            // Check for existing open issue
-            const { data: issues } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'documentation-structure'
-            });
-            
-            const title = '📋 Documentation Structure Issues';
-            const body = [
-              'The documentation structure no longer matches the governance model defined in docs/index.md.',
-              '',
-              '## Report',
-              reportContent,
-              '',
-              '## To Fix',
-              '```bash',
-              'task ss:hygiene:docs-structure',
-              '```',
-              '',
-              '## Review',
-              'See [docs/index.md](../blob/main/docs/index.md) for the current governance model.',
-              '',
-              'This issue was automatically created by the Documentation Structure Check workflow.',
-              `Commit: ${context.sha}`
-            ].join('\n');
-            
-            if (issues.length > 0) {
-              // Update existing issue
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issues[0].number,
-                body: body
-              });
-              
-              // Add comment about new violation
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issues[0].number,
-                body: `🔔 Documentation structure issues detected again in commit ${context.sha}`
-              });
-            } else {
-              // Create new issue
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: title,
-                body: body,
-                labels: ['documentation-structure', 'documentation']
-              });
-            }
-      
+
+      - name: Run documentation structure check
+        id: check
+        continue-on-error: true
+        run: slopstopper run hygiene:docs-structure
+
+      - name: Emit PR comment
+        if: github.event_name == 'pull_request' && steps.check.outcome == 'failure'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: slopstopper emit hygiene:docs-structure --target pr-comment
+
+      - name: Emit issue on main (if violations)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.check.outcome == 'failure'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: slopstopper emit hygiene:docs-structure --target issue
+
       - name: Upload structure report
         if: always()
         uses: actions/upload-artifact@v4
@@ -176,3 +76,9 @@ jobs:
           name: docs-structure-report
           path: .ss/reports/docs/docs-structure-report.md
           retention-days: 30
+
+      - name: Fail the job if violations
+        if: steps.check.outcome == 'failure'
+        run: |
+          echo "::error::Documentation structure violations detected. See report."
+          exit 1

--- a/cli/slopstopper/checks/docs_structure.py
+++ b/cli/slopstopper/checks/docs_structure.py
@@ -25,6 +25,19 @@ REPORT_DIR = Path(".ss/reports/docs")
 REPORT_JSON = REPORT_DIR / "docs-structure-report.json"
 REPORT_MD = REPORT_DIR / "docs-structure-report.md"
 
+# Consumed by `slopstopper emit hygiene:docs-structure --target {pr-comment,issue}`.
+# Strings are byte-for-byte identical to the discriminator / title / labels
+# the legacy actions/github-script@v7 block in
+# .github/workflows/ss-hygiene-docs-structure-check.yml used, so the same
+# bot comments/issues are matched after the workflow flip.
+META = {
+    "report_path": str(REPORT_MD),
+    "comment_discriminator": "📋 Documentation Structure",
+    "issue_title": "📋 Documentation Structure Issues",
+    "issue_labels": ["documentation-structure", "documentation"],
+    "issue_followup": "🔔 Documentation structure issues detected again in commit",
+}
+
 # Files allowed at the top level of docs/ without being declared in
 # the categories table. Mirrors the bash check exactly.
 ALLOWED_TOP_FILES = {"index.md", "README.md", "AGENTS.md", "CONTRIBUTING.md"}


### PR DESCRIPTION
## Summary

- Adds \`META\` to \`cli/slopstopper/checks/docs_structure.py\` with the same 5 keys as docs-size (report path, comment discriminator, issue title, labels, follow-up string).
- Rewrites \`ss-hygiene-docs-structure-check.yml\`: -138 / +59 lines. Replaces the two \`actions/github-script@v7\` blocks with \`slopstopper emit ... --target {pr-comment,issue}\`. Uses \`continue-on-error: true\` on the check step so emit fires when violations are found, then re-fails the job at the end so the workflow status mirrors pre-flip behaviour.
- Registers the workflow path in \`ci-cli.yml\`.

## Issue body shape change

Pre-flip, the main-branch issue body wrapped the report in a preamble ("The documentation structure no longer matches…"), a "To Fix" block, and a "Review" footer. Post-flip, the emit module just appends a \`Commit: <sha>\` footer to the raw report — same as docs-size #209. The report itself already contains the violation list and recommendations (its generator writes them in), so no information is lost; only the surrounding wrapper changes. Tracking-issue identity is preserved via the \`documentation-structure\` label.

## Test plan

- [x] \`task -t cli/Taskfile.yml test\` — all 380 pass
- [x] \`slopstopper run hygiene:docs-structure\` locally — clean
- [ ] CI green: pytest + parity + templates-sync + the dogfooded docs-structure workflow
- [ ] PR bot-comment renders when violations exist; updates on subsequent pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)