### PR TITLE
chore(install): pin install URL to @v0.2.0 + clarify per-check tool deps

### DIFF
--- a/.github/workflows/ss-hygiene-complexity-check.yml
+++ b/.github/workflows/ss-hygiene-complexity-check.yml
@@ -49,7 +49,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
+            pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl"
           fi
 
       - name: Run complexity analysis

--- a/.github/workflows/ss-hygiene-complexity-check.yml
+++ b/.github/workflows/ss-hygiene-complexity-check.yml
@@ -49,7 +49,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
           fi
 
       - name: Run complexity analysis

--- a/.github/workflows/ss-hygiene-csp-exceptions-check.yml
+++ b/.github/workflows/ss-hygiene-csp-exceptions-check.yml
@@ -47,7 +47,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
           fi
 
       - name: Run CSP exceptions check

--- a/.github/workflows/ss-hygiene-csp-exceptions-check.yml
+++ b/.github/workflows/ss-hygiene-csp-exceptions-check.yml
@@ -47,7 +47,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
+            pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl"
           fi
 
       - name: Run CSP exceptions check

--- a/.github/workflows/ss-hygiene-docs-accuracy-check.yml
+++ b/.github/workflows/ss-hygiene-docs-accuracy-check.yml
@@ -79,7 +79,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
+            pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl"
           fi
 
       - name: Run documentation accuracy check

--- a/.github/workflows/ss-hygiene-docs-accuracy-check.yml
+++ b/.github/workflows/ss-hygiene-docs-accuracy-check.yml
@@ -79,7 +79,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
           fi
 
       - name: Run documentation accuracy check

--- a/.github/workflows/ss-hygiene-docs-size-check.yml
+++ b/.github/workflows/ss-hygiene-docs-size-check.yml
@@ -47,7 +47,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
           fi
 
       - name: Run documentation size check

--- a/.github/workflows/ss-hygiene-docs-size-check.yml
+++ b/.github/workflows/ss-hygiene-docs-size-check.yml
@@ -47,7 +47,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
+            pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl"
           fi
 
       - name: Run documentation size check

--- a/.github/workflows/ss-hygiene-docs-structure-check.yml
+++ b/.github/workflows/ss-hygiene-docs-structure-check.yml
@@ -49,7 +49,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
+            pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl"
           fi
 
       - name: Run documentation structure check

--- a/.github/workflows/ss-hygiene-docs-structure-check.yml
+++ b/.github/workflows/ss-hygiene-docs-structure-check.yml
@@ -49,7 +49,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
           fi
 
       - name: Run documentation structure check

--- a/.github/workflows/ss-hygiene-entry-files-check.yml
+++ b/.github/workflows/ss-hygiene-entry-files-check.yml
@@ -49,7 +49,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
           fi
 
       - name: Run entry-file budget check

--- a/.github/workflows/ss-hygiene-entry-files-check.yml
+++ b/.github/workflows/ss-hygiene-entry-files-check.yml
@@ -49,7 +49,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
+            pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl"
           fi
 
       - name: Run entry-file budget check

--- a/.github/workflows/ss-reliability-accessibility-check.yml
+++ b/.github/workflows/ss-reliability-accessibility-check.yml
@@ -85,7 +85,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
           fi
 
       - name: Determine audit URL

--- a/.github/workflows/ss-reliability-accessibility-check.yml
+++ b/.github/workflows/ss-reliability-accessibility-check.yml
@@ -85,7 +85,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
+            pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl"
           fi
 
       - name: Determine audit URL

--- a/.github/workflows/ss-reliability-broken-links-check.yml
+++ b/.github/workflows/ss-reliability-broken-links-check.yml
@@ -77,7 +77,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
+            pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl"
           fi
 
       - name: Determine check URL

--- a/.github/workflows/ss-reliability-broken-links-check.yml
+++ b/.github/workflows/ss-reliability-broken-links-check.yml
@@ -77,7 +77,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
           fi
 
       - name: Determine check URL

--- a/.github/workflows/ss-reliability-core-web-vitals.yml
+++ b/.github/workflows/ss-reliability-core-web-vitals.yml
@@ -69,7 +69,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
+            pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl"
           fi
 
       # ── Local server (PR / push to main) ────────────────────────────────────

--- a/.github/workflows/ss-reliability-core-web-vitals.yml
+++ b/.github/workflows/ss-reliability-core-web-vitals.yml
@@ -69,7 +69,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
           fi
 
       # ── Local server (PR / push to main) ────────────────────────────────────

