### PR TITLE
feat(cli): slopstopper discover subcommand + drop bash discovery from reliability workflows (Phase 2)

### DIFF
--- a/.github/workflows/ss-reliability-accessibility-check.yml
+++ b/.github/workflows/ss-reliability-accessibility-check.yml
@@ -156,7 +156,7 @@ jobs:
             workflow_dispatch) EVENT="${DISPATCH_MODE:-main}" ;;
             *)                 EVENT=main ;;
           esac
-          PAGES=$(python3 .ss/scripts/discover-pages.py accessibility --event="$EVENT")
+          PAGES=$(slopstopper discover accessibility --event="$EVENT")
           echo "ACCESSIBILITY_PAGES=$PAGES" >> "$GITHUB_ENV"
 
       - name: Run accessibility audit

--- a/.github/workflows/ss-reliability-broken-links-check.yml
+++ b/.github/workflows/ss-reliability-broken-links-check.yml
@@ -143,7 +143,7 @@ jobs:
             workflow_dispatch) EVENT="${DISPATCH_MODE:-main}" ;;
             *)                 EVENT=main ;;
           esac
-          PAGES=$(python3 .ss/scripts/discover-pages.py broken_links --event="$EVENT")
+          PAGES=$(slopstopper discover broken_links --event="$EVENT")
           echo "BROKEN_LINKS_PAGES=$PAGES" >> "$GITHUB_ENV"
 
       - name: Run broken-link checks

--- a/.github/workflows/ss-reliability-seo-check.yml
+++ b/.github/workflows/ss-reliability-seo-check.yml
@@ -142,7 +142,7 @@ jobs:
             workflow_dispatch) EVENT="${DISPATCH_MODE:-main}" ;;
             *)                 EVENT=main ;;
           esac
-          PAGES=$(python3 .ss/scripts/discover-pages.py seo --event="$EVENT")
+          PAGES=$(slopstopper discover seo --event="$EVENT")
           echo "SEO_PAGES=$PAGES" >> "$GITHUB_ENV"
 
       - name: Run SEO metatag audit

--- a/cli/slopstopper/cli.py
+++ b/cli/slopstopper/cli.py
@@ -5,6 +5,11 @@ Subcommands today:
   emit <check> --target {pr-comment,issue}
                                     — post the report MD to the current PR
                                       or create/update a tracking issue on main
