### PR TITLE
feat(workflows): flip ss-security-vulnerability-all to slopstopper emit (Phase 2)

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -60,6 +60,7 @@ on:
       - '.github/workflows/ss-hygiene-csp-exceptions-check.yml'
       - '.github/workflows/ss-security-secrets-check.yml'
       - '.github/workflows/ss-security-sast-check.yml'
+      - '.github/workflows/ss-security-vulnerability-all-check.yml'
   push:
     branches: [ main ]
     paths:
@@ -95,6 +96,7 @@ on:
       - '.github/workflows/ss-hygiene-csp-exceptions-check.yml'
       - '.github/workflows/ss-security-secrets-check.yml'
       - '.github/workflows/ss-security-sast-check.yml'
+      - '.github/workflows/ss-security-vulnerability-all-check.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ss-security-vulnerability-all-check.yml
+++ b/.github/workflows/ss-security-vulnerability-all-check.yml
@@ -1,5 +1,15 @@
 name: SlopStopper · Dependency Vulnerability Scan
 
+# CLI-flipped workflow (Phase 2). Mirrors the secrets / sast flips —
+# two `slopstopper emit` steps replace ~90 lines of duplicated
+# actions/github-script@v7. The check exits 0 always; the workflow
+# gates fail/emit-issue on the count of CRITICAL/HIGH vulnerabilities
+# in the Trivy JSON output.
+#
+# Filename is kept as `ss-security-vulnerability-all-check.yml` for
+# backward compatibility with existing adopter installations; the
+# CLI standardises the check name to `security:dependencies`.
+
 on:
   pull_request:
     branches: [ main ]
@@ -22,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -33,69 +43,43 @@ jobs:
           sudo apt-get update -qq && sudo apt-get install -y trivy
           trivy --version
 
-      - name: Install Task
+      - name: Install slopstopper-cli
         run: |
-          curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
-          task --version
+          # Pre-PyPI dogfood install. slopstopper.dev installs editable
+          # from local source; adopters (no cli/ dir) install from git.
+          # Once published, both branches collapse into:
+          #   pipx install slopstopper-cli==<pinned-version>
+          if [ -f cli/pyproject.toml ]; then
+            pip install -e ./cli
+          else
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+          fi
 
       - name: Run dependency scan
         id: dependencies
+        run: slopstopper run security:dependencies
+
+      - name: Detect critical/high vulnerabilities
+        id: gate
         run: |
-          task ss:security:vulnerability:all
-
-      - name: Check reports generated
-        run: |
-          if [ ! -f .ss/reports/dependencies/dependencies-report.md ]; then
-            echo "❌ Failed to generate dependencies report"
-            exit 1
-          fi
-
-          echo "✅ Dependency reports generated successfully"
-
-      - name: Check for critical/high vulnerabilities
-        id: check-dependencies
-        run: |
-          set +e
-          VULNS_FOUND=0
-
           if [ -f .ss/reports/dependencies/dependencies-report.json ]; then
             VULN_COUNT=$(python3 -c "
-          import json, sys
+          import json
           with open('.ss/reports/dependencies/dependencies-report.json') as f:
-            data = json.load(f)
+              data = json.load(f)
           count = 0
-          for result in data.get('Results', []):
-            for v in result.get('Vulnerabilities', []):
-              if v.get('Severity', '').upper() in ('CRITICAL', 'HIGH'):
-                count += 1
+          for r in data.get('Results', []):
+              for v in r.get('Vulnerabilities', []):
+                  if v.get('Severity', '').upper() in ('CRITICAL', 'HIGH'):
+                      count += 1
           print(count)
-          " 2>/dev/null || echo "0")
-            if [ "$VULN_COUNT" -gt 0 ]; then
-              VULNS_FOUND=1
-              echo "⚠️  Found $VULN_COUNT CRITICAL/HIGH vulnerability(ies)"
-            fi
-          fi
-
-          set -e
-          echo "vulns_found=$VULNS_FOUND" >> $GITHUB_OUTPUT
-
-      - name: Debug - Check directory contents before upload
-        if: always()
-        run: |
-          echo "🔍 Debugging directory structure and paths"
-          echo ""
-          echo "📍 Current working directory:"
-          pwd
-          echo ""
-          echo "📂 Checking .ss/reports/dependencies/:"
-          if [ -d .ss/reports/dependencies ]; then
-            echo "✅ Directory exists"
-            ls -la .ss/reports/dependencies/
-            echo ""
-            echo "Content of dependencies-report.md (first 10 lines):"
-            cat .ss/reports/dependencies/dependencies-report.md | head -10 || echo "File not readable"
+          ")
           else
-            echo "❌ Directory .ss/reports/dependencies does not exist"
+            VULN_COUNT=0
+          fi
+          echo "vulns_found=$([ "$VULN_COUNT" -gt 0 ] && echo 1 || echo 0)" >> "$GITHUB_OUTPUT"
+          if [ "$VULN_COUNT" -gt 0 ]; then
+            echo "⚠️  Found $VULN_COUNT CRITICAL/HIGH vulnerability(ies)"
           fi
 
       - name: Upload dependency reports
@@ -109,93 +93,20 @@ jobs:
           retention-days: 30
           if-no-files-found: warn
 
-      - name: Comment on PR with dependency report
+      - name: Emit PR comment
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: slopstopper emit security:dependencies --target pr-comment
 
-            let reportContent = '## 📦 Dependency Vulnerability Scan\n\n';
+      - name: Emit issue on main (if critical/high vulns)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.gate.outputs.vulns_found == '1'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: slopstopper emit security:dependencies --target issue
 
-            try {
-              const markdownReport = fs.readFileSync('.ss/reports/dependencies/dependencies-report.md', 'utf8');
-              reportContent += markdownReport + '\n\n';
-            } catch (e) {
-              reportContent += '**Could not read dependency report.** See workflow artifacts for details.\n\n';
-            }
-
-            reportContent += '### 🔍 How to Check Locally\n\n';
-            reportContent += '```bash\n';
-            reportContent += 'task ss:vulnerability:all\n';
-            reportContent += '```\n\n';
-            reportContent += '[Full reports available in workflow artifacts](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) (`.ss/reports/dependencies/` directory)\n';
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: reportContent
-            });
-
-      - name: Create/Update issue on main branch with critical/high vulnerabilities
-        if: steps.check-dependencies.outputs.vulns_found == '1' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-
-            const title = '⚠️ Dependency Vulnerabilities in Main Branch';
-            let body = '## Dependency Scan Found Vulnerabilities\n\n';
-            body += `**Commit:** [\`${{ github.sha }}\`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})\n`;
-            body += `**Run:** [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n\n`;
-
-            try {
-              const markdownReport = fs.readFileSync('.ss/reports/dependencies/dependencies-report.md', 'utf8');
-              body += '## Report\n\n' + markdownReport + '\n\n';
-            } catch (e) {
-              body += 'See workflow artifacts for detailed reports.\n\n';
-            }
-
-            body += '## Reproduction Steps\n\n';
-            body += '```bash\n';
-            body += '# Install Task (one-time)\n';
-            body += 'curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin\n\n';
-            body += '# Run dependency scan locally\n';
-            body += 'task ss:vulnerability:all\n';
-            body += '```\n\n';
-            body += '## Guidelines\n\n';
-            body += '- **CRITICAL/HIGH**: Update or replace the vulnerable package\n';
-            body += '- **MEDIUM/LOW**: Review and plan remediation\n';
-
-            // Check for existing open issue
-            const issues = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: ['dependencies']
-            });
-
-            if (issues.data.length === 0) {
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: title,
-                body: body,
-                labels: ['dependencies', 'security']
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issues.data[0].number,
-                body: `## New Report\n\n${new Date().toISOString()}\n\n${body}`
-              });
-            }
-
-      - name: Fail job if critical/high vulnerabilities found
-        if: steps.check-dependencies.outputs.vulns_found == '1'
+      - name: Fail job if critical/high vulnerabilities
+        if: steps.gate.outputs.vulns_found == '1'
         run: |