--- a/.github/workflows/ss-reliability-seo-check.yml
+++ b/.github/workflows/ss-reliability-seo-check.yml
@@ -67,7 +67,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
+            pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl"
           fi
 
       - name: Determine audit URL

--- a/.github/workflows/ss-reliability-seo-check.yml
+++ b/.github/workflows/ss-reliability-seo-check.yml
@@ -67,7 +67,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
           fi
 
       - name: Determine audit URL

--- a/.github/workflows/ss-reliability-smoke-tests.yml
+++ b/.github/workflows/ss-reliability-smoke-tests.yml
@@ -72,7 +72,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
           fi
 
       - name: Determine test URL

--- a/.github/workflows/ss-reliability-smoke-tests.yml
+++ b/.github/workflows/ss-reliability-smoke-tests.yml
@@ -72,7 +72,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
+            pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl"
           fi
 
       - name: Determine test URL

--- a/.github/workflows/ss-security-dast-check.yml
+++ b/.github/workflows/ss-security-dast-check.yml
@@ -44,7 +44,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
           fi
 
       - name: Set up Node.js

--- a/.github/workflows/ss-security-dast-check.yml
+++ b/.github/workflows/ss-security-dast-check.yml
@@ -44,7 +44,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
+            pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl"
           fi
 
       - name: Set up Node.js

--- a/.github/workflows/ss-security-sast-check.yml
+++ b/.github/workflows/ss-security-sast-check.yml
@@ -46,7 +46,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
+            pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl"
           fi
 
       - name: Run SAST analysis

--- a/.github/workflows/ss-security-sast-check.yml
+++ b/.github/workflows/ss-security-sast-check.yml
@@ -46,7 +46,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
           fi
 
       - name: Run SAST analysis

--- a/.github/workflows/ss-security-secrets-check.yml
+++ b/.github/workflows/ss-security-secrets-check.yml
@@ -65,7 +65,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
+            pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl"
           fi
 
       - name: Run secrets detection

--- a/.github/workflows/ss-security-secrets-check.yml
+++ b/.github/workflows/ss-security-secrets-check.yml
@@ -65,7 +65,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
           fi
 
       - name: Run secrets detection

--- a/.github/workflows/ss-security-vulnerability-all-check.yml
+++ b/.github/workflows/ss-security-vulnerability-all-check.yml
@@ -52,7 +52,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
+            pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl"
           fi
 
       - name: Run dependency scan

--- a/.github/workflows/ss-security-vulnerability-all-check.yml
+++ b/.github/workflows/ss-security-vulnerability-all-check.yml
@@ -52,7 +52,7 @@ jobs:
           if [ -f cli/pyproject.toml ]; then
             pip install -e ./cli
           else
-            pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+            pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
           fi
 
       - name: Run dependency scan

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 The CLI alone (most use cases):
 
 ```bash
-pipx install git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli
+pipx install git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli
 slopstopper checks list             # see what's available
 slopstopper doctor                  # verify the external tools you'll need
 slopstopper run hygiene:docs-size   # run a check (writes .ss/reports/...)
@@ -41,12 +41,23 @@ curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/ins
 
 ## Prerequisites
 
-- **Python 3.11+** — slopstopper-cli runs here; `pipx` recommended (`brew install pipx`)
-- **Node 20+** — Playwright, Lighthouse CI, markdownlint, bundled `slopstopper serve`
-- **Git + bash** — for `install.sh` and the CI workflows
-- **Task v3.x** *(optional)* — adopters who use `task` get a thin `task ss:*` shim layer
-- **Docker** — only needed for DAST (OWASP ZAP runs in a container)
-- **`gh` CLI** — only needed for `slopstopper emit` (PR comments / issues from CI)
+slopstopper-cli itself only needs Python. Each check subprocess-invokes its underlying tool (`semgrep`, `gitleaks`, `trivy`, `lizard`, `docker`, `node`) — deliberate licensing-boundary design. You install only the tools for checks you actually use; `slopstopper doctor` tells you what's installed and what's missing.
+
+- **Python 3.11+** — `pipx` recommended (`brew install pipx`)
+
+Per-check tools (skip if you've disabled the check):
+
+| Tool | Needed by | Install hint |
+| ---- | --------- | ------------ |
+| `node` 20+ | Reliability checks (Playwright + Lighthouse), `slopstopper serve` | [nodejs.org](https://nodejs.org/) |
+| `gh` | `slopstopper emit` (PR comments + issues from CI) | [cli.github.com](https://cli.github.com/) |
+| `lizard` | `hygiene:complexity` | `pip install --user lizard` (**not** brew — that's lz4) |
+| `semgrep` | `security:sast` | `pip install --user semgrep` |
+| `gitleaks` | `security:secrets` | `brew install gitleaks` |
+| `trivy` | `security:dependencies` | `brew install aquasecurity/trivy/trivy` |
+| `docker` | `security:dast` | [docs.docker.com/get-docker](https://docs.docker.com/get-docker/) |
+
+Optional: **bash + git** (if using `install.sh`), **Task v3.x** (for the `task ss:*` shim layer).
 
 ## What gets installed
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 The CLI alone (most use cases):
 
 ```bash
