### PR TITLE
feat(workflows): flip ss-reliability-seo to slopstopper emit (Phase 2)

### DIFF
--- a/.github/workflows/ci-cli.yml
+++ b/.github/workflows/ci-cli.yml
@@ -64,6 +64,7 @@ on:
       - '.github/workflows/ss-reliability-smoke-tests.yml'
       - '.github/workflows/ss-reliability-broken-links-check.yml'
       - '.github/workflows/ss-reliability-accessibility-check.yml'
+      - '.github/workflows/ss-reliability-seo-check.yml'
   push:
     branches: [ main ]
     paths:
@@ -103,6 +104,7 @@ on:
       - '.github/workflows/ss-reliability-smoke-tests.yml'
       - '.github/workflows/ss-reliability-broken-links-check.yml'
       - '.github/workflows/ss-reliability-accessibility-check.yml'
+      - '.github/workflows/ss-reliability-seo-check.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ss-reliability-seo-check.yml
+++ b/.github/workflows/ss-reliability-seo-check.yml
@@ -1,17 +1,20 @@
 name: SlopStopper · SEO Metatag Check
 
+# CLI-flipped workflow (Phase 2). The SEO check writes a markdown
+# report (.ss/reports/seo/seo-metatags-report.md), so emit.py is the
+# right fit here — same shape as the hygiene/security flips.
+# Replaces ~35 lines of duplicated actions/github-script@v7 with one
+# `slopstopper emit` step. No main-branch issue: the check's exit
+# code fails the workflow on missing tags, which is enough signal.
+
 on:
   pull_request:
     branches: [main]
-
   push:
     branches: [main]
-
   deployment_status:
-
   schedule:
     - cron: '0 7 * * *'
-
   workflow_dispatch:
     inputs:
       url:
@@ -29,7 +32,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  issues: write
 
 jobs:
   seo:
@@ -43,7 +45,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          # discover-pages.py changed-mode needs git history vs the base branch.
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -57,10 +58,17 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install Task
+      - name: Install slopstopper-cli
         run: |
-          curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
-          task --version
+          # Pre-PyPI dogfood install. slopstopper.dev installs editable
+          # from local source; adopters (no cli/ dir) install from git.
+          # Once published, both branches collapse into:
+          #   pipx install slopstopper-cli==<pinned-version>
+          if [ -f cli/pyproject.toml ]; then
+            pip install -e ./cli
+          else
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+          fi
 
       - name: Determine audit URL
         id: url
@@ -100,10 +108,9 @@ jobs:
 
       - name: Start local server (PR / push builds)
         if: steps.url.outputs.use_local == 'true'
-        # CUSTOMISE FOR YOUR APP: this step is wired for this repo's static
-        # site (build + node server.js). Replace with whatever starts your
-        # app on port 8080 — or set use_local=false in the Determine audit
-        # URL step and point SEO_TEST_URL at a deployed environment.
+        # CUSTOMISE FOR YOUR APP: wired for a static site (build + node
+        # server.js). Replace with whatever starts your app on port
+        # 8080 — or point SEO_TEST_URL at a deployed environment.
         run: |
           if [ -f server.js ] && [ -f package.json ] && node -e "process.exit(require('./package.json').scripts?.build ? 0 : 1)"; then
             npm run build
@@ -126,9 +133,6 @@ jobs:
         env:
           DISPATCH_MODE: ${{ github.event.inputs.coverage_mode }}
           GITHUB_BASE_REF: ${{ github.base_ref || 'main' }}
-        # Calls discover-pages.py with the event-mapped mode. Falls through
-        # to pages.seo when reliability.coverage.* is unset, so existing
-        # adopters see no behaviour change.
         run: |
           case "${{ github.event_name }}" in
             pull_request|pull_request_target) EVENT=pr ;;
@@ -145,14 +149,14 @@ jobs:
         id: audit
         env:
           SEO_TEST_URL: ${{ steps.url.outputs.url }}
