### PR TITLE
feat(cwv): lift threshold-table rendering into cwv.py + emit (Phase 2)

### DIFF
--- a/.github/workflows/ss-reliability-core-web-vitals.yml
+++ b/.github/workflows/ss-reliability-core-web-vitals.yml
@@ -1,13 +1,12 @@
 name: SlopStopper · Core Web Vitals
 
-# CLI-flipped workflow (Phase 2). Last reliability flip. Routes the
-# check through `slopstopper run reliability:cwv` (which is a thin
-# wrapper around `npx lhci autorun`) and converts the three
-# actions/github-script@v7 blocks (PR comment, issue create/update on
-# main, issue close on success) to inline `gh`. emit.py isn't a fit:
-# cwv.py doesn't render a markdown report; the threshold table is
-# built from the lhci JSON output in this workflow. Lifting that
-# rendering into the CLI is a follow-up.
+# CLI-flipped workflow (Phase 2). The CWV check now renders its own
+# threshold table inside cwv.py (lifted from the github-script JS
+# block) and writes .ss/reports/cwv/cwv-report.md. emit.py handles
+# PR-comment find-or-update and main-branch issue create/update, same
+# shape as every other Phase-2 flip. Auto-close on a green main /
+# schedule / deploy still uses inline `gh issue close` because emit
+# doesn't model that.
 
 on:
   deployment_status:
@@ -136,8 +135,8 @@ jobs:
             echo "config=.ss/lighthouserc.prod.json" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Run Lighthouse CI
-        id: lhci
+      - name: Run Core Web Vitals audit
+        id: cwv
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
           AUDIT_URL: ${{ steps.audit-url.outputs.url }}
@@ -146,47 +145,11 @@ jobs:
         run: |
           echo "🔍 Auditing: $AUDIT_URL"
           echo "📋 Using config: $LHCI_CONFIG"
-          set -o pipefail
-          slopstopper run reliability:cwv -- --url "$AUDIT_URL" --config "$LHCI_CONFIG" \
-            2>&1 | tee /tmp/lhci-output.txt
-          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+          slopstopper run reliability:cwv -- --url "$AUDIT_URL" --config "$LHCI_CONFIG"
 
       - name: Stop local server
         if: (github.event_name == 'pull_request' || github.event_name == 'push') && always()
         run: kill "$SERVER_PID" || true
-
-      - name: Parse Lighthouse results
-        id: results
-        run: |
-          REPORT_FILE=$(find .lighthouseci -name "lhr-*.json" | sort | tail -1)
-          if [ -z "$REPORT_FILE" ]; then
-            echo "⚠️ No Lighthouse report JSON found — using fallback values"
-            {
-              echo "performance=N/A"
-              echo "lcp=N/A"
-              echo "tbt=N/A"
-              echo "cls=N/A"
-              echo "fcp=N/A"
-              echo "report_url="
-            } >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          node -e "
-            const fs = require('fs');
-            const data = JSON.parse(fs.readFileSync('$REPORT_FILE', 'utf8'));
-            const perf = Math.round((data.categories?.performance?.score ?? 0) * 100);
-            const lcp  = Math.round(data.audits?.['largest-contentful-paint']?.numericValue ?? 0);
-            const tbt  = Math.round(data.audits?.['total-blocking-time']?.numericValue ?? 0);
-            const cls  = (data.audits?.['cumulative-layout-shift']?.numericValue ?? 0).toFixed(3);
-            const fcp  = Math.round(data.audits?.['first-contentful-paint']?.numericValue ?? 0);
-            const out  = ['performance='+perf,'lcp='+lcp,'tbt='+tbt,'cls='+cls,'fcp='+fcp].join('\n');
-            fs.appendFileSync(process.env.GITHUB_OUTPUT, out + '\n');
-            console.log('Parsed metrics:\n' + out);
-          "
-
-          REPORT_URL=$(grep -oE 'https://storage\.googleapis\.com/[^[:space:]]+' /tmp/lhci-output.txt 2>/dev/null | head -1 || true)
-          echo "report_url=$REPORT_URL" >> "$GITHUB_OUTPUT"
 
       - name: Upload Lighthouse reports
         if: always()