-pipx install git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli
+pipx install https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl
 slopstopper checks list             # see what's available
 slopstopper doctor                  # verify the external tools you'll need
 slopstopper run hygiene:docs-size   # run a check (writes .ss/reports/...)
 ```
 
-> Installing from git while we get the PyPI release pipeline up. Once `slopstopper-cli` is on PyPI the command will collapse to `pipx install slopstopper-cli` — `pipx upgrade slopstopper-cli` already works for refresh either way.
+> Installing the pre-built wheel attached to the [v0.2.0 GitHub Release](https://github.com/hungovercoders/slopstopper/releases/tag/v0.2.0). Once `slopstopper-cli` lands on PyPI this collapses to `pipx install slopstopper-cli`. `pipx upgrade slopstopper-cli` works regardless of source.
 
 The full suite into a repo (CLI + GitHub Actions workflows + Taskfile shim + config seed):
 

--- a/app/features.html
+++ b/app/features.html
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli" && pip install semgrep
+      - run: pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl" && pip install semgrep
       - run: slopstopper run security:sast
       - if: github.event_name == 'pull_request'
         run: slopstopper emit security:sast --target pr-comment</code></pre></div>
@@ -104,7 +104,7 @@ jobs:
     name: Dynamic Application Security Testing with OWASP ZAP
     steps:
       - uses: actions/checkout@v4
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
+      - run: pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl"
       - run: npm ci &amp;&amp; npm run build &amp;&amp; slopstopper serve &amp;
       - run: slopstopper run security:dast -- --target http://localhost:8080
       - if: github.event_name == 'pull_request'
@@ -126,7 +126,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli" && curl -sL gitleaks/install.sh | bash
+      - run: pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl" && curl -sL gitleaks/install.sh | bash
       - run: slopstopper run security:secrets
       - if: github.event_name == 'pull_request'
         run: slopstopper emit security:secrets --target pr-comment</code></pre></div>
@@ -146,7 +146,7 @@ jobs:
     name: Scan Dependencies with Trivy
     steps:
       - uses: actions/checkout@v4
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli" && brew install aquasecurity/trivy/trivy
+      - run: pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl" && brew install aquasecurity/trivy/trivy
       - run: slopstopper run security:dependencies
       - if: github.event_name == 'pull_request'
         run: slopstopper emit security:dependencies --target pr-comment</code></pre></div>
@@ -183,7 +183,7 @@ jobs:
     name: Check Code Complexity with Lizard
     steps:
       - uses: actions/checkout@v4
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli" lizard
+      - run: pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl" lizard
       - run: slopstopper run hygiene:complexity
       - if: github.event_name == 'pull_request'
         run: slopstopper emit hygiene:complexity --target pr-comment</code></pre></div>
@@ -223,7 +223,7 @@ jobs:
   check-csp-exceptions:
     steps:
       - uses: actions/checkout@v4
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
+      - run: pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl"
       - run: slopstopper run hygiene:csp-exceptions
       - if: github.event_name == 'pull_request'
         run: slopstopper emit hygiene:csp-exceptions --target pr-comment</code></pre></div>
@@ -278,7 +278,7 @@ jobs:
   smoke-test:
     steps:
       - uses: actions/checkout@v4
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli" &amp;&amp; npm ci
+      - run: pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl" &amp;&amp; npm ci
       - run: npm run build &amp;&amp; slopstopper serve &amp;
       - run: slopstopper run reliability:smoke -- --ci
       - if: github.event_name == 'pull_request'
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli" &amp;&amp; npm ci
+      - run: pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl" &amp;&amp; npm ci
       - run: npm run build &amp;&amp; slopstopper serve &amp;
       - run: slopstopper run reliability:broken-links -- --ci
       - if: github.event_name == 'pull_request'
@@ -325,7 +325,7 @@ jobs:
     name: Accessibility Audit (axe-core / WCAG 2.1 AA)
     steps:
       - uses: actions/checkout@v4
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli" &amp;&amp; npm ci
+      - run: pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl" &amp;&amp; npm ci
       - run: npm run build &amp;&amp; slopstopper serve &amp;
       - run: slopstopper run reliability:accessibility -- --ci
       - if: github.event_name == 'pull_request'
@@ -348,7 +348,7 @@ jobs:
     name: Core Web Vitals (Lighthouse CI)
     steps:
       - uses: actions/checkout@v4
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli" &amp;&amp; npm ci &amp;&amp; npm run build
+      - run: pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl" &amp;&amp; npm ci &amp;&amp; npm run build
       - run: slopstopper serve &amp;
       - run: slopstopper run reliability:cwv -- --url http://localhost:8080
       - if: github.event_name == 'pull_request'
@@ -371,7 +371,7 @@ jobs:
     name: SEO Metatag Audit (OpenGraph + Twitter Card + canonical)
     steps:
       - uses: actions/checkout@v4
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli" &amp;&amp; npm ci
+      - run: pip install "https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl" &amp;&amp; npm ci
       - run: npm run build &amp;&amp; slopstopper serve &amp;
       - run: slopstopper run reliability:seo   # title, description, canonical,
                                                # og:*, twitter:*, og:image fetch

--- a/app/features.html
+++ b/app/features.html
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli" && pip install semgrep
+      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli" && pip install semgrep
       - run: slopstopper run security:sast
       - if: github.event_name == 'pull_request'
         run: slopstopper emit security:sast --target pr-comment</code></pre></div>
@@ -104,7 +104,7 @@ jobs:
     name: Dynamic Application Security Testing with OWASP ZAP
     steps:
       - uses: actions/checkout@v4
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
       - run: npm ci &amp;&amp; npm run build &amp;&amp; slopstopper serve &amp;
       - run: slopstopper run security:dast -- --target http://localhost:8080
       - if: github.event_name == 'pull_request'
@@ -126,7 +126,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli" && curl -sL gitleaks/install.sh | bash
+      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli" && curl -sL gitleaks/install.sh | bash
       - run: slopstopper run security:secrets
       - if: github.event_name == 'pull_request'
         run: slopstopper emit security:secrets --target pr-comment</code></pre></div>
@@ -146,7 +146,7 @@ jobs:
     name: Scan Dependencies with Trivy
     steps:
       - uses: actions/checkout@v4
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli" && brew install aquasecurity/trivy/trivy
+      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli" && brew install aquasecurity/trivy/trivy
       - run: slopstopper run security:dependencies
       - if: github.event_name == 'pull_request'
         run: slopstopper emit security:dependencies --target pr-comment</code></pre></div>
@@ -183,7 +183,7 @@ jobs:
     name: Check Code Complexity with Lizard
     steps:
       - uses: actions/checkout@v4
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli" lizard
+      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli" lizard
       - run: slopstopper run hygiene:complexity
       - if: github.event_name == 'pull_request'
         run: slopstopper emit hygiene:complexity --target pr-comment</code></pre></div>
@@ -223,7 +223,7 @@ jobs:
   check-csp-exceptions:
     steps:
       - uses: actions/checkout@v4
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
       - run: slopstopper run hygiene:csp-exceptions
       - if: github.event_name == 'pull_request'
         run: slopstopper emit hygiene:csp-exceptions --target pr-comment</code></pre></div>
@@ -278,7 +278,7 @@ jobs:
   smoke-test:
     steps:
       - uses: actions/checkout@v4
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli" &amp;&amp; npm ci
+      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli" &amp;&amp; npm ci
       - run: npm run build &amp;&amp; slopstopper serve &amp;
       - run: slopstopper run reliability:smoke -- --ci
       - if: github.event_name == 'pull_request'
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli" &amp;&amp; npm ci
+      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli" &amp;&amp; npm ci
       - run: npm run build &amp;&amp; slopstopper serve &amp;
       - run: slopstopper run reliability:broken-links -- --ci
       - if: github.event_name == 'pull_request'
@@ -325,7 +325,7 @@ jobs:
     name: Accessibility Audit (axe-core / WCAG 2.1 AA)
     steps:
       - uses: actions/checkout@v4
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli" &amp;&amp; npm ci
+      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli" &amp;&amp; npm ci
       - run: npm run build &amp;&amp; slopstopper serve &amp;
       - run: slopstopper run reliability:accessibility -- --ci
       - if: github.event_name == 'pull_request'
@@ -348,7 +348,7 @@ jobs:
     name: Core Web Vitals (Lighthouse CI)
     steps:
       - uses: actions/checkout@v4
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli" &amp;&amp; npm ci &amp;&amp; npm run build
+      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli" &amp;&amp; npm ci &amp;&amp; npm run build
       - run: slopstopper serve &amp;
       - run: slopstopper run reliability:cwv -- --url http://localhost:8080
       - if: github.event_name == 'pull_request'
@@ -371,7 +371,7 @@ jobs:
     name: SEO Metatag Audit (OpenGraph + Twitter Card + canonical)
     steps:
       - uses: actions/checkout@v4
-      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli" &amp;&amp; npm ci
+      - run: pip install "git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli" &amp;&amp; npm ci
       - run: npm run build &amp;&amp; slopstopper serve &amp;
       - run: slopstopper run reliability:seo   # title, description, canonical,
                                                # og:*, twitter:*, og:image fetch

--- a/app/index.html
+++ b/app/index.html
@@ -91,12 +91,12 @@
             <p class="lede">SlopStopper is a Python CLI plus the GitHub Actions workflows that drive it. Install the CLI alone for local use, or run the all-in-one installer to also seed the workflows + Taskfile shim into a repo.</p>
             <h3 class="install-heading">Just the CLI</h3>
             <div class="codeblock codeblock--sh" role="region" aria-label="Install slopstopper-cli via pipx" data-copyable>
-                <pre><code>pipx install git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli
+                <pre><code>pipx install https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl
 slopstopper checks list
 slopstopper doctor
 slopstopper run hygiene:docs-size</code></pre>
             </div>
-            <p class="install-subnote">Installing from git, pinned to a tagged release while we get the PyPI release pipeline up; the short <code>pipx install slopstopper-cli</code> form lands soon. <code>pipx upgrade slopstopper-cli</code> already keeps it fresh either way. The CLI itself only needs Python — per-check tools (<code>node</code>, <code>semgrep</code>, <code>gitleaks</code>, <code>trivy</code>, <code>lizard</code>, <code>docker</code>) install per the checks you actually use; run <code>slopstopper doctor</code> to see what's missing.</p>
+            <p class="install-subnote">Installing the pre-built wheel attached to the <a href="https://github.com/hungovercoders/slopstopper/releases/tag/v0.2.0">v0.2.0 GitHub Release</a>. The short <code>pipx install slopstopper-cli</code> form lands once PyPI is wired up; <code>pipx upgrade slopstopper-cli</code> works regardless. The CLI itself only needs Python — per-check tools (<code>node</code>, <code>semgrep</code>, <code>gitleaks</code>, <code>trivy</code>, <code>lizard</code>, <code>docker</code>) install per the checks you actually use; run <code>slopstopper doctor</code> to see what's missing.</p>
             <h3 class="install-heading">Full suite into a repo</h3>
             <div class="codeblock codeblock--sh" role="region" aria-label="Install full suite" data-copyable>
                 <pre><code>curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install.sh | bash</code></pre>

--- a/app/index.html
+++ b/app/index.html
@@ -91,12 +91,12 @@
             <p class="lede">SlopStopper is a Python CLI plus the GitHub Actions workflows that drive it. Install the CLI alone for local use, or run the all-in-one installer to also seed the workflows + Taskfile shim into a repo.</p>
             <h3 class="install-heading">Just the CLI</h3>
             <div class="codeblock codeblock--sh" role="region" aria-label="Install slopstopper-cli via pipx" data-copyable>
-                <pre><code>pipx install git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli
+                <pre><code>pipx install git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli
 slopstopper checks list
 slopstopper doctor
 slopstopper run hygiene:docs-size</code></pre>
             </div>
-            <p class="install-subnote">Installing from git while we get the PyPI release pipeline up; the short <code>pipx install slopstopper-cli</code> form lands soon. <code>pipx upgrade slopstopper-cli</code> already keeps it fresh either way.</p>
+            <p class="install-subnote">Installing from git, pinned to a tagged release while we get the PyPI release pipeline up; the short <code>pipx install slopstopper-cli</code> form lands soon. <code>pipx upgrade slopstopper-cli</code> already keeps it fresh either way. The CLI itself only needs Python — per-check tools (<code>node</code>, <code>semgrep</code>, <code>gitleaks</code>, <code>trivy</code>, <code>lizard</code>, <code>docker</code>) install per the checks you actually use; run <code>slopstopper doctor</code> to see what's missing.</p>
             <h3 class="install-heading">Full suite into a repo</h3>
             <div class="codeblock codeblock--sh" role="region" aria-label="Install full suite" data-copyable>
                 <pre><code>curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install.sh | bash</code></pre>

--- a/app/tools.html
+++ b/app/tools.html
@@ -60,7 +60,7 @@
         <div class="card-grid">
             <div class="card">
                 <h2>🐍 slopstopper-cli</h2>
-                <p>The Python package every check, report and PR comment goes through. Install from git today (<code>pipx install git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli</code>) — the short PyPI form lands once the release pipeline is up.</p>
+                <p>The Python package every check, report and PR comment goes through. Install from git today (<code>pipx install git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli</code>) — the short PyPI form lands once the release pipeline is up.</p>
                 <details class="details">
                     <summary>CLI surface</summary>
                     <div class="details__body">

--- a/app/tools.html
+++ b/app/tools.html
@@ -60,7 +60,7 @@
         <div class="card-grid">
             <div class="card">
                 <h2>🐍 slopstopper-cli</h2>
-                <p>The Python package every check, report and PR comment goes through. Install from git today (<code>pipx install git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli</code>) — the short PyPI form lands once the release pipeline is up.</p>
+                <p>The Python package every check, report and PR comment goes through. Install the <a href="https://github.com/hungovercoders/slopstopper/releases/tag/v0.2.0">v0.2.0 release</a> wheel — the short <code>pipx install slopstopper-cli</code> form lands once PyPI is wired up.</p>
                 <details class="details">
                     <summary>CLI surface</summary>
                     <div class="details__body">

--- a/cli/README.md
+++ b/cli/README.md
@@ -9,13 +9,13 @@ The SlopStopper quality suite, packaged as a `pipx`-installable CLI.
 End-user (most adopters):
 
 ```bash