-          # og:image is an absolute URL pointing at the production domain
-          # (required by social-share crawlers). The reachability HEAD check
-          # can't succeed when auditing localhost, so skip it for local
-          # builds. Keep the presence assertion on. Schedule and
-          # deployment_status runs still verify reachability against the
+          # og:image is an absolute URL pointing at the production
+          # domain (required by social-share crawlers). The reachability
+          # HEAD check can't succeed when auditing localhost, so skip
+          # for local builds. Keep the presence assertion on. Schedule
+          # and deployment_status runs verify reachability against the
           # real deployed URL.
           SEO_VERIFY_OG_IMAGE: ${{ steps.url.outputs.use_local == 'true' && '0' || '1' }}
-        run: task ss:reliability:seo:ci
+        run: slopstopper run reliability:seo
 
       - name: Stop local server
         if: steps.url.outputs.use_local == 'true' && always()
@@ -167,36 +171,8 @@ jobs:
           retention-days: 30
           if-no-files-found: ignore
 
-      - name: Comment on PR with SEO results
+      - name: Emit PR comment
         if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@v7
         env:
-          JOB_STATUS: ${{ job.status }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        with:
-          script: |
-            const status = process.env.JOB_STATUS === 'success' ? '✅ PASSED' : '❌ FAILED';
-            const runUrl = process.env.RUN_URL;
-
-            let body = `## 🔎 SEO Metatag Audit ${status}\n\n`;
-            body += 'Checks each page for `<title>`, meta description, canonical, viewport, the OpenGraph set (og:title/description/type/url/image) and the Twitter Card set (twitter:card/title/description/image). Also HEAD-fetches `og:image` to confirm reachability.\n\n';
-
-            if (process.env.JOB_STATUS !== 'success') {
-              body += '> ⚠️ Missing or unreachable tags. See workflow logs / artifact for details.\n\n';
-            }
-
-            body += '### 🔍 How to Check Locally\n\n';
-            body += '```bash\n';
-            body += '# Audit the local build\n';
-            body += 'task ss:reliability:seo -- http://localhost:8080\n\n';
-            body += '# Or audit a deployed URL\n';
-            body += 'task ss:reliability:seo -- https://your-site.example.com\n';
-            body += '```\n\n';
-            body += `[Full report in workflow artifacts](${runUrl})\n`;
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body
-            });
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: slopstopper emit reliability:seo --target pr-comment

--- a/cli/slopstopper/checks/seo.py
+++ b/cli/slopstopper/checks/seo.py
@@ -54,9 +54,22 @@ from slopstopper import discovery
 
 
 REPORT_DIR = Path(".ss/reports/seo")
+REPORT_MD = REPORT_DIR / "seo-metatags-report.md"
 USER_AGENT = "SlopStopper-SEO-Check/1.0"
 TIMEOUT_SECONDS = 15
 ALLOWED_SCHEMES = ("http", "https")
+
+# Consumed by `slopstopper emit reliability:seo --target pr-comment`.
+# Discriminator `🔎 SEO` matches both the pre-flip JS heading
+# ("## 🔎 SEO Metatag Audit") and the post-flip report H1
+# ("# 🔎 SEO / Social-Share Metatag Report"), so the same bot comment
+# is reused after the workflow flip. No issue keys: the check's exit
+# code fails the workflow on missing tags, no main-branch issue is
+# created.
+META = {
+    "report_path": str(REPORT_MD),
+    "comment_discriminator": "🔎 SEO",
+}
 
 
 # ── safety ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- SEO is the only reliability check that writes a markdown report, so emit.py is the right fit (the other reliability flips used inline \`gh\` since their PR-comment bodies were built from context).
- Adds \`META\` to \`cli/slopstopper/checks/seo.py\` with discriminator \`🔎 SEO\` — matches both legacy bot comments and the post-flip report H1.
- Workflow shrinks by ~35 lines: one \`slopstopper emit\` step replaces the github-script@v7 block.
- Same dedup improvement (find-or-update) as the rest of the suite.
- Registers the workflow path in \`ci-cli.yml\`.

## Test plan

- [x] \`task -t cli/Taskfile.yml test\` — 380 pass
- [ ] CI green: SEO job (dogfooded against local build) + parity + pytest + templates-sync
- [ ] PR bot-comment renders and updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)