### PR TITLE
feat(workflows): flip ss-hygiene-csp-exceptions to slopstopper emit (Phase 2)

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -57,6 +57,7 @@ on:
       - '.github/workflows/ss-hygiene-docs-structure-check.yml'
       - '.github/workflows/ss-hygiene-complexity-check.yml'
       - '.github/workflows/ss-hygiene-docs-accuracy-check.yml'
+      - '.github/workflows/ss-hygiene-csp-exceptions-check.yml'
   push:
     branches: [ main ]
     paths:
@@ -89,6 +90,7 @@ on:
       - '.github/workflows/ss-hygiene-docs-structure-check.yml'
       - '.github/workflows/ss-hygiene-complexity-check.yml'
       - '.github/workflows/ss-hygiene-docs-accuracy-check.yml'
+      - '.github/workflows/ss-hygiene-csp-exceptions-check.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ss-hygiene-csp-exceptions-check.yml
+++ b/.github/workflows/ss-hygiene-csp-exceptions-check.yml
@@ -1,18 +1,22 @@
 name: SlopStopper · Hygiene - CSP Exceptions Drift Check
 
+# CLI-flipped workflow (Phase 2). Replaces task ss:hygiene:csp-exceptions
+# + ~50 lines of duplicated actions/github-script@v7 with one
+# `slopstopper emit` step. The check itself runs via the CLI and the
+# workflow's failure surfaces drift on main; no separate main-branch
+# issue is created (the check's exit-code gate is enough).
+
 on:
   pull_request:
     paths:
       - 'worker/headers.json'
       - 'docs/security/CSP_EXCEPTIONS.md'
-      - '.ss/scripts/check-csp-exceptions.py'
       - '.github/workflows/ss-hygiene-csp-exceptions-check.yml'
   push:
     branches: [main]
     paths:
       - 'worker/headers.json'
       - 'docs/security/CSP_EXCEPTIONS.md'
-      - '.ss/scripts/check-csp-exceptions.py'
       - '.github/workflows/ss-hygiene-csp-exceptions-check.yml'
   workflow_dispatch:
 
@@ -34,14 +38,21 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install Task
+      - name: Install slopstopper-cli
         run: |
-          curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
-          task --version
+          # Pre-PyPI dogfood install. slopstopper.dev installs editable
+          # from local source; adopters (no cli/ dir) install from git.
+          # Once published, both branches collapse into:
+          #   pipx install slopstopper-cli==<pinned-version>
+          if [ -f cli/pyproject.toml ]; then
+            pip install -e ./cli
+          else
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+          fi
 
       - name: Run CSP exceptions check
         id: check
-        run: task ss:hygiene:csp-exceptions
+        run: slopstopper run hygiene:csp-exceptions
 
       - name: Upload report
         if: always()
@@ -52,49 +63,8 @@ jobs:
           retention-days: 30
           if-no-files-found: ignore
 
-      - name: Comment on PR with drift summary
+      - name: Emit PR comment
         if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@v7
         env:
-          JOB_STATUS: ${{ job.status }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        with:
-          script: |
-            const fs = require('fs');
-            const status = process.env.JOB_STATUS === 'success' ? '✅ PASSED' : '❌ FAILED';
-            const runUrl = process.env.RUN_URL;
-
-            let body = `## 🔐 CSP Exceptions Check ${status}\n\n`;
-            body += 'This check enforces that every per-path CSP relaxation in `worker/headers.json` is documented in `docs/security/CSP_EXCEPTIONS.md` — and vice versa.\n\n';
-
-            try {
-              const report = fs.readFileSync('.ss/reports/csp/csp-exceptions-report.md', 'utf8');
-              body += '<details><summary>Full report</summary>\n\n' + report + '\n</details>\n\n';
-            } catch (e) {
-              body += '_Report unavailable._\n\n';
-            }
-
-            body += `[View workflow run](${runUrl})\n`;
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const marker = '🔐 CSP Exceptions Check';
-            const existing = comments.find(c => c.user.type === 'Bot' && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body
-              });
-            }
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: slopstopper emit hygiene:csp-exceptions --target pr-comment

--- a/cli/slopstopper/checks/csp_exceptions.py
+++ b/cli/slopstopper/checks/csp_exceptions.py
@@ -33,6 +33,18 @@ REPORT_DIR = Path(".ss/reports/csp")
 REPORT_JSON = REPORT_DIR / "csp-exceptions-report.json"
 REPORT_MD = REPORT_DIR / "csp-exceptions-report.md"
 
+# Consumed by `slopstopper emit hygiene:csp-exceptions --target pr-comment`.
+# The discriminator substring `🔐 CSP Exceptions` appears in both legacy
+# bot comments (pre-flip JS heading "🔐 CSP Exceptions Check") and the
+# post-flip body (report H1 "🔐 CSP Exceptions Report"), so a single bot
+# comment is reused across the migration. No issue keys: this check fails
+# the workflow on drift via its own exit code, no main-branch issue is
+# created.
+META = {
+    "report_path": str(REPORT_MD),
+    "comment_discriminator": "🔐 CSP Exceptions",
+}
+
 REQUIRED_FIELDS = {
     "Origin allowed",
     "Directives added",


### PR DESCRIPTION
## Summary

- Adds \`META\` to \`cli/slopstopper/checks/csp_exceptions.py\` (report path + comment discriminator). No issue keys — drift fails the workflow via the check's exit code.
- Rewrites \`ss-hygiene-csp-exceptions-check.yml\`: -50 / +34 lines, mirroring the entry-files shape.
- Discriminator \`🔐 CSP Exceptions\` is a substring of both the pre-flip JS heading ("🔐 CSP Exceptions Check") and the post-flip report H1 ("🔐 CSP Exceptions Report"), so the same bot comment is reused across the migration.
- Registers the workflow path in \`ci-cli.yml\`.
- **Completes the hygiene category flip** — all 5 hygiene workflows now route through the CLI.

## Test plan

- [x] \`task -t cli/Taskfile.yml test\` — 380 pass
- [x] \`slopstopper run hygiene:csp-exceptions\` locally — no drift
- [ ] CI green: pytest + parity + templates-sync + the dogfooded CSP workflow
- [ ] PR bot-comment renders and updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)