-pipx install git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli
+pipx install https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl
 slopstopper --version
 slopstopper checks list
 slopstopper doctor
 ```
 
-> Installing from git until the PyPI release pipeline is up. Once published the command collapses to `pipx install slopstopper-cli`. `pipx upgrade slopstopper-cli` already works for refresh.
+> Installing the pre-built wheel from the [v0.2.0 GitHub Release](https://github.com/hungovercoders/slopstopper/releases/tag/v0.2.0). Once `slopstopper-cli` lands on PyPI this collapses to `pipx install slopstopper-cli`. `pipx upgrade slopstopper-cli` works regardless of source.
 
 Development (editable, from a clone of this repo):
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -9,7 +9,7 @@ The SlopStopper quality suite, packaged as a `pipx`-installable CLI.
 End-user (most adopters):
 
 ```bash
-pipx install git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli
+pipx install git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli
 slopstopper --version
 slopstopper checks list
 slopstopper doctor

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -29,7 +29,7 @@ slopstopper/
 │   ├── slopstopper/data/     # Bundled Playwright specs, lighthouserc dev/prod, server.js
 │   ├── slopstopper/templates.py / emit.py / discovery.py / config.py
 │   ├── tests/                # pytest suite (486 tests)
-│   └── pyproject.toml        # 0.2.0 Beta — install: `pipx install git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli`
+│   └── pyproject.toml        # 0.2.0 Beta — install: `pipx install git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli`
 ├── app/                      # Static site — bound as the [assets] dir on the Worker
 │   ├── index.html            # Hero + Get Started (pipx install) + capability grid
 │   ├── features.html         # 5 category cards with workflow excerpts + mock reports

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -29,7 +29,7 @@ slopstopper/
 │   ├── slopstopper/data/     # Bundled Playwright specs, lighthouserc dev/prod, server.js
 │   ├── slopstopper/templates.py / emit.py / discovery.py / config.py
 │   ├── tests/                # pytest suite (486 tests)
