### PR TITLE
feat(release): CHANGELOG + ss-release.yml on tag → GitHub Release

### DIFF
--- a/.github/workflows/ss-release.yml
+++ b/.github/workflows/ss-release.yml
@@ -1,0 +1,121 @@
+name: SlopStopper · Release
+
+# Tag-triggered release flow. On any `v*.*.*` push tag, build the
+# wheel + sdist with hatch, extract the matching section from
+# CHANGELOG.md as the release notes, and create a GitHub Release with
+# both artifacts attached. PyPI publish is intentionally NOT wired up
+# yet — that needs the Trusted Publisher trust relationship set up on
+# PyPI's side first. Until then, this workflow lands a "real" GitHub
+# Release every tag and you can publish to PyPI manually with
+# `twine upload dist/*` when ready.
+#
+# Pushing the tag:
+#   git tag v0.2.0 -m "0.2.0"
+#   git push origin v0.2.0
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to (re-)release (e.g. v0.2.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write     # create GitHub Releases + upload assets
+
+jobs:
+  build-and-release:
+    name: Build wheel + sdist, create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # CHANGELOG diff and git describe both need full history.
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Resolve tag + version
+        id: tag
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          TAG="${INPUT_TAG:-$REF_NAME}"
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "🏷  Releasing $TAG  (version $VERSION)"
+
+      - name: Sanity-check pyproject + __init__ versions match the tag
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          PYPROJECT_VER=$(grep -m1 '^version = ' cli/pyproject.toml | sed -E 's/version = "(.*)"/\1/')
+          INIT_VER=$(grep -m1 '__version__' cli/slopstopper/__init__.py | sed -E 's/__version__ = "(.*)"/\1/')
+          echo "pyproject:     $PYPROJECT_VER"
+          echo "__init__.py:   $INIT_VER"
+          echo "tag (without v): $VERSION"
+          if [ "$PYPROJECT_VER" != "$VERSION" ] || [ "$INIT_VER" != "$VERSION" ]; then
+            echo "::error::Version mismatch — bump cli/pyproject.toml and cli/slopstopper/__init__.py to match the tag before releasing."
+            exit 1
+          fi
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build tooling
+        run: pip install --upgrade build
+
+      - name: Build wheel + sdist
+        working-directory: cli
+        run: python -m build
+
+      - name: List built artifacts
+        run: ls -la cli/dist/
+
+      - name: Extract release notes for this version from CHANGELOG.md
+        id: notes
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          # Pull the section between `## [VERSION]` and the next `## [`.
+          # If we can't find one, fall back to a generic body so the
+          # release still lands.
+          python3 <<'PY' > release-notes.md
+          import os, re, sys
+          version = os.environ["VERSION"]
+          text = open("CHANGELOG.md").read()
+          pattern = rf"##\s*\[{re.escape(version)}\][^\n]*\n(.*?)(?=\n##\s*\[|\Z)"
+          m = re.search(pattern, text, re.DOTALL)
+          if m:
+              sys.stdout.write(m.group(1).strip() + "\n")
+          else:
+              sys.stdout.write(
+                  f"Release {version}. See CHANGELOG.md on the repo for details.\n"
+              )
+          PY
+          echo "--- release notes preview ---"
+          head -40 release-notes.md
+          echo "------------------------------"
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          # Skip if a release already exists for this tag (idempotent re-runs).
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "ℹ️  Release $TAG already exists — uploading any missing artifacts only."
+            gh release upload "$TAG" cli/dist/* --clobber
+          else
+            gh release create "$TAG" cli/dist/* \
+              --title "slopstopper-cli ${TAG#v}" \
+              --notes-file release-notes.md
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to **slopstopper-cli** are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The release workflow (`.github/workflows/ss-release.yml`) reads the section matching the pushed tag and posts it as the GitHub Release notes. To cut a release: bump `version` in `cli/pyproject.toml` and `__version__` in `cli/slopstopper/__init__.py`, move the `## [Unreleased]` block down to a new `## [X.Y.Z] - YYYY-MM-DD`, push a `vX.Y.Z` tag.
+
+## [Unreleased]
+
+Nothing yet.
+
+## [0.2.0] - 2026-06-13
+
+First release with a real product surface. Phase 2 of the CLI pivot is complete — every check runs through `slopstopper-cli` and adopter `.ss/` directories shrink to `reports/` + the workflow manifest. The CLI now has a polished UX (bare-invocation banner, `checks list`, `doctor`, consistent output module, `--quiet`).
+
+### Added
+
+- `slopstopper checks list [--category <c>] [--json]` — walk the registry and print every check with its one-line summary.
+- `slopstopper doctor` — verify external tools (`node`, `gh`, `lizard`, `semgrep`, `gitleaks`, `trivy`, `docker`) are installed; exit 1 only when a required-and-enabled tool is missing.
+- `slopstopper templates {list, path, eject}` — inspect and customise bundled templates (Playwright specs, lighthouserc dev/prod, server.js).
+- `slopstopper serve` — runs the bundled static server via `execvp(node)` so backgrounded `slopstopper serve &` gives bash the right PID for kill.
+- `slopstopper config get <key> [<default>]` — read `.slopstopper.yml` values for shell scripting.
+- `slopstopper discover <check> --event <e>` — resolve `pages.<check>` via sitemap / changed / explicit list.
+- Bare `slopstopper` prints a friendly command grid + Quick-start block (no longer errors).
+- `--quiet` / `-q` global flag suppresses decorative output while preserving reports.
+- Shared output module (`slopstopper.output`) with consistent `running` / `success` / `warn` / `error` / `info` / `status` / `section` / `separator` / `footer` formatters.
+
+### Changed
+
+- `lighthouserc.prod.json` lifted into the wheel; `--prod` flag on `cwv.py` selects it.
+- `server.js` lifted into the wheel; CWV/smoke/accessibility/SEO/broken-links/DAST workflows all use `slopstopper serve &` instead of `node server.js &`.
+- `.ss/` in a fresh adopter install now contains only `reports/` and `.workflows-installed`.
+- `install.sh` pip-installs `slopstopper-cli` (pipx-preferred) and scrubs legacy byte-equal copies of bundled templates from existing adopter `.ss/` directories.
+- Workflows now emit PR comments and tracking issues via `slopstopper emit --target {pr-comment, issue}` instead of inline `actions/github-script@v7` JS.
+
+### Removed
+
+- Every Python/bash script previously seeded into adopter repos under `.ss/scripts/` — logic lives in `slopstopper-cli` now.
+- `templates-sync-check` CI job — `.ss/` no longer ships byte-equal duplicates of `cli/slopstopper/data/`.
+
+## [0.1.0] - 2026-06-12
+
+Initial CLI pivot. Bash + Python scripts under `.ss/scripts/` remain authoritative; the Python `slopstopper-cli` package reproduces them check-by-check while CI runs both paths in parallel via the `bash↔cli parity` job.
+
+### Added
+
+- `slopstopper run <category>:<check>` dispatcher and the 15 check modules under `cli/slopstopper/checks/`.
+- `slopstopper emit <check> --target {pr-comment, issue}` with find-or-update semantics.
+- Templates resolver: `.ss/<filename>` override → package-data fallback.

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -25,9 +25,8 @@ Run `task --list` for the full set. The most-used ones:
 | Task | What it does |
 | ---- | ------------ |
 | `task ss:contributing:setup` | Install dependencies |
-| `task ss:contributing:build` | TypeScript build (`tsc`) |
-| `task ss:contributing:run` | Local dev server on port 8080 |
-| `task ss:contributing:test` | Playwright smoke + a11y suite |
+| `task ss:contributing:run` | Local dev server on port 8080 (via `slopstopper serve`) |
+| `task ss:contributing:test` | Playwright smoke + a11y suite (via the CLI) |
 | `task ss:contributing:lint` | Lint checks |
 | `task ss:hygiene:complexity` | Cyclomatic complexity check (Lizard) |
 | `task ss:hygiene:entry-files` | Enforce <2k token budget on entry files |
@@ -50,7 +49,6 @@ Run these before opening a PR. Each one mirrors the equivalent CI check
 exactly:
 
 ```bash
-task ss:contributing:build           # TypeScript build
 task ss:contributing:run              # Local server on :8080
 task ss:contributing:test             # Playwright smoke + a11y
 task ss:reliability:accessibility     # axe-core audit
@@ -59,9 +57,9 @@ task ss:hygiene:test                  # Full hygiene suite
 task ss:security:sast                 # Semgrep
 ```
 
-Or run the underlying npm scripts if you don't have Task installed
-(`npm start`, `npm run build`, `npm test`) — but **prefer `task`** so your
-behaviour matches CI exactly.
+Or call the CLI directly if you'd rather skip the `task` shim layer
+(`slopstopper serve &`, `slopstopper run reliability:smoke`, etc.) —
+the shims are thin and call the same code path either way.
 
 ## Workflow
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -11,6 +11,7 @@ This directory holds step-by-step runbooks for common operational tasks. As the 
 | Runbook | What it covers |
 | ------- | -------------- |
 | [INSTALL_SKILLS.md](./INSTALL_SKILLS.md) | Install the SlopStopper Claude Code skill trio (`slopstopper-install`, `slopstopper-update`, `slopstopper-triage`) into your user profile so any project on this machine can ask Claude Code to add, refresh, or triage SlopStopper |
+| [RELEASE.md](./RELEASE.md) | Cut a `slopstopper-cli` release: CHANGELOG bump, version bump in `cli/pyproject.toml` + `__init__.py`, tag, GitHub Release via `ss-release.yml`, optional manual PyPI publish |
 
 ## Adding Runbooks
 

--- a/docs/runbooks/RELEASE.md
+++ b/docs/runbooks/RELEASE.md
@@ -1,0 +1,71 @@
+# Cutting a release
+
+slopstopper-cli ships via GitHub Releases. The [`ss-release.yml`](../../.github/workflows/ss-release.yml) workflow fires on any `v*.*.*` tag push, builds the wheel + sdist, and creates a GitHub Release with notes pulled from [`CHANGELOG.md`](../../CHANGELOG.md). PyPI publishing is intentionally **not** automated yet — that needs a Trusted Publisher trust relationship set up on PyPI first.
+
+## When to bump
+
+Follow [Semantic Versioning](https://semver.org/):
+
+- **MAJOR** (`1.0.0`) — breaking changes to the CLI surface, check names, or report formats.
+- **MINOR** (`0.X.0`) — new subcommands, new checks, additive configuration knobs.
+- **PATCH** (`0.0.X`) — bug fixes, doc-only changes, dependency bumps.
+
+If in doubt, prefer a MINOR bump over a PATCH.
+
+## Release steps
+
+1. **Make sure `main` is green.** Every check on the most recent commit should be passing — CI on the release tag re-runs everything, so a broken `main` blocks the release.
+
+2. **Update the CHANGELOG.** Move the `## [Unreleased]` block contents under a new `## [X.Y.Z] - YYYY-MM-DD` heading. Leave a stub `## [Unreleased]` block at the top:
+
+   ```markdown
+   ## [Unreleased]
+
+   Nothing yet.
+
+   ## [0.3.0] - 2026-07-01
+
+   ### Added
+   - …
+   ```
+
+   The workflow's release-notes extractor matches `## [X.Y.Z]` exactly — keep the format consistent.
+
+3. **Bump the version in lockstep.** Two files need to match the tag:
+
+   - `cli/pyproject.toml` → `version = "X.Y.Z"`
+   - `cli/slopstopper/__init__.py` → `__version__ = "X.Y.Z"`
+
+   The release workflow has a sanity-check step that fails the build if these diverge from the tag.
+
+4. **Commit + push** the CHANGELOG and version bumps as a single commit (`chore(release): bump version to X.Y.Z`). Open a PR if you want CI to pre-verify; otherwise push straight to `main` if you have permission.
+
+5. **Tag + push.** Once the bump commit is on `main`:
+
+   ```bash
+   git tag vX.Y.Z -m "X.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+6. **Watch the workflow.** The `SlopStopper · Release` workflow runs against the tag. It will:
+   - Verify versions match the tag.
+   - Build wheel + sdist with `python -m build` (uses `hatchling`).
+   - Extract the matching `## [X.Y.Z]` section from `CHANGELOG.md`.
+   - Create the GitHub Release with that body and both artifacts attached.
+
+7. **Verify the release.** Open [Releases](https://github.com/hungovercoders/slopstopper/releases). Sanity-check the body, download the wheel, run `pipx install <path-to-wheel>` somewhere and confirm `slopstopper --version` matches.
+
+## Manual re-release
+
+If the workflow fails partway, fix the cause then trigger it from the Actions tab → `SlopStopper · Release` → `Run workflow` → enter the tag. The job is idempotent: if a Release already exists for the tag, the workflow uploads any missing artifacts and exits.
+
+## Manual PyPI publish (until Trusted Publisher is set up)
+
+Once the GitHub Release lands, the artifacts are at `cli/dist/`. From a clean local checkout of the tag:
+
+```bash
+cd cli && python -m build
+pipx run twine upload dist/*
+```
+
+You'll be prompted for a PyPI API token (use a project-scoped one — never the account-wide token). Once Trusted Publisher OIDC is configured on PyPI's side, we'll add a `publish-pypi` job to `ss-release.yml` and this manual step goes away.


### PR DESCRIPTION
## Summary

PR C of the polish trio. After A (#234, CLI UX polish) and B (#235, docs + website + src cleanup), the CLI feels like a product but the repo has zero tags, zero Releases, and no version-bumping ritual. This PR adds the missing release infrastructure — **GitHub-only artifacts for now, PyPI publish deferred** (per the locked plan).

## What lands

- **`CHANGELOG.md`** — Keep-a-Changelog format. `## [Unreleased]` block + the first real entry (`## [0.2.0] - 2026-06-13`) summarising what shipped across the polish trio. The release workflow's notes extractor matches `## [X.Y.Z]` exactly.
- **`.github/workflows/ss-release.yml`** — fires on `v*.*.*` tag push (or `workflow_dispatch` for manual re-runs). Steps:
  1. Sanity-check `cli/pyproject.toml` and `cli/slopstopper/__init__.py` versions match the tag.
  2. Build wheel + sdist via `python -m build` (uses the existing `hatchling` backend).
  3. Extract the matching `## [X.Y.Z]` section from `CHANGELOG.md`.
  4. Create the GitHub Release with that body and both artifacts attached.
  
  Idempotent — re-runs upload any missing artifacts only.
- **`docs/runbooks/RELEASE.md`** — the cut-a-release playbook. When to bump (semver), CHANGELOG move, version bump in two files, tag + push, watch the workflow. Includes the manual `twine upload` recipe for PyPI until Trusted Publisher OIDC is set up. Linked from `docs/runbooks/README.md`.
- **`docs/contributing/README.md`** — drops the stale `task ss:contributing:build` row (tsc removed in PR B), points the test row at the CLI, rewrites the "without Task" fallback to mention `slopstopper serve` / `slopstopper run …` instead of `npm` scripts.

## Cutting 0.2.0 once this lands

```bash
git checkout main && git pull
git tag v0.2.0 -m "0.2.0"
git push origin v0.2.0
```

The workflow takes ~2 minutes, then the GitHub Release shows up under [Releases](https://github.com/hungovercoders/slopstopper/releases).

## Test plan

- [x] Hygiene checks green locally (docs-accuracy, entry-files, docs-structure, docs-size).
- [x] CHANGELOG `## [0.2.0]` section is what the workflow's notes extractor will pull (matches the regex exactly).
- [x] Version sanity-check step in the workflow correctly fails on mismatch.
- [ ] CI: every `ss-*` workflow green.
- [ ] (Post-merge) tag v0.2.0 and confirm a real GitHub Release lands with the wheel + sdist attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)