### PR TITLE
docs(skills): rewrite trio for slopstopper-cli shape (Phase 2)

### DIFF
--- a/.claude/skills/slopstopper-install/SKILL.md
+++ b/.claude/skills/slopstopper-install/SKILL.md
@@ -5,13 +5,17 @@ description: Install slopstopper into a repo for the first time. Use when a user
 
 # Install slopstopper
 
-You're being asked to install slopstopper into an existing repo. Slopstopper is a portable suite of GitHub Actions, Task targets, and analysis scripts that drops a consistent quality pipeline into any repository. This skill walks you through doing that responsibly — and, critically, getting every check green **locally** before pushing, so the first CI run is a confirmation pass rather than a discovery pass.
+You're being asked to install slopstopper into an existing repo. Slopstopper is a portable suite of GitHub Actions plus a `slopstopper-cli` Python package that owns every check's logic. The install drops a consistent quality pipeline into any repository. This skill walks you through doing that responsibly — and, critically, getting every check green **locally** before pushing, so the first CI run is a confirmation pass rather than a discovery pass.
 
-The install ships ~21 GitHub Actions workflows in one shot, merges devDeps into `package.json`, and creates a `Taskfile.yml` if the target doesn't have one. That's a lot of moving parts. Don't run it blind — work through the pre-flight first, then drive every check to green locally before opening a PR.
+The install ships ~21 GitHub Actions workflows in one shot, pip-installs `slopstopper-cli` (via pipx), merges devDeps into `package.json`, and creates a `Taskfile.yml` if the target doesn't have one. That's a lot of moving parts. Don't run it blind — work through the pre-flight first, then drive every check to green locally before opening a PR.
+
+**The CLI is the single source of truth for every check.** Every workflow boils down to two CLI commands: `slopstopper run <category>:<check>` (executes the check, writes reports under `.ss/reports/`) and `slopstopper emit <category>:<check> --target {pr-comment,issue}` (posts the report to GitHub). Reliability checks also use `slopstopper discover <check> --event=<event>` (resolves which pages to audit) and the installer itself uses `slopstopper config get <key>` to read `.slopstopper.yml`. No bash scripts under `.ss/scripts/` any more — pure Python, one package, one upgrade path.
 
 ## Step 1 — Pre-flight: read the target repo before installing
 
 Before running anything, learn enough about the target to predict where it'll bite you:
+
+0. **Is `python3` available?** Hard prereq — `install.sh` errors out without it because the first thing it does is pip-install `slopstopper-cli` (pipx-preferred, `pip install --user` fallback). The CLI runs every check, so no Python = no slopstopper. If `pipx` is also installed the CLI lands in its own venv (cleanest); without `pipx` it goes into `~/.local/bin` via `pip --user`. Make sure that directory is on `$PATH` (it should be on modern macOS/Linux setups, but isn't always on minimal CI containers).
 
 1. **Does the target have an existing `Taskfile.yml`?** If yes, the installer prints include instructions instead of overwriting — you (or the user) need to manually add:
    ```yaml
@@ -31,7 +35,7 @@ Before running anything, learn enough about the target to predict where it'll bi
 
 6. **Does the target follow the Map Pattern for docs?** Three workflows — `ss-hygiene-docs-accuracy-check.yml`, `ss-hygiene-docs-structure-check.yml`, `ss-hygiene-docs-size-check.yml` — require a `docs/` directory with an `index.md` listing categories (each as a subdirectory with its own `README.md`). Two valid choices: set up the Map Pattern (see Step 5) or delete these three workflows. A half-built `docs/` directory will fail the structure check until the tree matches the index.
 
-7. **Does the target serve a site-wide `/og-image.png` with `Cross-Origin-Resource-Policy: cross-origin`?** The slopstopper Playwright smoke test (`.ss/tests/smoke.spec.ts`) asserts that `/og-image.png` returns 200, has `Content-Type: image/png`, and the CORP header set to `cross-origin` (so social platforms can embed it). Targets that use per-post share images instead won't have it. Either add a 1200×630 `og-image.png` at the site root with CORP configured for that path (Astro/Cloudflare adapter respects `public/_headers`), or restrict the Playwright suite to skip the smoke spec for that target.
+7. **Does the target serve a site-wide `/og-image.png` with `Cross-Origin-Resource-Policy: cross-origin`?** The slopstopper Playwright smoke test (`.ss/tests/smoke.spec.ts`, or the bundled `cli/slopstopper/data/tests/smoke.spec.ts` when no `.ss/` override is present) asserts that `/og-image.png` returns 200, has `Content-Type: image/png`, and the CORP header set to `cross-origin` (so social platforms can embed it). Targets that use per-post share images instead won't have it. Either add a 1200×630 `og-image.png` at the site root with CORP configured for that path (Astro/Cloudflare adapter respects `public/_headers`), or set `smoke.og_image_path: ''` in `.slopstopper.yml` to skip the assertion.
 
 8. **Existing `package.json` devDeps that might collide?** Slopstopper merges in `@axe-core/playwright`, `@lhci/cli`, `@playwright/test`, `markdownlint-cli`, `typescript`. Spot collisions ahead of time.
 
@@ -53,7 +57,7 @@ From the target repo root, run the canonical one-liner:
 curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install.sh | bash
 ```
 
-The installer is idempotent. Re-running it pulls newer checks but respects deletions (tracked via `.ss/.workflows-installed`). All slopstopper files live under the `ss` namespace — your repo's existing files are not touched.
+The installer is idempotent. Re-running it pulls newer checks but respects deletions (tracked via `.ss/.workflows-installed`), and refreshes `slopstopper-cli` via `pipx upgrade` (or re-runs `pip install --user --upgrade` when pipx isn't available). All slopstopper files live under the `ss` namespace — your repo's existing files are not touched. If a pre-CLI install left a `.ss/scripts/` directory behind, the installer scrubs it on first run.
 
 If the user prefers to review the script first:
 ```bash
@@ -65,14 +69,17 @@ bash install.sh [TARGET_DIR]
 
 Sanity-check the install dropped what you expect:
 
-- `Taskfile.ss.yml` — all slopstopper task definitions
-- `Taskfile.yml` — created if missing (otherwise: needs manual `includes:` block per Step 1.1)
-- `.ss/scripts/` — Python+shell analyzers
-- `.ss/tests/` — Playwright specs (smoke, accessibility, broken-links)
-- `.ss/playwright.config.js`, `.ss/lighthouserc.json`, `.ss/lighthouserc.prod.json`
-- `.ss/.workflows-installed` — manifest of installed workflows (tracks deletions on reinstall; commit this)
-- `.github/workflows/ss-*.yml` — the curated installer set (~21 files)
-- `package.json` — devDeps merged
+- `slopstopper-cli` — installed system-wide via `pipx` (preferred) or `pip install --user`. Confirm with `slopstopper --version`. Every check runs through this.
+- `Taskfile.ss.yml` — thin `task ss:*` shims that each call `slopstopper run <category>:<check>` under the covers. Useful for adopters who already drive their dev loop with `task`.
+- `Taskfile.yml` — created if missing (otherwise: needs manual `includes:` block per Step 1.1).
+- `.ss/tests/` — Playwright specs (smoke, accessibility, broken-links). The CLI prefers these over its own bundled copies under `cli/slopstopper/data/tests/`, so adopters can customize without forking the package.
+- `.ss/playwright.config.js`, `.ss/lighthouserc.json`, `.ss/lighthouserc.prod.json` — same override pattern: `.ss/` wins, CLI package data is the fallback.
+- `.ss/server.js` — tiny static-server shim for serving the built site on `:8080` during the local loop.
+- `.ss/.workflows-installed` — manifest of installed workflows (tracks deletions on reinstall; commit this).
+- `.github/workflows/ss-*.yml` — the curated installer set (~21 files). Each workflow body is now ~8 lines: install CLI, `slopstopper run …`, `slopstopper emit … --target pr-comment|issue`.
+- `package.json` — devDeps merged.
+
+**What's NOT there any more** (if you're updating from a pre-CLI install): `.ss/scripts/`. Every Python/bash script that used to live there is now in `slopstopper-cli`. The installer scrubs the directory on re-run, so don't be alarmed if the old contents are gone.
 
 **Confirm the installed set matches upstream.** `install.sh` uses a hardcoded `GENERIC_WORKFLOWS` array, not a wildcard over slopstopper's `.github/workflows/ss-*.yml`. The two can drift — slopstopper may ship a workflow that the installer hasn't been updated to include. To catch this:
 
@@ -240,7 +247,9 @@ The "powered by slopstopper" badge uses a static shields.io URL (`https://img.sh
 
 ## Step 7 — Drive every check to green locally, **before** pushing
 
-This is the spine of a good install. Every slopstopper check has a local `task ss:*` equivalent. Running them locally in a tight loop — fix, re-run, fix, re-run — is an order of magnitude faster than pushing and waiting on CI for each iteration. The goal of this step is that the first CI run on the target's PR is a **confirmation pass**, not a discovery pass.
+This is the spine of a good install. Every slopstopper check has a local equivalent — either `task ss:<category>:<action>` (thin shim) or `slopstopper run <category>:<action>` directly. Running them locally in a tight loop — fix, re-run, fix, re-run — is an order of magnitude faster than pushing and waiting on CI for each iteration. The goal of this step is that the first CI run on the target's PR is a **confirmation pass**, not a discovery pass.
+
+**Both surfaces work; pick one consistently.** The `task ss:*` shims read `.slopstopper.yml`, set the env vars the CLI expects, and invoke `slopstopper run …`. If you don't already use `task` in the target repo, calling `slopstopper run hygiene:docs-size` directly is equally valid (and skips the Taskfile load).
 
 **Two passes, in order:**
 
@@ -250,36 +259,44 @@ Run the two static aggregates first. They cover every static workflow that ships
 
 ```bash
 npm install                  # pulls merged devDeps once
-task ss:hygiene:test         # complexity + docs-* + entry-files + lint + structure + size
-task ss:security:scan        # SAST + secrets + dependency CVEs + DAST (will need URL — skip via SKIP_DAST or run after Pass B)
+task ss:hygiene:test         # lint + structure + size + docs-size + docs-structure + docs-accuracy + entry-files + complexity
+task ss:security:scan        # SAST + secrets + dependency CVEs + DAST (DAST needs URL — skip or run after Pass B)
 ```
 
-If `task ss:security:scan` complains about a missing DAST URL, run security checks individually instead:
+Or call each check via the CLI directly:
 
 ```bash
-task ss:security:secrets         # Gitleaks — fast, usually surfaces something
-task ss:security:sast            # Semgrep
-task ss:security:vulnerability:all  # Trivy (CVE scan of dependencies)
+slopstopper run security:secrets           # Gitleaks — fast, usually surfaces something
+slopstopper run security:sast              # Semgrep
+slopstopper run security:dependencies      # Trivy (CVE scan of dependencies)
+slopstopper run hygiene:complexity         # lizard
+slopstopper run hygiene:docs-accuracy      # repo-relative link resolver
+slopstopper run hygiene:docs-structure     # Map Pattern validator
+slopstopper run hygiene:docs-size          # docs/ size budget
+slopstopper run hygiene:entry-files        # README/AGENTS/CLAUDE word budget
+slopstopper run hygiene:csp-exceptions     # if headers.source is configured
 ```
 
-For each failure: fix the root cause locally, re-run **just that one task** to confirm, and only move on once green. Anticipated issues during Pass A are listed in the table below.
+For each failure: fix the root cause locally, re-run **just that one check** to confirm, and only move on once green. Anticipated issues during Pass A are covered in `slopstopper-triage`.
 
 ### Pass B — Dynamic checks (need a URL + a built site)
 
-The reliability and DAST workflows assert behaviour on a running site. The fastest local loop is to build once, serve via a tiny `server.js` shim on `localhost:8080`, then run each dynamic task against `http://localhost:8080`.
+The reliability and DAST workflows assert behaviour on a running site. The fastest local loop is to build once, serve via the installed `.ss/server.js` shim on `localhost:8080`, then run each dynamic check against `http://localhost:8080`.
 
 ```bash
 npm run build                                # target's own build
-node server.js &                             # static server on :8080 (see "Anticipated issues" below if missing)
-SMOKE_TEST_URL=http://localhost:8080 task ss:reliability:smoke
-ACCESSIBILITY_TEST_URL=http://localhost:8080 task ss:reliability:accessibility
-CWV_URL=http://localhost:8080 task ss:reliability:cwv
-SEO_TEST_URL=http://localhost:8080 task ss:reliability:seo
-BROKEN_LINKS_TEST_URL=http://localhost:8080 task ss:reliability:links
-DAST_TEST_URL=http://localhost:8080 task ss:security:dast    # needs Docker for OWASP ZAP
+node .ss/server.js &                         # static server on :8080
+SMOKE_TEST_URL=http://localhost:8080 slopstopper run reliability:smoke
+ACCESSIBILITY_TEST_URL=http://localhost:8080 slopstopper run reliability:accessibility
+CWV_URL=http://localhost:8080 slopstopper run reliability:cwv
+SEO_TEST_URL=http://localhost:8080 slopstopper run reliability:seo
+BROKEN_LINKS_TEST_URL=http://localhost:8080 slopstopper run reliability:broken-links
+DAST_TEST_URL=http://localhost:8080 slopstopper run security:dast    # needs Docker for OWASP ZAP
 ```
 
-`task ss:security:dast` is the heaviest local check (pulls and runs the OWASP ZAP container) — leave it for last in the loop. Skip it locally if Docker isn't installed and run it on CI only.
+The Taskfile equivalents work the same way: `task ss:reliability:smoke -- http://localhost:8080`, `task ss:security:dast -- http://localhost:8080`, etc.
+
+`slopstopper run security:dast` is the heaviest local check (pulls and runs the OWASP ZAP container) — leave it for last in the loop. Skip it locally if Docker isn't installed and run it on CI only.
 
 Iterate the same way as Pass A: fix root cause locally, re-run the single task, move on once green.
 
@@ -325,10 +342,12 @@ This skill names specific files, env vars, workflow IDs, the `GENERIC_WORKFLOWS`
 
 Triggers that require revisiting this skill:
 
-- A workflow is added, removed, or renamed under `slopstopper/.github/workflows/ss-*.yml` → update the workflow count in the intro, Step 1.2, and Step 3; add/remove the matching local-task row in Step 7's Pass A or Pass B; add/remove the badge example in Step 6. (The per-check failure entry lives in `slopstopper-triage` — update there too.)
+- A workflow is added, removed, or renamed under `slopstopper/.github/workflows/ss-*.yml` → update the workflow count in the intro, Step 1.2, and Step 3; add/remove the matching local-CLI row in Step 7's Pass A or Pass B; add/remove the badge example in Step 6. (The per-check failure entry lives in `slopstopper-triage` — update there too.)
 - The `GENERIC_WORKFLOWS` array in `slopstopper/install.sh` changes → confirm the "What just landed" inventory in Step 3 still matches.
-- A `task ss:*` target is renamed in `slopstopper/Taskfile.ss.yml` → update the matching command in Step 7's Pass A or Pass B (and the equivalent in `slopstopper-update` Step 7 + `slopstopper-triage`'s reproduce table).
+- A check is added or renamed in `cli/slopstopper/checks/__init__.py`'s `REGISTRY` → update Step 7's `slopstopper run` list (and the equivalent in `slopstopper-update` Step 7 + `slopstopper-triage`'s reproduce table).
+- A `task ss:*` shim is renamed in `slopstopper/Taskfile.ss.yml` → update the matching command in Step 7's Pass A or Pass B (and the equivalents in `slopstopper-update` + `slopstopper-triage`).
 - A new env var is introduced for a dynamic check → add to the URL-defaults list in Step 4 and to the Pass B example in Step 7 (and the equivalents in `slopstopper-update`).
+- A new `slopstopper` subcommand is added (e.g. `init`, `inspect`) → mention in the intro and surface in the relevant Step.
 
 The companion to this is `AGENTS.md` in the slopstopper repo: its "When making changes" table flags the skill as a follow-on target whenever a change of the above kind ships. If you're updating slopstopper itself and that table isn't pointing readers back here, fix that first.
 

--- a/.claude/skills/slopstopper-triage/SKILL.md
+++ b/.claude/skills/slopstopper-triage/SKILL.md
@@ -7,11 +7,13 @@ description: Diagnose and fix a failing slopstopper check. Use when a user repor
 
 You're being asked to fix a slopstopper check that's failing. This skill is reactive — it assumes the install is in place and at least one check is red. If the user is mid-install, the install playbook (`slopstopper-install` Step 7) already handed off here; if they're refreshing an existing install, `slopstopper-update` handed off here. Either way, the procedure is the same.
 
+Every check now runs through `slopstopper-cli`. The workflow body for each `ss-*.yml` is ~8 lines: install the CLI, `slopstopper run <category>:<check>`, `slopstopper emit <category>:<check> --target {pr-comment,issue}`. So the local reproducer is always `slopstopper run …` (or its `task ss:*` shim).
+
 The shape of the fix depends on which of three things you're looking at:
 
 1. **A real finding** — the check is right, the code is wrong. Fix the code.
 2. **A false positive** — the check's heuristic is misfiring on this codebase. Suppress narrowly via the check's documented mechanism, always with a `# why` comment.
-3. **A threshold too tight for this repo** — the check itself is correct, but its config doesn't fit this codebase's reality. Tune in the relevant `docs/<loop>/<CONFIG>.md`.
+3. **A threshold too tight for this repo** — the check itself is correct, but its config doesn't fit this codebase's reality. Tune in `.slopstopper.yml` (most knobs live there) or the relevant `docs/<loop>/<CONFIG>.md` for the few that aren't config-driven yet.
 
 Don't apply blanket suppressions and don't loosen thresholds without writing down why.
 
@@ -20,36 +22,38 @@ Don't apply blanket suppressions and don't loosen thresholds without writing dow
 Slopstopper workflows follow the naming pattern `ss-<loop>-<action>-check.yml`. Decode:
 
 - **`<loop>`** = `security`, `hygiene`, `reliability` → maps to `docs/<loop>/README.md` for the loop-level overview.
-- **`<action>`** = `sast`, `secrets`, `complexity`, `docs-accuracy`, etc. → maps to a specific `task ss:<loop>:<action>` target.
+- **`<action>`** = `sast`, `secrets`, `complexity`, `docs-accuracy`, etc. → maps to a specific check name `<loop>:<action>` in the CLI's `REGISTRY` (`cli/slopstopper/checks/__init__.py`).
 
-If the user only gave you the workflow URL or a failing CI badge, click through to the workflow file under `.github/workflows/` in the target repo and read the `run:` step — it usually calls a single `task ss:*` command.
+If the user only gave you the workflow URL or a failing CI badge, click through to the workflow file under `.github/workflows/` in the target repo and read the `run:` step — every slopstopper workflow now calls `slopstopper run <category>:<check>` directly (with `slopstopper emit … --target pr-comment|issue` afterwards). The check name in that command is the same one you use locally.
 
 ## Step 2 — Reproduce locally
 
-Every slopstopper workflow has a local `task ss:*` equivalent. Run that, not the workflow. The local loop is an order of magnitude faster than pushing to CI per iteration.
+Every slopstopper workflow's logic lives inside `slopstopper-cli`. Run `slopstopper run <category>:<check>` locally (or its `task ss:*` shim) — same code, same exit codes, same reports. The local loop is an order of magnitude faster than pushing to CI per iteration.
 
-| Workflow | Local task | Needs URL? | Needs build? | Needs Docker? |
-|---|---|---|---|---|
-| `ss-security-sast-check.yml` | `task ss:security:sast` | – | – | – |
-| `ss-security-secrets-check.yml` | `task ss:security:secrets` | – | – | – |
-| `ss-security-vulnerability-all-check.yml` | `task ss:security:vulnerability:all` | – | – | – |
-| `ss-security-vulnerability-new-check.yml` | (CI-only — Dependency Review) | – | – | – |
-| `ss-security-dast-check.yml` | `task ss:security:dast` | ✓ | ✓ (if local) | ✓ |
-| `ss-hygiene-complexity-check.yml` | `task ss:hygiene:complexity` | – | – | – |
-| `ss-hygiene-csp-exceptions-check.yml` | `task ss:hygiene:csp-exceptions` | – | – | – |
-| `ss-hygiene-docs-accuracy-check.yml` | `task ss:hygiene:docs-accuracy` | – | – | – |
-| `ss-hygiene-docs-size-check.yml` | `task ss:hygiene:docs-size` | – | – | – |
-| `ss-hygiene-docs-structure-check.yml` | `task ss:hygiene:docs-structure` | – | – | – |
-| `ss-hygiene-entry-files-check.yml` | `task ss:hygiene:entry-files` | – | – | – |
-| `ss-hygiene-auto-label-pr.yml` | (CI-only — needs PR context) | – | – | – |
-| `ss-reliability-smoke-tests.yml` | `task ss:reliability:smoke -- <URL>` | ✓ | ✓ (if URL is local) | – |
-| `ss-reliability-accessibility-check.yml` | `task ss:reliability:accessibility -- <URL>` | ✓ | ✓ | – |
-| `ss-reliability-core-web-vitals.yml` | `task ss:reliability:cwv -- <URL>` | ✓ | ✓ | – |
-| `ss-reliability-seo-check.yml` | `task ss:reliability:seo -- <URL>` | ✓ | ✓ | – |
-| `ss-reliability-broken-links-check.yml` | `task ss:reliability:links -- <URL>` | ✓ | ✓ | – |
-| `ss-workflow-failure-issue.yml` | (CI-only — operational, runs on workflow_run) | – | – | – |
+| Workflow | Local command (CLI) | Taskfile shim | Needs URL? | Needs build? | Needs Docker? |
+|---|---|---|---|---|---|
+| `ss-security-sast-check.yml` | `slopstopper run security:sast` | `task ss:security:sast` | – | – | – |
+| `ss-security-secrets-check.yml` | `slopstopper run security:secrets` | `task ss:security:secrets` | – | – | – |
+| `ss-security-vulnerability-all-check.yml` | `slopstopper run security:dependencies` | `task ss:security:vulnerability:all` | – | – | – |
+| `ss-security-vulnerability-new-check.yml` | (CI-only — Dependency Review action) | – | – | – | – |
+| `ss-security-dast-check.yml` | `slopstopper run security:dast -- --target <URL>` | `task ss:security:dast -- <URL>` | ✓ | ✓ (if local) | ✓ |
+| `ss-hygiene-complexity-check.yml` | `slopstopper run hygiene:complexity` | `task ss:hygiene:complexity` | – | – | – |
+| `ss-hygiene-csp-exceptions-check.yml` | `slopstopper run hygiene:csp-exceptions` | `task ss:hygiene:csp-exceptions` | – | – | – |
+| `ss-hygiene-docs-accuracy-check.yml` | `slopstopper run hygiene:docs-accuracy` | `task ss:hygiene:docs-accuracy` | – | – | – |
+| `ss-hygiene-docs-size-check.yml` | `slopstopper run hygiene:docs-size` | `task ss:hygiene:docs-size` | – | – | – |
+| `ss-hygiene-docs-structure-check.yml` | `slopstopper run hygiene:docs-structure` | `task ss:hygiene:docs-structure` | – | – | – |
+| `ss-hygiene-entry-files-check.yml` | `slopstopper run hygiene:entry-files` | `task ss:hygiene:entry-files` | – | – | – |
+| `ss-hygiene-auto-label-pr.yml` | (CI-only — needs PR context) | – | – | – | – |
+| `ss-reliability-smoke-tests.yml` | `SMOKE_TEST_URL=<URL> slopstopper run reliability:smoke` | `task ss:reliability:smoke -- <URL>` | ✓ | ✓ (if URL is local) | – |
+| `ss-reliability-accessibility-check.yml` | `ACCESSIBILITY_TEST_URL=<URL> slopstopper run reliability:accessibility` | `task ss:reliability:accessibility -- <URL>` | ✓ | ✓ | – |
+| `ss-reliability-core-web-vitals.yml` | `CWV_URL=<URL> slopstopper run reliability:cwv` | `task ss:reliability:cwv -- <URL>` | ✓ | ✓ | – |
+| `ss-reliability-seo-check.yml` | `SEO_TEST_URL=<URL> slopstopper run reliability:seo` | `task ss:reliability:seo -- <URL>` | ✓ | ✓ | – |
+| `ss-reliability-broken-links-check.yml` | `BROKEN_LINKS_TEST_URL=<URL> slopstopper run reliability:broken-links` | `task ss:reliability:links -- <URL>` | ✓ | ✓ | – |
+| `ss-workflow-failure-issue.yml` | (CI-only — operational, runs on workflow_run) | – | – | – | – |
 
-For dynamic checks (`URL ✓`): pass the URL via the `--` arg, or set the matching env var (`SMOKE_TEST_URL`, `DAST_TEST_URL`, etc.). Pointing at `http://localhost:8080` with a `server.js` shim serving the built site is the fastest local loop.
+For dynamic checks (`URL ✓`): set the matching env var, or pass the URL via the `--` arg on the Taskfile shim. Pointing at `http://localhost:8080` with `node .ss/server.js` serving the built site is the fastest local loop.
+
+If a reliability workflow's failure is about *which pages it audited* rather than what it found, the page-list comes from `slopstopper discover <check> --event=<event>` — run that directly to see the resolved set before reproducing the check itself.
 
 ## Step 3 — Read the report
 
@@ -91,7 +95,7 @@ The check's heuristic is misfiring on this codebase. Use the check's documented 
 | DAST — other rule false positives | `.zap/rules.tsv` → `<plugin-id>\tIGNORE\t# why` | Per-rule, site-wide |
 | Accessibility (axe-core) | `disabledRules` in the spec, or scope the spec to exclude the offending selector | Per-rule or per-element |
 | Vulnerability (Trivy) | `.trivyignore` with the CVE ID + a `# why` line | Per-CVE |
-| Complexity (lizard) | `# nolint` on the function, or raise the threshold in `docs/hygiene/COMPLEXITY_CONFIG.md` | Per-function or repo-wide |
+| Complexity (lizard) | `# nolint` on the function, or raise the threshold in `docs/hygiene/README.md` complexity config block | Per-function or repo-wide |
 
 Each suppression is a documented gate exception, not a way to quiet findings that should be fixed. The PR that adds it is the place reviewers catch it.
 
@@ -111,8 +115,8 @@ Config-driven knobs (no file edit needed beyond `.slopstopper.yml`):
 
 Tunings that are NOT yet config-driven (require code/file edits):
 
-- `docs/hygiene/COMPLEXITY_CONFIG.md` — lizard cyclomatic complexity caps.
-- `.ss/lighthouserc.json` (or the bundled `cli/slopstopper/data/lighthouserc.json`) — Core Web Vitals thresholds.
+- `docs/hygiene/README.md` complexity config — lizard cyclomatic complexity caps.
+- `.ss/lighthouserc.json` (or the bundled `cli/slopstopper/data/lighthouserc.json`) — Core Web Vitals thresholds. Edit the `.ss/` copy if you want adopter-side persistence; the CLI prefers it over the package-data fallback.
 
 Tuning is a real decision — when you raise a threshold, leave a `# why` comment in `.slopstopper.yml` so the next maintainer doesn't roll it back. Don't tune to silence noise; tune to match a deliberate design decision.
 
@@ -128,18 +132,20 @@ Common failures, with diagnostic step and the file the fix lives in. Categories 
 | `task ss:hygiene:docs-accuracy` flags backtick-quoted filenames that don't resolve | Grep the docs for the bare filename — does the file exist anywhere under the repo? | Old docs reference renamed/moved files, or use bare filenames the resolver can't find | Fix the link in the doc; use repo-relative paths (`scripts/foo.sh`, not bare `foo.sh`) | code (docs) |
 | `task ss:hygiene:docs-structure` fails with `❌ docs/ directory not found` or category mismatch | `ls docs/` against the table in `docs/index.md` | Target doesn't follow the Map Pattern, or has an undocumented dir | Set up the Map Pattern (`slopstopper-install` Step 5 has the template) OR delete the three docs-* workflows | code (docs) OR delete check |
 | `task ss:hygiene:csp-exceptions` reports "no headers.source configured" with exit 0 | `cat .slopstopper.yml \| grep -A2 headers:` | `.slopstopper.yml` `headers.source` is null (the seeded default) | If you want the check active, set `headers.source` to your headers file (e.g. `public/_headers`) and `headers.format` to match (`cloudflare-text` for `_headers` files, `json` for JSON arrays, `auto` to infer). Otherwise this is harmless. | config |
-| `task ss:hygiene:csp-exceptions` reports "Unknown headers.format" | Run `python3 -c "from slopstopper import headers_adapters; print(list(headers_adapters.ADAPTERS.keys()))"` | `.slopstopper.yml` `headers.format` doesn't match a shipped adapter | Set `headers.format` to one of the listed adapter names or `auto`. If you need a format slopstopper doesn't ship, add a module under `cli/slopstopper/headers_adapters/` and register it in `__init__.py`'s `ADAPTERS`. | config (or new adapter) |
+| `slopstopper run hygiene:csp-exceptions` reports "Unknown headers.format" | Run `python3 -c "from slopstopper import headers_adapters; print(list(headers_adapters.ADAPTERS.keys()))"` | `.slopstopper.yml` `headers.format` doesn't match a shipped adapter | Set `headers.format` to one of the listed adapter names or `auto`. If you need a format slopstopper doesn't ship, add a module under `cli/slopstopper/headers_adapters/` and register it in `__init__.py`'s `ADAPTERS`. | config (or new adapter) |
 | `task ss:hygiene:entry-files` fails with one of README/AGENTS/CLAUDE over 1500 words | Run the task — the report names the file + word count | Entry file has bloated with content that belongs under `docs/<category>/` | Move the bulk into the appropriate category README; the entry file should be a pointer | code (docs) |
 | `task ss:reliability:smoke` fails: `expected /og-image.png to return 200` or wrong CORP header | `cat .slopstopper.yml \| grep -A2 smoke:` then `curl -I http://localhost:8080$(yq '.smoke.og_image_path' .slopstopper.yml)` | Site doesn't have a site-wide og-image at the configured path, OR local server isn't applying prod headers | Either (a) add the og-image at the configured path with `Cross-Origin-Resource-Policy: cross-origin`, OR (b) set `smoke.og_image_path: ''` in `.slopstopper.yml` to skip the assertion (use this if you ship per-post share images instead) | config OR code |
-| Reliability or DAST tasks fail at "Start local server" / connection refused | `ls server.js` | No `server.js` at repo root serving the build on port 8080 | (a) add a `server.js` shim that serves the built output and applies the platform's header file per request, OR (b) point each workflow at a deployed URL via the `*_TEST_URL` env vars | code |
+| Reliability or DAST tasks fail at "Start local server" / connection refused | `ls .ss/server.js` | No server on `localhost:8080` | (a) start the installed shim: `node .ss/server.js &` (it serves the built output and applies `public/_headers` per request), OR (b) point each workflow at a deployed URL via the `*_TEST_URL` env vars | code |
+| `slopstopper run reliability:<check>` audits only `/` when you expected the full sitemap, or audits `/` on a PR you expected to skip | Run `slopstopper discover <check> --event=<event>` (events: `local`, `pr`, `main`, `cron`) to see the resolved page list | `reliability.coverage.<event>` is in hand-list mode (default) instead of `sitemap` / `changed` | Opt into `sitemap` on `main`/`cron` or `changed` on `pr` in `.slopstopper.yml` (see `.slopstopper.yml.example`). The check itself is fine — discovery is the lever. | config |
 | `task ss:security:dast` reports `Content Security Policy (CSP) Header Not Set`, `X-Frame-Options Missing`, `Cross-Origin-*-Policy Missing` | Inspect headers: `curl -I http://localhost:8080/` | Site has no security headers configured | Add headers via the platform (Cloudflare: `public/_headers`; Vercel: `vercel.json`; Netlify: `_headers` or `netlify.toml`). Baseline below | code |
 | `task ss:security:dast` reports a CSP finding on a page that genuinely needs the relaxation (Giscus, GTM, etc.) | The page legitimately loads a third-party script/iframe that the strict CSP blocks | Per-path CSP relaxation is real and needs documenting | `docs/security/CSP_EXCEPTIONS.md` under `## Exceptions` with a `### /path` heading (glob patterns supported). The DAST gate swallows CSP findings only on documented paths | suppress |
 | `task ss:security:dast` reports a ZAP rule that's structurally wrong for this target (SRI on rotating GTM script; SQL Disclosure on blog posts with code blocks) | The flagged finding is genuinely wrong for content-heavy sites | ZAP heuristic doesn't fit | `.zap/rules.tsv` with the plugin ID marked `IGNORE` and a `# why` comment | suppress |
 | `task ss:reliability:accessibility` reports `color-contrast`, `link-in-text-block`, or `label-title-only` on DOM that belongs to a third-party widget (cookie banner, chat, search UI, embedded video) | The failing HTML belongs to a runtime-injected widget, not your source | Widget injects its stylesheet at runtime after your CSS — wins on load order. The page owns the violations regardless of authorship | Scope CSS overrides to the widget's root class; use `!important` (runtime-injected styles can't be beaten on specificity alone if loaded last); add `text-decoration: underline` for `link-in-text-block`; add `aria-label` via small post-init script for inputs missing labels | code (CSS / JS) |
 | `ss-security-vulnerability-new-check.yml` fails with `Dependency review is not supported on this repository` | Repo Settings → Code security and analysis → Dependency graph status | `actions/dependency-review-action` needs GHAS on a private repo OR Dependency Graph enabled on a public repo | Toggle the setting (admin action), OR delete the workflow | repo-admin OR delete check |
 | `ss-hygiene-auto-label-pr.yml` fails with `The config file was not found at .github/labeler.yml` | `ls .github/labeler.yml` | A pre-`install.sh`-seeding install OR you deleted the seeded file | Re-run `install.sh` to re-seed (it won't overwrite an existing file), or tune the seeded labeler.yml's globs to match your repo's directory structure | config |
-| `task ss:hygiene:complexity` flags a function with high cyclomatic complexity and the function is genuinely well-factored | Read the function — is it actually complex or just long-tabular? | Default complexity cap is too tight for this codebase's patterns | Raise the threshold in `docs/hygiene/COMPLEXITY_CONFIG.md` with a `## why` note | tune |
-| Lighthouse CWV check fails Performance / LCP / TBT / CLS thresholds | `task ss:reliability:cwv -- <URL>` and read the report's audit-level breakdown | Site has a genuine perf issue OR the threshold doesn't match the target's nature | Real → optimise (image sizing, render-blocking JS, etc.). Threshold mismatch → tune in `.ss/lighthouserc.json` with the change documented in `docs/reliability/CORE_WEB_VITALS.md` | code OR tune |
+| `slopstopper run hygiene:complexity` flags a function with high cyclomatic complexity and the function is genuinely well-factored | Read the function — is it actually complex or just long-tabular? | Default complexity cap is too tight for this codebase's patterns | Raise the threshold in `docs/hygiene/README.md` complexity section with a `## why` note | tune |
+| Lighthouse CWV check fails Performance / LCP / TBT / CLS thresholds | `CWV_URL=<URL> slopstopper run reliability:cwv` and read the report's audit-level breakdown | Site has a genuine perf issue OR the threshold doesn't match the target's nature | Real → optimise (image sizing, render-blocking JS, etc.). Threshold mismatch → tune in `.ss/lighthouserc.json` (adopter override) with the change documented in `docs/reliability/README.md` Core Web Vitals section | code OR tune |
+| A check's behaviour disagrees with what slopstopper-cli ships upstream | `slopstopper --version`; compare against [`cli/pyproject.toml`](https://github.com/hungovercoders/slopstopper/blob/main/cli/pyproject.toml) | CLI version on PATH is stale | `pipx upgrade slopstopper-cli` (or re-run `install.sh` to refresh both CLI and workflows). Confirm new version with `slopstopper --version`. | environment |
 
 ### Baseline security headers (for the missing-headers row above)
 
@@ -160,13 +166,14 @@ Tune `script-src` / `connect-src` to the actual third parties the site loads. `'
 
 ## Step 6 — When the fix is broader than one check
 
-If multiple checks fail with the same root cause, batch-fix once and re-run all affected tasks instead of fixing each in isolation. Common patterns:
+If multiple checks fail with the same root cause, batch-fix once and re-run all affected checks instead of fixing each in isolation. Common patterns:
 
 - **Node version pin bump** → fixes Core Web Vitals + Accessibility + SEO + Playwright + Smoke + DAST in one edit.
 - **Adding `public/_headers` with a security-headers baseline** → fixes DAST's missing-header alerts AND the smoke spec's CORP header check.
 - **Setting up the Map Pattern** (`docs/index.md` + per-category READMEs) → fixes docs-structure + docs-size + docs-accuracy together.
+- **Upgrading `slopstopper-cli`** → if a default tuning was widened upstream, multiple checks go green at once. `pipx upgrade slopstopper-cli` then re-run the aggregates.
 
-The aggregates make this fast: `task ss:hygiene:test` re-runs every hygiene check; `task ss:security:scan` re-runs every security check. Use them after a batch fix to confirm the whole class is closed.
+The aggregates make this fast: `task ss:hygiene:test` re-runs every hygiene check; `task ss:security:scan` re-runs every security check. Both are just sequenced `slopstopper run …` calls under the hood, so adopters who skip the Taskfile can chain the CLI invocations directly.
 
 ## Step 7 — When to delete the check instead of fixing it
 
@@ -189,10 +196,12 @@ Don't delete a check just because it's failing. The bar is *"this check has noth
 
 Update this skill when:
 
-- A new workflow is added under `slopstopper/.github/workflows/ss-*.yml` → add a row to Step 2's workflow→task table and a row to Step 5's gotcha table (with a forward-looking diagnostic step and fix location, not citing the install that surfaced it).
+- A new workflow is added under `slopstopper/.github/workflows/ss-*.yml` → add a row to Step 2's workflow→CLI table and a row to Step 5's gotcha table (with a forward-looking diagnostic step and fix location, not citing the install that surfaced it).
 - A workflow is renamed or removed → update both tables.
-- A `task ss:*` target is renamed in `slopstopper/Taskfile.ss.yml` → update Step 2's table.
+- A check is added or renamed in `cli/slopstopper/checks/__init__.py`'s `REGISTRY` → update Step 2's table (CLI column AND Taskfile-shim column, since the shim mirrors the CLI name).
+- A `task ss:*` shim is renamed in `slopstopper/Taskfile.ss.yml` → update Step 2's Taskfile-shim column.
+- A new `slopstopper` subcommand ships (e.g. `init`, `inspect`) → mention in the intro and the relevant Step.
 - A new suppression mechanism becomes available for an existing check (e.g. a new `.zap/rules.tsv`-shaped file for a different tool) → add a row to Step 4's suppression table.
-- A new tuning config file is added under `docs/<loop>/` → add to Step 4's tuning list.
+- A new config-driven knob is added to a check (`config.get("<x>")` in the check module) → add to Step 4's "Config-driven knobs" table, with the default mirroring `.slopstopper.yml.example`.
 
 The AGENTS.md "When making changes" table in the slopstopper repo flags this skill alongside `slopstopper-install` and `slopstopper-update` whenever a change of the above kind ships.

--- a/.claude/skills/slopstopper-update/SKILL.md
+++ b/.claude/skills/slopstopper-update/SKILL.md
@@ -5,7 +5,9 @@ description: Update an existing slopstopper installation in place. Use when a us
 
 # Update slopstopper
 
-You're being asked to refresh an existing slopstopper installation in a repo that already has it. The install is idempotent, so the mechanical part is "re-run the installer" — but a few classes of customization get wiped on every re-run, and a few classes of upstream change need manual catch-up because the installer doesn't drag everything across. This skill walks the steady-state upgrade flow so nothing important gets missed.
+You're being asked to refresh an existing slopstopper installation in a repo that already has it. The install is idempotent, so the mechanical part is "re-run the installer" — which also re-pulls `slopstopper-cli` from upstream (via `pipx upgrade` or `pip install --user --upgrade`). A few classes of customization get wiped on every re-run, and a few classes of upstream change need manual catch-up because the installer doesn't drag everything across. This skill walks the steady-state upgrade flow so nothing important gets missed.
+
+**The CLI is the upgrade path for every check's logic.** Each check used to be a Python/bash script under `.ss/scripts/`; now it's a module inside `slopstopper-cli`, and `install.sh` ships the CLI itself. That means a re-run picks up new behaviour in checks without touching adopter files — and a pre-CLI install gets its old `.ss/scripts/` scrubbed clean automatically.
 
 If the target doesn't have slopstopper installed yet, this is the wrong skill — use `slopstopper-install` instead. If you're triaging a check that's failing right now, use `slopstopper-triage`.
 
@@ -28,17 +30,21 @@ curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/ins
 ```
 
 What this refreshes (always, on every run):
-- `Taskfile.ss.yml`
-- `.ss/scripts/`
-- `.ss/tests/`
-- `.ss/playwright.config.js`, `.ss/lighthouserc.json`, `.ss/lighthouserc.prod.json`
-- Each workflow in `install.sh`'s `GENERIC_WORKFLOWS` array — provided it's still present in the target's `.github/workflows/`
+- `slopstopper-cli` — `pipx upgrade slopstopper-cli` (preferred) or `pip install --user --upgrade <git url>` fallback. Confirm with `slopstopper --version`.
+- `Taskfile.ss.yml` — thin `task ss:*` shims that all call `slopstopper run …` under the hood.
+- `.ss/tests/` — Playwright specs (smoke, accessibility, broken-links). Wholesale replacement; the CLI prefers these over its own bundled copies under `cli/slopstopper/data/tests/`.
+- `.ss/playwright.config.js`, `.ss/lighthouserc.json`, `.ss/lighthouserc.prod.json`, `.ss/server.js` — same override pattern.
+- Each workflow in `install.sh`'s `GENERIC_WORKFLOWS` array — provided it's still present in the target's `.github/workflows/`. The workflow body itself is short now (~8 lines: install CLI, `slopstopper run …`, `slopstopper emit …`), so most updates are CLI-version bumps invisible to the workflow YAML.
+
+What it scrubs (on a pre-CLI install):
+- `.ss/scripts/` — the entire directory. Every Python/bash script that used to live there is now bundled in `slopstopper-cli`. The installer detects the directory and removes it; commit the deletion as part of the upgrade PR.
 
 What it leaves alone:
-- Any workflow you've deleted (tracked via `.ss/.workflows-installed` — the marker file is the source of truth, commit it)
-- Your existing `Taskfile.yml` if you have one (just verifies the include is present, otherwise prints the block to paste)
-- Anything in `package.json` apart from devDependencies merges
-- Your own files outside the `ss` namespace
+- Any workflow you've deleted (tracked via `.ss/.workflows-installed` — the marker file is the source of truth, commit it).
+- `.slopstopper.yml` — never overwritten. All config (URLs, headers source, thresholds, disabled workflows) survives every re-run.
+- Your existing `Taskfile.yml` if you have one (just verifies the include is present, otherwise prints the block to paste).
+- Anything in `package.json` apart from devDependencies merges.
+- Your own files outside the `ss` namespace.
 
 The installer's stdout summarises what was installed, refreshed, or skipped as a previously-deleted item. Read it and relay to the user — especially if anything was added (a newly-shipped upstream workflow showing up for the first time) or skipped (a workflow you deleted that the installer is honouring).
 
@@ -57,15 +63,17 @@ Any line in the output is an `ss-*.yml` workflow that exists upstream but isn't 
 
 ## Step 4 — Re-apply customizations that got wiped (much smaller than it used to be)
 
-The installer refreshes `Taskfile.ss.yml`, `.ss/scripts/`, and the `ss-*.yml` workflows wholesale. Anything hand-edited in those files is gone — but `.slopstopper.yml` is **never** overwritten by the installer, so the bulk of customization (node version, headers source/format, URLs, pages, og-image path, disabled workflows) survives every re-run.
+The installer refreshes `Taskfile.ss.yml`, the `.ss/` overlay, and the `ss-*.yml` workflows wholesale. Anything hand-edited in those files is gone — but `.slopstopper.yml` is **never** overwritten by the installer, so the bulk of customization (node version, headers source/format, URLs, pages, og-image path, disabled workflows, hygiene thresholds) survives every re-run.
 
 What still needs re-checking after an update:
 
-- **Anything you hand-edited inside `ss-*.yml` workflow files** beyond what `.slopstopper.yml` covers. Common case: extra workflow-level `permissions:` for a custom integration, or a non-standard schedule. Diff against upstream to find them.
+- **Anything you hand-edited inside `ss-*.yml` workflow files** beyond what `.slopstopper.yml` covers. Common case: extra workflow-level `permissions:` for a custom integration, a non-standard schedule, or workflow-level env vars beyond the documented URL/PAGES set. Diff against upstream to find them.
+- **Anything you hand-edited inside `.ss/tests/*.spec.ts`, `.ss/playwright.config.js`, or `.ss/lighthouserc.json`.** These are refreshed wholesale on every install. If you need persistent customization, fork the spec under a different name and update `pages.smoke|accessibility|broken_links` in `.slopstopper.yml` to skip the bundled one, OR upstream the change.
 - **GitHub repo variables.** If `.slopstopper.yml` `node_version` changed, re-sync the `SLOPSTOPPER_NODE_VERSION` repo variable. If `urls.production` / `urls.preview` changed and you mirror them as repo variables, push those too:
 
   ```bash
-  gh variable set SLOPSTOPPER_NODE_VERSION --body "$(grep '^node_version:' .slopstopper.yml | cut -d\' -f2)"
+  NODE_VER=$(slopstopper config get node_version 20)
+  gh variable set SLOPSTOPPER_NODE_VERSION --body "$NODE_VER"
   # plus any URL variables you mirror
   ```
 
@@ -89,31 +97,48 @@ Surfaces worth checking explicitly:
 
 If a previously-failing check started passing after an update without any code change, eyeball whether a default got loosened upstream — those are flagged in the slopstopper changelog.
 
-## Step 6 — Check for new task targets
+## Step 6 — Check for new checks and task targets
 
-Re-running the installer refreshes `Taskfile.ss.yml`, which may now expose new `task ss:*` targets that weren't there last time. Eyeball the list:
+Two surfaces to scan after an upgrade:
 
-```bash
-task --list | grep '^\* ss:'
-```
+1. **The CLI's check registry.** `slopstopper --help` lists subcommands; the canonical list of check names is in `cli/slopstopper/checks/__init__.py`'s `REGISTRY` dict upstream. If a new check landed (e.g. `reliability:<new-check>`), it's runnable as `slopstopper run reliability:<new-check>` even before any workflow ships it.
+2. **The Taskfile shims.** Re-running the installer refreshes `Taskfile.ss.yml`, which mirrors every CLI check as a `task ss:*` shim. Eyeball:
 
-If anything looks unfamiliar, check `Taskfile.ss.yml` for the `desc:` and `summary:` to understand what it does. New tasks are usually surfaced as part of a new workflow — if you skipped the workflow in Step 3 you'll see the task in here regardless, since `Taskfile.ss.yml` is refreshed wholesale.
+   ```bash
+   task --list | grep '^\* ss:'
+   ```
 
-Flag any new tasks the user might want to wire into local pre-commit hooks or the standard dev loop.
+If anything looks unfamiliar, check `Taskfile.ss.yml` for the `desc:` and `summary:` (each shim documents the env vars it forwards). New checks are usually surfaced as part of a new workflow — if you skipped the workflow in Step 3 you'll see the task here regardless, since `Taskfile.ss.yml` is refreshed wholesale.
+
+Flag any new checks the user might want to wire into local pre-commit hooks or the standard dev loop.
 
 ## Step 7 — Re-run the static aggregates locally before pushing
 
 Same loop as `slopstopper-install` Step 7, condensed because the build / Playwright deps are already in place:
 
 ```bash
-task ss:hygiene:test    # complexity + docs-* + entry-files + lint + structure + size
+task ss:hygiene:test    # lint + structure + size + docs-* + entry-files + complexity
 task ss:security:scan   # SAST + secrets + dependency CVEs (+ DAST if a URL is wired)
+```
+
+Or hit each check via the CLI directly without the Taskfile detour:
+
+```bash
+slopstopper run hygiene:docs-size
+slopstopper run hygiene:docs-structure
+slopstopper run hygiene:docs-accuracy
+slopstopper run hygiene:entry-files
+slopstopper run hygiene:complexity
+slopstopper run hygiene:csp-exceptions
+slopstopper run security:secrets
+slopstopper run security:sast
+slopstopper run security:dependencies
 ```
 
 Anything that comes back red is one of two things:
 
 1. **A new check** that just landed and is hitting your repo for the first time → hand off to `slopstopper-triage` for the per-check playbook.
-2. **An existing check** with a stricter tuning than before (e.g. complexity threshold tightened in the new `Taskfile.ss.yml`) → check the config under `docs/<loop>/` for tunable values; `slopstopper-triage` also covers this.
+2. **An existing check** with a stricter default tuning than before (e.g. complexity threshold tightened in the new CLI release) → check `.slopstopper.yml.example` for the canonical schema and the per-check defaults; `slopstopper-triage` covers when to tune vs. fix.
 
 Don't push until the local loop is green. The point of running the aggregates first is to keep the upgrade-PR's CI run as a confirmation pass, not a discovery pass — same principle as a fresh install.
 
@@ -130,8 +155,10 @@ Push to a PR branch. CI should mirror local. If a CI-only check goes red (Depend
 
 Update this skill when:
 
-- The installer's behaviour changes (new tracked-files mechanism, different deletion semantics, additional refresh targets) → update Step 2's "what this refreshes / leaves alone" lists.
-- A new env var is introduced for a dynamic check → add to Step 4's list and Step 5's `gh variable set` example.
+- The installer's behaviour changes (new tracked-files mechanism, different deletion semantics, additional refresh targets, CLI install path change) → update Step 2's "what this refreshes / scrubs / leaves alone" lists.
+- A new check is added to `cli/slopstopper/checks/__init__.py`'s `REGISTRY` → mention it in Step 6 and add to Step 7's `slopstopper run` list (and the equivalents in `slopstopper-install` Step 7 + `slopstopper-triage`'s reproduce table).
+- A new env var is introduced for a dynamic check → add to Step 4's list and Step 4's `gh variable set` example.
+- A new `slopstopper` subcommand ships (e.g. `init`, `inspect`) → mention in the intro and the relevant Step.
 - A new hardcoded-on-reinstall surface emerges (e.g. another file the installer overwrites that users commonly hand-edit) → add to Step 4.
 - The trio gains a fourth skill → update the Step 1 description of what `install-skill.sh` refreshes and the "When to hand off" pointers.
 


### PR DESCRIPTION
## Summary

The skill trio (`slopstopper-install`, `slopstopper-update`, `slopstopper-triage`) was last edited under the pre-CLI shape. With Phase 2 complete (`.ss/scripts/` gone, `install.sh` pip-installs `slopstopper-cli`, every check runs through `slopstopper run` + `slopstopper emit`), the skills were quoting deleted files and pre-CLI workflow YAML.

This PR brings the trio back into alignment.

- **`slopstopper-install`** — opens with the CLI-as-source-of-truth callout; adds `python3` as a hard prereq in Step 1; rewrites Step 3 "what just landed" to lead with the CLI and call out that `.ss/scripts/` is now scrubbed on re-run; Step 7 Pass A/B now uses `slopstopper run …` as the primary surface (Taskfile shims still listed as the alternative).
- **`slopstopper-update`** — explains that `install.sh` refreshes the CLI itself via `pipx upgrade`; adds the `.ss/scripts/` scrub to the refresh inventory; swaps the `load_config.py`-shim usage in the `gh variable set` example for `slopstopper config get`; widens Step 6 to scan both the CLI's `REGISTRY` and the Taskfile shims.
- **`slopstopper-triage`** — Step 2's reproduce table now lists a CLI command **and** a Taskfile shim per workflow; new row uses `slopstopper discover` to diagnose "audited only `/`" symptoms; new row for stale CLI versions; Step 4's threshold list now cites `docs/hygiene/README.md` (the deleted `COMPLEXITY_CONFIG.md` was the old home).

Maintenance pointers at the bottom of each skill now name the CLI registry and subcommands as triggers, so future adopter-facing changes have a clear update target.

## Test plan

- [x] `grep -n "\.ss/scripts\|COMPLEXITY_CONFIG\|DOCS_SIZE_MONITORING"` returns only intentional callouts in update/install (the "scrubbed on re-run" lines)
- [x] No skill references workflow IDs or check names that aren't in `REGISTRY` / `GENERIC_WORKFLOWS`
- [ ] CI: `ss-hygiene-entry-files-check` passes (skills sit under `.claude/skills/`, outside the entry-file budget, but the docs-accuracy check could trip on a bad link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)