@@ -198,132 +161,25 @@ jobs:
           if-no-files-found: warn
 
       - name: Comment on PR with results
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && always()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERFORMANCE: ${{ steps.results.outputs.performance }}
-          LCP: ${{ steps.results.outputs.lcp }}
-          TBT: ${{ steps.results.outputs.tbt }}
-          CLS: ${{ steps.results.outputs.cls }}
-          FCP: ${{ steps.results.outputs.fcp }}
-          REPORT_URL: ${{ steps.results.outputs.report_url }}
-          LHCI_EXIT: ${{ steps.lhci.outputs.exit_code }}
-          AUDIT_URL: ${{ steps.audit-url.outputs.url }}
-        run: |
-          # Build the threshold table via node (already a dep here for
-          # lhci) so we don't have to redo the int / float comparisons
-          # in bash. This used to live in the github-script block.
-          BODY=$(node -e "
-            const perf = process.env.PERFORMANCE;
-            const lcp  = process.env.LCP;
-            const tbt  = process.env.TBT;
-            const cls  = process.env.CLS;
-            const reportUrl = process.env.REPORT_URL;
-            const passed = process.env.LHCI_EXIT === '0';
-            const status = passed ? '✅ PASSED' : '❌ FAILED';
-            const auditUrl = process.env.AUDIT_URL;
-            const lcpMs  = lcp !== 'N/A' ? lcp + ' ms'  : 'N/A';
-            const tbtMs  = tbt !== 'N/A' ? tbt + ' ms'  : 'N/A';
-            const perfPc = perf !== 'N/A' ? perf + '/100' : 'N/A';
-            const rows = [
-              '| Metric | Threshold | Status |',
-              '|--------|-----------|--------|',
-              '| Performance score | ≥ 70  | ' + (perf !== 'N/A' ? (parseInt(perf) >= 70 ? '✅' : '❌') : '⚠️') + ' ' + perfPc + ' |',
-              '| LCP               | ≤ 4 s | ' + (lcp  !== 'N/A' ? (parseInt(lcp)  <= 4000 ? '✅' : '❌') : '⚠️') + ' ' + lcpMs  + ' |',
-              '| TBT               | ≤ 600 ms | ' + (tbt  !== 'N/A' ? (parseInt(tbt)  <= 600  ? '✅' : '❌') : '⚠️') + ' ' + tbtMs  + ' |',
-              '| CLS               | ≤ 0.25 | ' + (cls  !== 'N/A' ? (parseFloat(cls) <= 0.25 ? '✅' : '❌') : '⚠️') + ' ' + cls + ' |',
-            ].join('\n');
-            let out = '## 🚦 Core Web Vitals ' + status + '\n\n';
-            out += '**URL audited:** ' + auditUrl + '\n\n' + rows + '\n\n';
-            if (reportUrl) out += '[📊 Full Lighthouse Report](' + reportUrl + ')\n\n';
-            out += '### How to run locally\n\n\`\`\`bash\nslopstopper run reliability:cwv -- --url https://your-site.example.com\n\`\`\`\n';
-            process.stdout.write(out);
-          ")
-
-          marker='🚦 Core Web Vitals'
-          pr_number=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
-          existing=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" \
-            --jq ".[] | select(.user.type==\"Bot\" and (.body | contains(\"$marker\"))) | .id" | head -n1)
-          if [ -n "$existing" ]; then
-            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" -f body="$BODY"
-          else
-            gh pr comment "$pr_number" --body "$BODY"
-          fi
-
-      - name: Enforce thresholds
-        if: steps.lhci.outputs.exit_code != '0'
-        env:
-          PERFORMANCE: ${{ steps.results.outputs.performance }}
-          LCP: ${{ steps.results.outputs.lcp }}
-          TBT: ${{ steps.results.outputs.tbt }}
-          CLS: ${{ steps.results.outputs.cls }}
-          CFG: ${{ steps.audit-url.outputs.config }}
-        run: |
-          echo "::error::Core Web Vitals thresholds not met. See $CFG for configured limits."
-          echo ""
-          echo "Metrics recorded:"
-          echo "  Performance : ${PERFORMANCE}/100  (threshold: ≥ 70)"
-          echo "  LCP         : ${LCP} ms           (threshold: ≤ 4000 ms)"
-          echo "  TBT         : ${TBT} ms           (threshold: ≤ 600 ms)"
-          echo "  CLS         : ${CLS}              (threshold: ≤ 0.25)"
-          exit 1
+        run: slopstopper emit reliability:cwv --target pr-comment
 
       - name: Open / update issue on CWV failure (main / schedule / deploy)
         if: |
-          failure() && (
+          steps.cwv.outcome == 'failure' && (
             (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
             github.event_name == 'schedule' ||
             github.event_name == 'deployment_status'
           )
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AUDIT_URL: ${{ steps.audit-url.outputs.url }}
-          PERFORMANCE: ${{ steps.results.outputs.performance }}
-          LCP: ${{ steps.results.outputs.lcp }}
-          TBT: ${{ steps.results.outputs.tbt }}
-          CLS: ${{ steps.results.outputs.cls }}
-        run: |
-          title='❌ Core Web Vitals Below Threshold'
-          label='cwv-failure'
-          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          body=$(cat <<EOF
-          ## Core Web Vitals Failure Detected
-
-          **URL Audited:** ${AUDIT_URL}
-          **Run:** [#${GITHUB_RUN_ID}](${run_url})
-
-          | Metric | Value | Threshold |
-          |--------|-------|-----------|
-          | Performance | ${PERFORMANCE}/100 | ≥ 70 |
-          | LCP | ${LCP} ms | ≤ 4000 ms |
-          | TBT | ${TBT} ms | ≤ 600 ms |
-          | CLS | ${CLS} | ≤ 0.25 |
-
-          ## How to Investigate
-
-          \`\`\`bash
-          slopstopper run reliability:cwv -- --url ${AUDIT_URL}
-          \`\`\`
-
-          [View the failed workflow run](${run_url})
-
-          ---
-          *This issue was automatically created by the Core Web Vitals workflow.*
-          EOF
-          )
-          existing=$(gh issue list --state open --label "$label" --search "in:title $title" --json number,title --jq ".[] | select(.title==\"$title\") | .number" | head -n1)
-          if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body "## New Failure
-
-          **Run:** [#${GITHUB_RUN_ID}](${run_url})
-          **URL Audited:** ${AUDIT_URL}"
-          else
-            gh issue create --title "$title" --body "$body" --label "$label" --label reliability
-          fi
+        run: slopstopper emit reliability:cwv --target issue
 
       - name: Close CWV failure issue on success
         if: |
-          success() && (
+          steps.cwv.outcome == 'success' && (
             (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
             github.event_name == 'schedule' ||
             github.event_name == 'deployment_status'
@@ -338,3 +194,9 @@ jobs:
             gh issue comment "$n" --body "✅ Core Web Vitals are now passing all thresholds. Closing this issue automatically."
             gh issue close "$n"
           done
+
+      - name: Fail the job if CWV thresholds were not met
+        if: steps.cwv.outcome == 'failure'
+        run: |
+          echo "::error::Core Web Vitals thresholds not met. See .ss/reports/cwv/cwv-report.md for details."
+          exit 1

--- a/cli/slopstopper/checks/cwv.py
+++ b/cli/slopstopper/checks/cwv.py
@@ -1,32 +1,72 @@
 """Core Web Vitals audit (Lighthouse CI wrapper).
 
-Ports the bash reliability:cwv flow:
+Implements the reliability:cwv flow:
 
-  task ss:reliability:cwv -- https://your-site.example.com
+  slopstopper run reliability:cwv -- --url https://your-site.example.com
 
   which is, under the covers:
 
-  npx lhci autorun --collect.url="$CWV_URL" --config=.ss/lighthouserc.json
+  npx lhci autorun --collect.url="$CWV_URL" --config=<resolved lhci config>
 
 Subprocess-invokes `npx lhci` — Lighthouse CI is Apache-2.0; the
-slopstopper-cli wheel ships zero Lighthouse code. The .ss/lighthouserc.json
-config (and any *-ci variant) is still adopter-vendored today; lifting
-into package data is a follow-up.
+slopstopper-cli wheel ships zero Lighthouse code.
+
+After lhci finishes, cwv.py reads the latest `.lighthouseci/lhr-*.json`,
+extracts the four headline metrics (Performance, LCP, TBT, CLS) plus
+FCP, and writes `.ss/reports/cwv/cwv-report.md` with the threshold
+table. emit.py then handles PR-comment / issue from that report — same
+shape as every other check.
+
+Configuration: thresholds and the lhci config path live in the
+`.ss/lighthouserc.json` override (or the package-data fallback under
+`cli/slopstopper/data/lighthouserc.json`). cwv.py's threshold-table
+limits mirror that file so the rendered table matches what lhci
+actually enforced.
 
 Exit codes:
   0 — lhci passed all thresholds
-  non-zero — lhci failed thresholds or URL/config missing
+  non-zero — lhci failed thresholds (report still written) or URL/config missing
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import os
+import re
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 from slopstopper import templates
+
+
+REPORT_DIR = Path(".ss/reports/cwv")
+REPORT_MD = REPORT_DIR / "cwv-report.md"
+LHCI_DIR = Path(".lighthouseci")
+
+# Threshold table — kept in lockstep with `.ss/lighthouserc.json`'s
+# `assertions` block so the rendered table reflects what lhci actually
+# enforced. If you tune the lhci config, mirror the change here.
+THRESHOLDS = {
+    "performance": ("Performance score", "≥ 70", 70, "min"),
+    "lcp":         ("LCP", "≤ 4 s",    4000, "max"),
+    "tbt":         ("TBT", "≤ 600 ms",  600, "max"),
+    "cls":         ("CLS", "≤ 0.25",  0.25, "max"),
+}
+
+# Consumed by `slopstopper emit reliability:cwv --target pr-comment|issue`.
+# Discriminator `🚦 Core Web Vitals` matches the pre-flip github-script
+# block's PR comment heading so the same bot comment is reused after
+# the workflow flip.
+META = {
+    "report_path": str(REPORT_MD),
+    "comment_discriminator": "🚦 Core Web Vitals",
+    "issue_title": "❌ Core Web Vitals Below Threshold",
+    "issue_labels": ["cwv-failure", "reliability"],
+    "issue_followup": "🔔 Core Web Vitals failure recurred in commit",
+}
 
 
 def _parse_args(args: list[str] | None) -> argparse.Namespace:
@@ -58,6 +98,142 @@ def _build_cmd(url: str, config_path: str) -> list[str]:
     ]
 
 
+def _run_lhci(cmd: list[str]) -> tuple[int, str]:
+    """Run lhci, tee its output to our stdout, and return (exit_code, captured_output)."""
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1
+    )
+    chunks: list[str] = []
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        sys.stdout.write(line)
+        sys.stdout.flush()
+        chunks.append(line)
+    rc = proc.wait()
+    return rc, "".join(chunks)
+
+
+# ── lhci JSON parsing + report rendering ─────────────────────────
+
+
+def _latest_lhr_json() -> Path | None:
+    if not LHCI_DIR.exists():
+        return None
+    reports = sorted(LHCI_DIR.glob("lhr-*.json"))
+    return reports[-1] if reports else None
+
+
+def _extract_metrics(lhr: dict) -> dict[str, float | None]:
+    """Pull the four headline metrics + FCP from a Lighthouse result JSON."""
+    categories = lhr.get("categories") or {}
+    audits = lhr.get("audits") or {}
+    perf_cat = categories.get("performance") or {}
+
+    def _audit_value(key: str) -> float | None:
+        audit = audits.get(key) or {}
+        value = audit.get("numericValue")
+        return float(value) if isinstance(value, (int, float)) else None
+
+    perf_score = perf_cat.get("score")
+    return {
+        "performance": round(perf_score * 100) if isinstance(perf_score, (int, float)) else None,
+        "lcp": _audit_value("largest-contentful-paint"),
+        "tbt": _audit_value("total-blocking-time"),
+        "cls": _audit_value("cumulative-layout-shift"),
+        "fcp": _audit_value("first-contentful-paint"),
+    }
+
+
+def _format_value(metric: str, value: float | None) -> str:
+    if value is None:
+        return "N/A"
+    if metric == "performance":
+        return f"{int(value)}/100"
+    if metric == "cls":
+        return f"{value:.3f}"
+    return f"{int(round(value))} ms"
+
+
+def _passes(metric: str, value: float | None) -> bool | None:
+    if value is None:
+        return None
+    _, _, threshold, direction = THRESHOLDS[metric]
+    return value >= threshold if direction == "min" else value <= threshold
+
+
+def _icon(passed: bool | None) -> str:
+    if passed is None:
+        return "⚠️"
+    return "✅" if passed else "❌"
+
+
+def _extract_report_url(output: str) -> str | None:
+    """lhci prints the storage URL to stdout. Capture the first one."""
+    match = re.search(r"https://storage\.googleapis\.com/\S+", output)
+    return match.group(0) if match else None
+
+
+def _build_report_md(
+    url: str,
+    metrics: dict[str, float | None],
+    report_url: str | None,
+    overall_pass: bool,
+) -> str:
+    status = "✅ PASSED" if overall_pass else "❌ FAILED"
+    lines: list[str] = [
+        f"## 🚦 Core Web Vitals {status}",
+        "",
+        f"**URL audited:** {url}",
+        "",
+        "| Metric | Threshold | Status |",
+        "|--------|-----------|--------|",
+    ]
+    for key, (label, threshold_str, _, _) in THRESHOLDS.items():
+        value = metrics.get(key)
+        lines.append(
+            f"| {label} | {threshold_str} | {_icon(_passes(key, value))} {_format_value(key, value)} |"
+        )
+    lines.append("")
+    if report_url:
+        lines.append(f"[📊 Full Lighthouse Report]({report_url})")
+        lines.append("")
+    lines.append("### How to run locally")
+    lines.append("")
+    lines.append("```bash")
+    lines.append("slopstopper run reliability:cwv -- --url https://your-site.example.com")
+    lines.append("```")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _write_report(url: str, output: str, lhci_exit: int) -> None:
+    """Parse the latest lhr-*.json + lhci stdout, and write the markdown report."""
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    lhr_path = _latest_lhr_json()
+    if lhr_path is None:
+        REPORT_MD.write_text(
+            "## 🚦 Core Web Vitals ⚠️ NO REPORT\n\n"
+            "Lighthouse CI did not produce a report JSON under `.lighthouseci/`. "
+            "Check the lhci output above for the cause.\n"
+        )
+        return
+    try:
+        lhr = json.loads(lhr_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        REPORT_MD.write_text(
+            f"## 🚦 Core Web Vitals ⚠️ PARSE ERROR\n\nCould not parse {lhr_path}: {e}\n"
+        )
+        return
+    metrics = _extract_metrics(lhr)
+    report_url = _extract_report_url(output)
+    REPORT_MD.write_text(
+        _build_report_md(url, metrics, report_url, overall_pass=lhci_exit == 0)
+    )
+
+
+# ── CLI entrypoint ───────────────────────────────────────────────
+
+
 def run(args: list[str] | None = None) -> int:
     if not _npx_available():
         print("❌ npx is not available — install Node.js to run Lighthouse CI")
@@ -79,5 +255,7 @@ def run(args: list[str] | None = None) -> int:
 
     print(f"🚦 Running Core Web Vitals audit against: {url}")
     cmd = _build_cmd(url, str(config_path))
-    result = subprocess.run(cmd, check=False)
-    return result.returncode
+    rc, captured = _run_lhci(cmd)
+    _write_report(url, captured, rc)
+    print(f"📝 Report written to {REPORT_MD}")
+    return rc

--- a/cli/tests/checks/test_cwv.py
+++ b/cli/tests/checks/test_cwv.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-import subprocess
+import json
+from pathlib import Path
 
 from slopstopper.checks import cwv
 
@@ -45,6 +46,175 @@ def test_build_cmd_threads_url_and_config():
     assert "--config=myconf.json" in cmd
 
 
+# ── META contract ────────────────────────────────────────────────
+
+
+def test_meta_has_required_keys_for_pr_comment_and_issue():
+    assert cwv.META["report_path"].endswith("cwv-report.md")
+    for key in ("comment_discriminator", "issue_title", "issue_labels", "issue_followup"):
+        assert key in cwv.META
+    # Bot reuses the existing pre-flip comment by matching this substring.
+    assert "Core Web Vitals" in cwv.META["comment_discriminator"]
+
+
+# ── lhci JSON parsing ────────────────────────────────────────────
+
+
+def _sample_lhr() -> dict:
+    return {
+        "categories": {"performance": {"score": 0.88}},
+        "audits": {
+            "largest-contentful-paint": {"numericValue": 1234.5},
+            "total-blocking-time": {"numericValue": 50},
+            "cumulative-layout-shift": {"numericValue": 0.0123},
+            "first-contentful-paint": {"numericValue": 600.4},
+        },
+    }
+
+
+def test_extract_metrics_rounds_perf_and_passes_through_audits():
+    m = cwv._extract_metrics(_sample_lhr())
+    assert m["performance"] == 88
+    assert m["lcp"] == 1234.5
+    assert m["tbt"] == 50
+    assert m["cls"] == 0.0123
+    assert m["fcp"] == 600.4
+
+
+def test_extract_metrics_handles_missing_fields():
+    m = cwv._extract_metrics({})
+    assert m == {"performance": None, "lcp": None, "tbt": None, "cls": None, "fcp": None}
+
+
+def test_passes_threshold_logic():
+    assert cwv._passes("performance", 70) is True
+    assert cwv._passes("performance", 69) is False
+    assert cwv._passes("lcp", 4000) is True
+    assert cwv._passes("lcp", 4001) is False
+    assert cwv._passes("tbt", 600) is True
+    assert cwv._passes("tbt", 601) is False
+    assert cwv._passes("cls", 0.25) is True
+    assert cwv._passes("cls", 0.26) is False
+
+
+def test_passes_returns_none_for_missing_metric():
+    assert cwv._passes("lcp", None) is None
+
+
+def test_format_value_per_metric():
+    assert cwv._format_value("performance", 88) == "88/100"
+    assert cwv._format_value("lcp", 1234.5) == "1234 ms"
+    assert cwv._format_value("cls", 0.123) == "0.123"
+    assert cwv._format_value("performance", None) == "N/A"
+
+
+def test_icon_paths():
+    assert cwv._icon(True) == "✅"
+    assert cwv._icon(False) == "❌"
+    assert cwv._icon(None) == "⚠️"
+
+
+def test_extract_report_url_finds_storage_url():
+    out = "lots of output\n  https://storage.googleapis.com/abc/def.html\n"
+    assert cwv._extract_report_url(out) == "https://storage.googleapis.com/abc/def.html"
+
+
+def test_extract_report_url_returns_none_when_absent():
+    assert cwv._extract_report_url("nothing to see here") is None
+
+
+# ── markdown rendering ───────────────────────────────────────────
+
+
+def test_build_report_md_pass_path_includes_table_and_status():
+    md = cwv._build_report_md(
+        "https://example.com",
+        {"performance": 88, "lcp": 1200, "tbt": 50, "cls": 0.01, "fcp": 600},
+        report_url="https://storage.googleapis.com/x.html",
+        overall_pass=True,
+    )
+    assert "PASSED" in md
+    assert "https://example.com" in md
+    assert "| Performance score | ≥ 70 |" in md
+    assert "✅" in md
+    assert "[📊 Full Lighthouse Report](https://storage.googleapis.com/x.html)" in md
+    assert "slopstopper run reliability:cwv" in md
+
+
+def test_build_report_md_fail_path_marks_failing_metrics():
+    md = cwv._build_report_md(
+        "https://example.com",
+        {"performance": 40, "lcp": 9000, "tbt": 50, "cls": 0.01, "fcp": 600},
+        report_url=None,
+        overall_pass=False,
+    )
+    assert "FAILED" in md
+    # Performance row should have a ❌; LCP row should have a ❌.
+    assert "❌ 40/100" in md
+    assert "❌ 9000 ms" in md
+    # No storage URL => no full-report link.
+    assert "Full Lighthouse Report" not in md
+
+
+def test_build_report_md_renders_warning_for_missing_metric():
+    md = cwv._build_report_md(
+        "https://example.com",
+        {"performance": None, "lcp": 1200, "tbt": 50, "cls": 0.01, "fcp": None},
+        report_url=None,
+        overall_pass=True,
+    )
+    assert "⚠️ N/A" in md
+
+
+# ── _write_report (happy + error paths) ─────────────────────────
+
+
+def test_write_report_writes_markdown_from_lhr_json(monkeypatch, isolated_cwd):
+    lhci = Path(".lighthouseci")
+    lhci.mkdir()
+    (lhci / "lhr-1.json").write_text(json.dumps(_sample_lhr()))
+
+    cwv._write_report("https://example.com", "log line\n", lhci_exit=0)
+
+    md = Path(cwv.REPORT_MD).read_text()
+    assert "PASSED" in md
+    assert "88/100" in md
+
+
+def test_write_report_picks_latest_lhr(monkeypatch, isolated_cwd):
+    lhci = Path(".lighthouseci")
+    lhci.mkdir()
+    (lhci / "lhr-1.json").write_text(json.dumps({"categories": {"performance": {"score": 0.5}}}))
+    (lhci / "lhr-2.json").write_text(json.dumps(_sample_lhr()))  # score 0.88
+
+    cwv._write_report("https://example.com", "", lhci_exit=0)
+    assert "88/100" in Path(cwv.REPORT_MD).read_text()
+
+
+def test_write_report_handles_missing_lhr_dir(monkeypatch, isolated_cwd):
+    cwv._write_report("https://example.com", "", lhci_exit=1)
+    text = Path(cwv.REPORT_MD).read_text()
+    assert "NO REPORT" in text
+
+
+def test_write_report_handles_unparseable_lhr(monkeypatch, isolated_cwd):
+    lhci = Path(".lighthouseci")
+    lhci.mkdir()
+    (lhci / "lhr-1.json").write_text("not json")
+
+    cwv._write_report("https://example.com", "", lhci_exit=1)
+    assert "PARSE ERROR" in Path(cwv.REPORT_MD).read_text()
+
+
+def test_write_report_marks_failed_on_nonzero_lhci_exit(monkeypatch, isolated_cwd):
+    lhci = Path(".lighthouseci")
+    lhci.mkdir()
+    (lhci / "lhr-1.json").write_text(json.dumps(_sample_lhr()))
+
+    cwv._write_report("https://example.com", "", lhci_exit=1)
+    assert "FAILED" in Path(cwv.REPORT_MD).read_text()
+
+
 # ── subprocess / runtime ─────────────────────────────────────────
 
 
@@ -80,33 +250,44 @@ def test_run_returns_one_when_explicit_config_missing(monkeypatch, isolated_cwd,
     assert "Lighthouse CI config not found" in capsys.readouterr().out
 
 
-def test_run_invokes_lhci_with_expected_args(monkeypatch, isolated_cwd):
+def test_run_invokes_lhci_and_writes_report(monkeypatch, isolated_cwd):
     captured: dict = {}
 
-    def fake_run(cmd, check):
+    def fake_run_lhci(cmd):
         captured["cmd"] = cmd
-        return subprocess.CompletedProcess(cmd, 0)
+        # Drop a lhr JSON like a real lhci would.
+        lhci = Path(".lighthouseci")
+        lhci.mkdir()
+        (lhci / "lhr-1.json").write_text(json.dumps(_sample_lhr()))
+        return 0, "lhci output https://storage.googleapis.com/x.html"
 
     monkeypatch.setattr(cwv, "_npx_available", lambda: True)
-    monkeypatch.setattr(cwv.subprocess, "run", fake_run)
+    monkeypatch.setattr(cwv, "_run_lhci", fake_run_lhci)
 
     rc = cwv.run(["--url", "https://example.com"])
     assert rc == 0
     assert captured["cmd"][:3] == ["npx", "lhci", "autorun"]
     assert "--collect.url=https://example.com" in captured["cmd"]
-    # default resolution lands on the bundled lighthouserc.json
-    assert any("lighthouserc.json" in arg for arg in captured["cmd"])
+    md = Path(cwv.REPORT_MD).read_text()
+    assert "PASSED" in md
+    assert "88/100" in md
+    assert "Full Lighthouse Report" in md
 
 
-def test_run_propagates_lhci_failure(monkeypatch, isolated_cwd):
+def test_run_propagates_lhci_failure_but_still_writes_report(monkeypatch, isolated_cwd):
+    def fake_run_lhci(cmd):
+        lhci = Path(".lighthouseci")
+        lhci.mkdir()
+        (lhci / "lhr-1.json").write_text(json.dumps(_sample_lhr()))
+        return 1, ""
+
     monkeypatch.setattr(cwv, "_npx_available", lambda: True)
-    monkeypatch.setattr(
-        cwv.subprocess, "run",
-        lambda cmd, check: subprocess.CompletedProcess(cmd, 1),
-    )
+    monkeypatch.setattr(cwv, "_run_lhci", fake_run_lhci)
 
     rc = cwv.run(["--url", "https://example.com"])
     assert rc == 1
+    md = Path(cwv.REPORT_MD).read_text()
+    assert "FAILED" in md
 
 
 def test_run_accepts_explicit_config(monkeypatch, isolated_cwd):
@@ -115,12 +296,15 @@ def test_run_accepts_explicit_config(monkeypatch, isolated_cwd):
 
     captured: dict = {}
 
-    def fake_run(cmd, check):
+    def fake_run_lhci(cmd):
         captured["cmd"] = cmd
-        return subprocess.CompletedProcess(cmd, 0)
+        lhci = Path(".lighthouseci")
+        lhci.mkdir()
+        (lhci / "lhr-1.json").write_text(json.dumps(_sample_lhr()))
+        return 0, ""
 
     monkeypatch.setattr(cwv, "_npx_available", lambda: True)
-    monkeypatch.setattr(cwv.subprocess, "run", fake_run)
+    monkeypatch.setattr(cwv, "_run_lhci", fake_run_lhci)
 
     rc = cwv.run(["--url", "https://example.com", "--config", str(custom)])
     assert rc == 0


### PR DESCRIPTION
## Summary

Last reliability check still doing its report work in YAML. The CWV workflow had ~30 lines of inline `node -e` parsing `.lighthouseci/lhr-*.json`, another inline node block assembling the threshold-table markdown, and three more `gh`-style blocks for PR-comment dedup / issue create-update / auto-close. All of that except the auto-close now lives in `cwv.py`.

- **`cwv.py`** reads the latest `lhr-*.json`, extracts the four headline metrics + FCP, formats the threshold table (mirroring the limits in `.ss/lighthouserc.json`), and writes `.ss/reports/cwv/cwv-report.md`. Storage URL is captured from the lhci stdout that we tee through `Popen` so the live workflow log still shows lhci's progress in real time.
- **META dict** added with comment discriminator `🚦 Core Web Vitals` (matches the pre-flip github-script block so the same bot comment is reused after the flip), issue title `❌ Core Web Vitals Below Threshold`, labels `["cwv-failure", "reliability"]`.
- **Workflow** drops both inline `node -e` blocks, the PR-comment find-or-update block, and the issue create-or-update block — all replaced by `slopstopper emit reliability:cwv --target {pr-comment,issue}`. Auto-close-on-green stays inline (emit doesn't model "close issue on success" yet). **Net: 340 → 202 lines.**
- **Tests**: 17 new tests cover metric extraction, threshold logic, format/icon helpers, markdown rendering (pass/fail/missing-metric paths), and `_write_report` happy + error paths. Existing subprocess tests updated to monkey-patch `_run_lhci` instead of `subprocess.run` since lhci now goes through `Popen` for live stdout teeing. Total: **430 passing**.

This completes the "no inline JS in workflows" promise of Phase 2 — every check that emits a markdown report now goes through `emit.py`.

## Test plan

- [x] `task -t cli/Taskfile.yml test` — 430 pass
- [x] `python3 -m lizard cli/slopstopper/checks/cwv.py` — max CCN 5, no thresholds exceeded
- [ ] CI: workflow runs against `http://localhost:8080` on this PR and posts the bot comment via emit. Confirm the previous bot comment (if any) is updated rather than duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)