-│   └── pyproject.toml        # 0.2.0 Beta — install: `pipx install git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli`
+│   └── pyproject.toml        # 0.2.0 Beta — install: `pipx install https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl`
 ├── app/                      # Static site — bound as the [assets] dir on the Worker
 │   ├── index.html            # Hero + Get Started (pipx install) + capability grid
 │   ├── features.html         # 5 category cards with workflow excerpts + mock reports

--- a/docs/runbooks/RELEASE.md
+++ b/docs/runbooks/RELEASE.md
@@ -38,16 +38,23 @@ If in doubt, prefer a MINOR bump over a PATCH.
 
    The release workflow has a sanity-check step that fails the build if these diverge from the tag.
 
-4. **Bump the pinned install URL** across docs, the website, `install.sh`, and every `ss-*-check.yml` workflow. The pattern to replace is `@vOLD#subdirectory=cli` → `@vNEW#subdirectory=cli`:
+4. **Bump the pinned wheel URL** across docs, the website, `install.sh`, and every `ss-*-check.yml` workflow. Adopters install the pre-built wheel attached to the GitHub Release, not a git URL — so the version appears twice (release path + filename). The pattern is:
+
+   ```
+   https://github.com/hungovercoders/slopstopper/releases/download/vX.Y.Z/slopstopper_cli-X.Y.Z-py3-none-any.whl
+   ```
+
+   One-liner to swap the version everywhere:
 
    ```bash
-   # From the repo root, swap the old tag for the new one everywhere:
-   git ls-files | xargs grep -l "@vOLD#subdirectory=cli" 2>/dev/null \
-     | xargs sed -i.bak "s|@vOLD#subdirectory=cli|@vNEW#subdirectory=cli|g" \
+   # From the repo root — replace OLD and NEW with the version numbers (no leading v):
+   OLD=0.2.0 NEW=0.3.0
+   git ls-files | xargs grep -l "releases/download/v$OLD" 2>/dev/null \
+     | xargs sed -i.bak -e "s|releases/download/v$OLD/slopstopper_cli-$OLD|releases/download/v$NEW/slopstopper_cli-$NEW|g" \
      && find . -name '*.bak' -delete
    ```
 
