### PR TITLE
fix(release): tighten sanity-check sed to handle trailing marker comment

### DIFF
--- a/.github/workflows/ss-release.yml
+++ b/.github/workflows/ss-release.yml
@@ -55,8 +55,12 @@ jobs:
         env:
           VERSION: ${{ steps.tag.outputs.version }}
         run: |
-          PYPROJECT_VER=$(grep -m1 '^version = ' cli/pyproject.toml | sed -E 's/version = "(.*)"/\1/')
-          INIT_VER=$(grep -m1 '__version__' cli/slopstopper/__init__.py | sed -E 's/__version__ = "(.*)"/\1/')
+          # Use [^"]+ to bound the capture and .* on both sides so any
+          # trailing content (e.g. release-please's
+          # `# x-release-please-version` marker on __init__.py) is
+          # consumed cleanly instead of being included in the version.
+          PYPROJECT_VER=$(grep -m1 '^version = ' cli/pyproject.toml | sed -E 's/.*= "([^"]+)".*/\1/')
+          INIT_VER=$(grep -m1 '__version__' cli/slopstopper/__init__.py | sed -E 's/.*= "([^"]+)".*/\1/')
           echo "pyproject:     $PYPROJECT_VER"
           echo "__init__.py:   $INIT_VER"
           echo "tag (without v): $VERSION"


### PR DESCRIPTION
## Summary

The first release-please-driven release (v0.4.0) failed its sanity check with:

\`\`\`
pyproject:     0.4.0
__init__.py:   0.4.0  # x-release-please-version
tag (without v): 0.4.0
##[error]Version mismatch — ...
\`\`\`

Cause: the regex \`s/__version__ = "(.*)"/\\1/\` substitutes only the matched prefix and leaves the trailing \`# x-release-please-version\` marker attached to the version variable. The marker comment is what release-please uses to find the line to bump in \`__init__.py\` — it has to stay.

Fix: anchor both sides — \`s/.*= "([^"]+)".*/\\1/\`. \`[^"]+\` bounds the capture to the quoted version string; \`.*\` on either side consumes everything outside the quotes. Applied to both \`PYPROJECT_VER\` and \`INIT_VER\` (pyproject happened to work by accident because there's no trailing comment today, but the same pattern is safer).

Local check against the v0.4.0 tag content:

\`\`\`
pyproject:   0.4.0
__init__.py: 0.4.0
\`\`\`

## After merge

Re-dispatch \`ss-release.yml\` against v0.4.0 from the Actions tab. The sanity check should pass and the rest of the chain (build → attest → upload → PyPI publish) will run as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)