+  discover <check> --event=<event>  — resolve pages.<check> via sitemap /
+                                      changed-pages / explicit list and print
+                                      a comma-separated path list to stdout
+                                      (drop-in replacement for the bash-side
+                                      .ss/scripts/discover-pages.py).
 
 Future: init, inspect.
 """
@@ -15,7 +20,7 @@ import argparse
 import importlib
 import sys
 
-from slopstopper import __version__, emit as emit_mod
+from slopstopper import __version__, discovery, emit as emit_mod
 from slopstopper.checks import REGISTRY
 
 
@@ -56,12 +61,33 @@ def main(argv: list[str] | None = None) -> int:
         help="Where to send the report",
     )
 
+    discover_parser = sub.add_parser(
+        "discover",
+        help="Resolve pages.<check> for a reliability check and print the list to stdout",
+    )
+    # Accept both `broken-links` (hyphen, slopstopper-style) and
+    # `broken_links` (underscore, matches the bash script's args) so this
+    # is a strict superset of `.ss/scripts/discover-pages.py`'s CLI.
+    discover_parser.add_argument(
+        "check",
+        choices=discovery.CHECKS + ("broken-links",),
+        help="Reliability check whose pages to resolve",
+    )
+    discover_parser.add_argument(
+        "--event",
+        choices=discovery.EVENTS,
+        default="local",
+        help="CI event that drives discovery mode (default: local)",
+    )
+
     args = parser.parse_args(argv)
 
     if args.command == "run":
         return _dispatch_run(args.check, args.check_args)
     if args.command == "emit":
         return _dispatch_emit(args.check, args.target)
+    if args.command == "discover":
+        return _dispatch_discover(args.check, args.event)
 
     parser.error(f"unknown command: {args.command}")
     return 2
@@ -73,6 +99,26 @@ def _dispatch_run(check_name: str, check_args: list[str]) -> int:
         print(f"   known checks: {', '.join(sorted(REGISTRY))}", file=sys.stderr)
         return 2
     return REGISTRY[check_name](check_args)
+
+
+def _dispatch_discover(check_name: str, event: str) -> int:
+    """Resolve pages for `check_name` under `event` and print comma-joined paths.
+
+    Mirrors the bash `.ss/scripts/discover-pages.py` exit codes:
+      0 — at least one path resolved (printed to stdout)
+      1 — internal error (logged to stderr)
+      2 — no path resolved (nothing printed)
+    """
+    normalised = check_name.replace("-", "_")
+    try:
+        paths = discovery.discover(normalised, event)
+    except Exception as e:  # noqa: BLE001
+        print(f"❌ internal discovery error: {e}", file=sys.stderr)
+        return 1
+    if not paths:
+        return 2
+    print(",".join(paths))
+    return 0
 
 
 def _dispatch_emit(check_name: str, target: str) -> int:

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -68,3 +68,70 @@ def test_emit_requires_target_flag(capsys):
     assert exc.value.code != 0
     err = capsys.readouterr().err
     assert "required" in err or "--target" in err
+
+
+# ── discover subcommand ───────────────────────────────────────────
+
+
+def test_discover_prints_comma_joined_paths(monkeypatch, capsys):
+    captured = {}
+
+    def fake_discover(check, event):
+        captured["check"] = check
+        captured["event"] = event
+        return ["/", "/blog", "/about"]
+
+    monkeypatch.setattr(cli.discovery, "discover", fake_discover)
+    rc = cli.main(["discover", "smoke", "--event", "pr"])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "/,/blog,/about"
+    assert captured == {"check": "smoke", "event": "pr"}
+
+
+def test_discover_returns_2_when_no_paths(monkeypatch, capsys):
+    monkeypatch.setattr(cli.discovery, "discover", lambda check, event: [])
+    rc = cli.main(["discover", "broken_links", "--event", "main"])
+    assert rc == 2
+    assert capsys.readouterr().out == ""
+
+
+def test_discover_accepts_hyphen_alias_for_broken_links(monkeypatch):
+    """`broken-links` (hyphen, slopstopper-style) maps to the same
+    underscore-form `broken_links` the discovery module expects."""
+    captured = {}
+
+    def fake_discover(check, event):
+        captured["check"] = check
+        return ["/"]
+
+    monkeypatch.setattr(cli.discovery, "discover", fake_discover)
+    rc = cli.main(["discover", "broken-links", "--event", "local"])
+    assert rc == 0
+    assert captured["check"] == "broken_links"
+
+
+def test_discover_returns_1_on_internal_error(monkeypatch, capsys):
+    def boom(check, event):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(cli.discovery, "discover", boom)
+    rc = cli.main(["discover", "seo", "--event", "cron"])
+    assert rc == 1
+    assert "kaboom" in capsys.readouterr().err
+
+
+def test_discover_rejects_unknown_check(capsys):
+    with pytest.raises(SystemExit):
+        cli.main(["discover", "nope", "--event", "local"])
+
+
+def test_discover_default_event_is_local(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        cli.discovery,
+        "discover",
+        lambda check, event: captured.update({"event": event}) or ["/"],
+    )
+    rc = cli.main(["discover", "smoke"])
+    assert rc == 0
+    assert captured["event"] == "local"


### PR DESCRIPTION
## Summary

Wires the existing \`slopstopper.discovery.discover()\` library function up as a CLI subcommand:

\`\`\`
slopstopper discover <check> [--event=pr|main|cron|local]
\`\`\`

Drop-in replacement for \`.ss/scripts/discover-pages.py\` — same exit codes (0 = path printed, 2 = no paths resolved, 1 = internal error), same args, same stdout format (comma-joined paths). Strict superset because it also accepts \`broken-links\` (hyphen) as an alias for \`broken_links\`.

Updates 3 reliability workflows (broken-links, accessibility, seo) to use the new subcommand. The bash script stays for now — it's still gated by parity + templates-sync, and will be deleted in the same cleanup PR that drops the rest of \`.ss/scripts/\` after the DAST flip.

## Why not also smoke / cwv?

- smoke reads \`pages.smoke\` from \`.slopstopper.yml\` via \`config.get()\` directly inside the check — no discovery step in the workflow.
- cwv audits a single URL, no per-check page list.

## Test plan

- [x] \`task -t cli/Taskfile.yml test\` — 386 pass (6 new)
- [x] Smoke-tested locally:
  - \`slopstopper discover broken_links --event=local\` ✅
  - \`slopstopper discover broken-links --event=local\` ✅ (hyphen alias)
  - \`slopstopper discover smoke\` ✅ (default event)
- [ ] CI green: 3 dogfooded reliability workflows run \`slopstopper discover\` successfully + parity + pytest + templates-sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)