-   This keeps adopters' fresh installs pinned to a known-good release and slopstopper.dev's own CI (which uses the editable install when `cli/` is present) unaffected.
+   The release tag URL (e.g. `releases/tag/v0.2.0`) also appears in user-facing copy as a "see the release" link — bump those too. Slopstopper.dev's own CI uses the editable install of `cli/` when `cli/pyproject.toml` is present, so it dogfoods `main` regardless of the pinned wheel URL.
 
 5. **Commit + push** the CHANGELOG, version bumps and URL bumps as a single commit (`chore(release): bump version to X.Y.Z`). Open a PR if you want CI to pre-verify; otherwise push straight to `main` if you have permission.
 

--- a/docs/runbooks/RELEASE.md
+++ b/docs/runbooks/RELEASE.md
@@ -38,22 +38,33 @@ If in doubt, prefer a MINOR bump over a PATCH.
 
    The release workflow has a sanity-check step that fails the build if these diverge from the tag.
 
-4. **Commit + push** the CHANGELOG and version bumps as a single commit (`chore(release): bump version to X.Y.Z`). Open a PR if you want CI to pre-verify; otherwise push straight to `main` if you have permission.
+4. **Bump the pinned install URL** across docs, the website, `install.sh`, and every `ss-*-check.yml` workflow. The pattern to replace is `@vOLD#subdirectory=cli` → `@vNEW#subdirectory=cli`:
 
