### PR TITLE
feat(workflows): route ss-reliability-broken-links through slopstopper CLI (Phase 2)

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -62,6 +62,7 @@ on:
       - '.github/workflows/ss-security-sast-check.yml'
       - '.github/workflows/ss-security-vulnerability-all-check.yml'
       - '.github/workflows/ss-reliability-smoke-tests.yml'
+      - '.github/workflows/ss-reliability-broken-links-check.yml'
   push:
     branches: [ main ]
     paths:
@@ -99,6 +100,7 @@ on:
       - '.github/workflows/ss-security-sast-check.yml'
       - '.github/workflows/ss-security-vulnerability-all-check.yml'
       - '.github/workflows/ss-reliability-smoke-tests.yml'
+      - '.github/workflows/ss-reliability-broken-links-check.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ss-reliability-broken-links-check.yml
+++ b/.github/workflows/ss-reliability-broken-links-check.yml
@@ -1,12 +1,21 @@
 name: SlopStopper · Broken Links Check
 
+# CLI-flipped workflow (Phase 2). Same shape as the smoke flip: there
+# is no markdown report and the PR-comment body is built from workflow
+# context only, so emit.py isn't a fit. The check runs via the CLI,
+# and the small PR-comment block uses `gh pr comment` directly.
+#
+# Discovery is still invoked via .ss/scripts/discover-pages.py for now
+# (it sets BROKEN_LINKS_PAGES, which the CLI check picks up via env).
+# A future PR can add `slopstopper discover` as a subcommand and drop
+# the bash script — keeping it here to keep this flip mechanical.
+
 on:
   pull_request:
     branches: [main]
   push:
     branches: [main]
   deployment_status:
-  # Run daily at 08:00 UTC
   schedule:
     - cron: '0 8 * * *'
   workflow_dispatch:
@@ -54,10 +63,22 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
-      - name: Install Task
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install slopstopper-cli
         run: |
-          curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
-          task --version
+          # Pre-PyPI dogfood install. slopstopper.dev installs editable
+          # from local source; adopters (no cli/ dir) install from git.
+          # Once published, both branches collapse into:
+          #   pipx install slopstopper-cli==<pinned-version>
+          if [ -f cli/pyproject.toml ]; then
+            pip install -e ./cli
+          else
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+          fi
 
       - name: Determine check URL
         id: url
@@ -110,9 +131,9 @@ jobs:
         env:
           DISPATCH_MODE: ${{ github.event.inputs.coverage_mode }}
           GITHUB_BASE_REF: ${{ github.base_ref || 'main' }}
-        # Calls discover-pages.py with the event-mapped mode. Falls through
-        # to pages.broken_links when reliability.coverage.* is unset, so
-        # existing adopters see no behaviour change.
+        # Maps GH event → discover-pages.py's --event flag. Falls
+        # through to pages.broken_links when reliability.coverage.* is
+        # unset, so existing adopters see no behaviour change.
         run: |
           case "${{ github.event_name }}" in
             pull_request|pull_request_target) EVENT=pr ;;
@@ -129,7 +150,7 @@ jobs:
         env:
           BROKEN_LINKS_TEST_URL: ${{ steps.url.outputs.url }}
           BROKEN_LINKS_PAGES: ${{ env.BROKEN_LINKS_PAGES }}
-        run: task ss:reliability:links:ci
+        run: slopstopper run reliability:broken-links -- --ci
 
       - name: Stop local server
         if: always() && steps.url.outputs.use_local == 'true'
@@ -148,36 +169,39 @@ jobs:
 
       - name: Comment on PR with results
         if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@v7
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JOB_STATUS: ${{ job.status }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           CHECK_URL: ${{ steps.url.outputs.url }}
-        with:
-          script: |
-            const status = process.env.JOB_STATUS === 'success' ? '✅ PASSED' : '❌ FAILED';
-            const runUrl = process.env.RUN_URL;
-            const checkUrl = process.env.CHECK_URL;
+        run: |
+          status_marker=$([ "$JOB_STATUS" = "success" ] && echo "✅ PASSED" || echo "❌ FAILED")
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          body=$(cat <<EOF
+          ## 🔗 Broken Links Check ${status_marker}
 
-            const body = [
-              `## 🔗 Broken Links Check ${status}`,
-              '',
-              `**Checked URL:** ${checkUrl}`,
-              '',
-              '### 🔍 How to Check Locally',
-              '',
-              '```bash',
-              'BROKEN_LINKS_TEST_URL=https://your-site.example.com task ss:reliability:links',
-              '',
-              'task ss:reliability:links -- https://your-site.example.com',
-              '```',
-              '',
-              `[Full report in workflow artifacts](${runUrl})`,
-            ].join('\n');
+          **Checked URL:** ${CHECK_URL}
 
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body,
-            });
+          ### 🔍 How to Check Locally
+
+          \`\`\`bash
+          BROKEN_LINKS_TEST_URL=https://your-site.example.com slopstopper run reliability:broken-links
+
+          slopstopper run reliability:broken-links -- --url https://your-site.example.com
+          \`\`\`
+
+          [Full report in workflow artifacts](${run_url})
+          EOF
+          )
+          # Match the existing bot comment by the H2 marker and update,
+          # else create. (Pre-flip used createComment only — this fixes
+          # the duplicates-on-every-push regression seen in the legacy
+          # checks; same dedup approach as the emit-routed flips.)
+          marker='🔗 Broken Links Check'
+          pr_number=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
+          existing=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" \
+            --jq ".[] | select(.user.type==\"Bot\" and (.body | contains(\"$marker\"))) | .id" | head -n1)
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" -f body="$body"
+          else
+            gh pr comment "$pr_number" --body "$body"
+          fi


### PR DESCRIPTION
## Summary

- Routes the broken-links check through \`slopstopper run reliability:broken-links -- --ci\`.
- Converts the \`actions/github-script@v7\` PR comment to inline \`gh\` with find-or-update dedup (matches the \`🔗 Broken Links Check\` marker). Pre-flip used \`createComment\` only → duplicate comments per push. Post-flip matches the emit-routed flips' behaviour.
- Keeps discovery on \`.ss/scripts/discover-pages.py\` for this PR (it sets \`BROKEN_LINKS_PAGES\` and the CLI check honours it). A future PR will add \`slopstopper discover\` as a subcommand and drop the bash dependency.
- Registers the workflow path in \`ci-cli.yml\`.

## Test plan

- [x] \`task -t cli/Taskfile.yml test\` — 380 pass
- [ ] CI green: the broken-links job (dogfooded against the local build), plus parity / pytest / templates-sync
- [ ] PR bot-comment renders + updates on subsequent pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)