### PR TITLE
fix(cli): drop redundant force-include — hatch was double-bundling slopstopper/data

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -57,13 +57,10 @@ Issues = "https://github.com/hungovercoders/slopstopper/issues"
 Documentation = "https://slopstopper.dev"
 
 [tool.hatch.build.targets.wheel]
+# `packages = ["slopstopper"]` includes the slopstopper/ tree (Python +
+# data files) automatically — no `force-include` needed; that block
+# caused a double-include error when building the wheel under hatchling.
 packages = ["slopstopper"]
-
-# Bundle Playwright specs + configs and the Lighthouse CI config inside
-# the wheel. The reliability checks resolve to these by default; an
-# adopter can still override by writing the same-named file under .ss/.
-[tool.hatch.build.targets.wheel.force-include]
-"slopstopper/data" = "slopstopper/data"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

The v0.2.0 release workflow failed at the wheel build step:

\`\`\`
ValueError: A second file is being added to the wheel archive at the same path: \`slopstopper/data/lighthouserc.json\`.
The most likely cause of this is an entry in the \`tool.hatch.build.targets.wheel.force-include\` table.
\`\`\`

Cause: \`packages = ["slopstopper"]\` already includes the \`slopstopper/\` tree (including \`data/\`) automatically. The extra \`[tool.hatch.build.targets.wheel.force-include]\` block told hatch to add \`slopstopper/data\` again — pre-0.x hatchling silently dropped the duplicate, current hatchling errors on it.

Fix: drop the force-include block. The bundled data is still in the wheel via the package include.

## Verified locally

\`\`\`
cli/.venv/bin/python -m build  →  builds slopstopper_cli-0.2.0-py3-none-any.whl
python -m zipfile -l dist/*.whl | grep data/  →
  slopstopper/data/lighthouserc.json
  slopstopper/data/lighthouserc.prod.json
  slopstopper/data/playwright.config.js
  slopstopper/data/server.js
  slopstopper/data/tests/{smoke,accessibility,broken-links}.spec.ts
\`\`\`

486 tests still pass.

## Next steps after merge

1. Delete the failed \`v0.2.0\` tag locally + remotely.
2. Re-cut \`v0.2.0\` from the new \`main\`. The release workflow retries from a clean state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)