-5. **Tag + push.** Once the bump commit is on `main`:
+   ```bash
+   # From the repo root, swap the old tag for the new one everywhere:
+   git ls-files | xargs grep -l "@vOLD#subdirectory=cli" 2>/dev/null \
+     | xargs sed -i.bak "s|@vOLD#subdirectory=cli|@vNEW#subdirectory=cli|g" \
+     && find . -name '*.bak' -delete
+   ```
+
+   This keeps adopters' fresh installs pinned to a known-good release and slopstopper.dev's own CI (which uses the editable install when `cli/` is present) unaffected.
+
+5. **Commit + push** the CHANGELOG, version bumps and URL bumps as a single commit (`chore(release): bump version to X.Y.Z`). Open a PR if you want CI to pre-verify; otherwise push straight to `main` if you have permission.
+
+6. **Tag + push.** Once the bump commit is on `main`:
 
    ```bash
    git tag vX.Y.Z -m "X.Y.Z"
    git push origin vX.Y.Z
    ```
 
-6. **Watch the workflow.** The `SlopStopper · Release` workflow runs against the tag. It will:
+7. **Watch the workflow.** The `SlopStopper · Release` workflow runs against the tag. It will:
    - Verify versions match the tag.
    - Build wheel + sdist with `python -m build` (uses `hatchling`).
    - Extract the matching `## [X.Y.Z]` section from `CHANGELOG.md`.
    - Create the GitHub Release with that body and both artifacts attached.
 