-          echo "❌ CRITICAL/HIGH dependency vulnerabilities detected"
-          echo "Please review the dependency report above and update vulnerable packages"
+          echo "::error::CRITICAL/HIGH dependency vulnerabilities detected. Update vulnerable packages."
           exit 1

--- a/cli/slopstopper/checks/dependencies.py
+++ b/cli/slopstopper/checks/dependencies.py
@@ -30,6 +30,20 @@ REPORT_DIR = Path(".ss/reports/dependencies")
 REPORT_JSON = REPORT_DIR / "dependencies-report.json"
 REPORT_MD = REPORT_DIR / "dependencies-report.md"
 
+# Consumed by `slopstopper emit security:dependencies --target {pr-comment,issue}`.
+# Discriminator `Dependency Vulnerability` matches both the pre-flip JS
+# heading ("## 📦 Dependency Vulnerability Scan") and the post-flip
+# report H1 ("# Dependency Vulnerability Report"), so the same bot
+# comment is reused after the workflow flip. Issue title, labels, and
+# follow-up string are byte-identical to the legacy block.
+META = {
+    "report_path": str(REPORT_MD),
+    "comment_discriminator": "Dependency Vulnerability",
+    "issue_title": "⚠️ Dependency Vulnerabilities in Main Branch",
+    "issue_labels": ["dependencies", "security"],
+    "issue_followup": "🔔 Dependency vulnerabilities detected again in commit",
+}
+
 _INSTALL_HELP = (
     "❌ trivy is not installed.\n"
     "Install with:\n"


### PR DESCRIPTION
## Summary

- Adds \`META\` to \`cli/slopstopper/checks/dependencies.py\` (5 keys; discriminator \`Dependency Vulnerability\` matches both legacy bot comments and the post-flip report H1).
- Rewrites \`ss-security-vulnerability-all-check.yml\`: -139 / +66 lines.
- Same dedup improvement as secrets / sast — PR comments now find-or-update.
- Workflow filename keeps \`vulnerability-all\` for backward compatibility with adopter installations; CLI standardises the check name to \`security:dependencies\`.
- Registers the workflow path in \`ci-cli.yml\`.

## Deferred — DAST flip

The DAST workflow has a 236-line CSP-exception gate script (\`.ss/scripts/check-dast-alerts.py\`) that builds a "swallowed CSP exceptions" preamble in the PR comment. A clean flip needs that logic lifted into the CLI (the same shape as the \`discover-pages.py\` lift in #204). Bigger than a mechanical flip; queued as a separate follow-up so this PR stays mechanical.

## Test plan

- [x] \`task -t cli/Taskfile.yml test\` — 380 pass
- [ ] CI green: pytest + parity + templates-sync + the dogfooded Trivy workflow
- [ ] PR bot-comment renders / dedups correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)