### PR TITLE
feat(release-please): mint App token to eliminate manual release touch points

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,8 +36,24 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived GitHub App installation token instead of using
+      # GITHUB_TOKEN. Two reasons:
+      #   * PRs opened by GITHUB_TOKEN have all their `pull_request`
+      #     workflows silently skipped (anti-recursion). App-authored PRs
+      #     are exempt, so PR CI runs automatically with no approval click.
+      #   * Tags pushed by GITHUB_TOKEN don't fire other tag-triggered
+      #     workflows (same anti-recursion rule). App-pushed tags do —
+      #     so the v* tag this workflow creates auto-fires ss-release.yml.
+      - name: Mint App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - name: Run release-please
         uses: googleapis/release-please-action@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

Closes the two remaining manual touch points on every release. Both stem from GitHub's anti-recursion rule: events caused by \`GITHUB_TOKEN\` don't trigger downstream workflows. Today that means:

1. **PRs opened by \`GITHUB_TOKEN\`** have all their \`pull_request\` workflows silently skipped → you click "Approve and run workflows" on every rolling Release PR.
2. **Tags pushed by \`GITHUB_TOKEN\`** don't fire other tag-triggered workflows → \`ss-release.yml\` doesn't auto-fire when release-please cuts a tag; someone has to dispatch it manually.

App-authored PRs and App-pushed tags are exempt from both rules. So this PR mints a short-lived installation token from the **SlopStopper Release Bot** GitHub App (created today, installed on this repo only) and passes it to release-please-action via its \`token:\` input.

## What changes

\`\`\`yaml
- name: Mint App token
  id: app-token
  uses: actions/create-github-app-token@v2
  with:
    app-id: \${{ secrets.RELEASE_PLEASE_APP_ID }}
    private-key: \${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}

- name: Run release-please
  uses: googleapis/release-please-action@v4
  with:
    token: \${{ steps.app-token.outputs.token }}     # <-- new
    config-file: release-please-config.json
    manifest-file: .release-please-manifest.json
\`\`\`

That's the entire diff. 16 lines added, 0 removed.

## Required secrets (already configured)

- \`RELEASE_PLEASE_APP_ID\` — the numeric App ID.
- \`RELEASE_PLEASE_APP_PRIVATE_KEY\` — the App's private key (.pem contents).

Both verified present on the repo:
\`\`\`
RELEASE_PLEASE_APP_ID            2026-06-14T14:37:26Z
RELEASE_PLEASE_APP_PRIVATE_KEY   2026-06-14T14:53:38Z
\`\`\`

## After-state release flow

1. Write conventional-commit PRs (\`feat:\`, \`fix:\`, etc.).
2. release-please opens / updates a rolling Release PR — **CI runs automatically** (no click).
3. Merge the Release PR.
4. The App pushes the \`vX.Y.Z\` tag — **\`ss-release.yml\` fires automatically**.
5. ss-release.yml builds, attests, uploads to GH Release, publishes to PyPI.

Zero further human input per release.

## Test plan

- [ ] PR CI green.
- [ ] After merge: confirm the next \`feat:\` or \`fix:\` commit pushed to main triggers release-please, opens a Release PR, and that PR's checks run automatically without the "Approve and run workflows" prompt.
- [ ] After merging that Release PR: the resulting \`v*\` tag should fire ss-release.yml without manual dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)