-7. **Verify the release.** Open [Releases](https://github.com/hungovercoders/slopstopper/releases). Sanity-check the body, download the wheel, run `pipx install <path-to-wheel>` somewhere and confirm `slopstopper --version` matches.
+8. **Verify the release.** Open [Releases](https://github.com/hungovercoders/slopstopper/releases). Sanity-check the body, download the wheel, run `pipx install <path-to-wheel>` somewhere and confirm `slopstopper --version` matches.
 
 ## Manual re-release
 

--- a/install.sh
+++ b/install.sh
@@ -185,7 +185,7 @@ fi
 # If an `.ss/` overlay (specs, playwright config, lighthouse config) is
 # already present in the target, the CLI's templates module prefers
 # those files over the package data — same shape as the workflows.
-SLOPSTOPPER_CLI_GIT="git+https://github.com/hungovercoders/slopstopper.git@main#subdirectory=cli"
+SLOPSTOPPER_CLI_GIT="git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
 
 install_cli() {
   if command -v pipx &>/dev/null; then

--- a/install.sh
+++ b/install.sh
@@ -185,7 +185,7 @@ fi
 # If an `.ss/` overlay (specs, playwright config, lighthouse config) is
 # already present in the target, the CLI's templates module prefers
 # those files over the package data — same shape as the workflows.
-SLOPSTOPPER_CLI_GIT="git+https://github.com/hungovercoders/slopstopper.git@v0.2.0#subdirectory=cli"
+SLOPSTOPPER_CLI_GIT="https://github.com/hungovercoders/slopstopper/releases/download/v0.2.0/slopstopper_cli-0.2.0-py3-none-any.whl"
 
 install_cli() {
   if command -v pipx &>/dev/null; then


### PR DESCRIPTION
## Summary

Two user questions, both addressed here.

### 1. Pin every adopter-facing git install URL to @v0.2.0

Now that v0.2.0 is a real release (wheel + sdist attached to a GitHub Release), `@main` for the adopter install command is wrong — it tracks bleeding edge and can change behaviour between installs without warning.

Every occurrence of `git+https://...slopstopper.git@main#subdirectory=cli` → `@v0.2.0`. 22 files: `install.sh`, `README.md`, `cli/README.md`, `app/{index,features,tools}.html`, `docs/architecture/README.md`, and every `.github/workflows/ss-*-check.yml` adopter-fallback `pip install` line.

slopstopper.dev's own workflows always hit the editable-install branch (`pip install -e ./cli`) since `cli/pyproject.toml` exists — this repo keeps dogfooding `main`. Only adopters who copy a workflow into their own repo land on the pinned fallback.

`pipx upgrade slopstopper-cli` still works because pipx tracks by package name regardless of install source.

### 2. Make per-check tool dependencies discoverable in the README

The CLI subprocess-invokes lizard/semgrep/gitleaks/trivy/docker/node — deliberate licensing boundary. Adopters need to install those tools themselves. The auto-fail-with-hint surfaces this at run time (every check has an `_INSTALL_HELP` constant) and `slopstopper doctor` walks the lot, but the README never made the model explicit.

- README Prerequisites: opens with "the CLI only needs Python; each check subprocess-invokes its tool" and shows a per-check tool table with install hints. Points at `slopstopper doctor` as the canonical verifier.
- `app/index.html` install-subnote extended with the same summary.
- README stays under budget at 1424/1500 words.

### 3. Release runbook update

Added "Bump the pinned install URL" as a new step in `docs/runbooks/RELEASE.md` with a one-liner sed recipe for the swap. Renumbered subsequent steps.

## Test plan

- [x] `cli/.venv/bin/pytest cli/tests/` — 486 passing.
- [x] All hygiene checks clean (docs-accuracy, entry-files, docs-structure, docs-size).
- [x] `grep -rln "@main#subdirectory=cli"` returns nothing.
- [ ] CI: every `ss-*` workflow green; Cloudflare Pages preview renders the new front page text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)