### PR TITLE
fix(cli): make complexity, playwright, serve work out of the box

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -38,16 +38,20 @@ classifiers = [
   "Operating System :: POSIX",
   "Operating System :: MacOS",
 ]
-dependencies = []
+dependencies = [
+  # `lizard` is invoked at runtime by hygiene:complexity via subprocess
+  # (`python -m lizard` against sys.executable). When slopstopper-cli is
+  # installed via pipx, sys.executable resolves to the pipx venv — which
+  # is where lizard must live too, otherwise `python -m lizard` fails
+  # even though `brew install lizard` (a different `lz4` tool) is on PATH.
+  # Promoting lizard from a test extra to a runtime dependency means
+  # pipx installs it into the same venv and the check works out of the box.
+  "lizard>=1.17",
+]
 
 [project.optional-dependencies]
 test = [
   "pytest>=7",
-  # `lizard` is invoked at runtime by hygiene:complexity via subprocess
-  # (`python -m lizard`). Not a runtime dep of slopstopper-cli itself —
-  # adopters install it themselves in production. Pulled into the test
-  # extra so CI parity + integration tests can exercise the real tool.
-  "lizard>=1.17",
 ]
 
 [project.scripts]

--- a/cli/slopstopper/checks/accessibility.py
+++ b/cli/slopstopper/checks/accessibility.py
@@ -96,6 +96,19 @@ def _build_env(url: str, ci_mode: bool) -> dict[str, str]:
     return env
 
 
+def _ensure_playwright_assets_ejected() -> None:
+    """Auto-eject the playwright config and the spec we're about to run.
+
+    The bundled assets live inside the pipx venv where node_modules
+    can't be resolved by Playwright. Ejecting into `.ss/` puts them in
+    the adopter's CWD where node_modules IS reachable. Idempotent.
+    """
+    for name in (templates.PLAYWRIGHT_CONFIG_NAME, f"tests/{SPEC_NAME}.spec.ts"):
+        dest, was_new = templates.ensure_ejected(name)
+        if was_new:
+            output.info(f"ejected {dest} (Playwright must run from a path with node_modules reachable)")
+
+
 def _build_cmd(ci_mode: bool) -> list[str]:
     reporter = "list,html" if ci_mode else "list"
     return [
@@ -120,6 +133,7 @@ def run(args: list[str] | None = None) -> int:
         output._emit("  ACCESSIBILITY_TEST_URL=https://your-site slopstopper run reliability:accessibility")
         return 1
 
+    _ensure_playwright_assets_ejected()
     spec = templates.playwright_spec(SPEC_NAME)
     if not spec.exists():
         output.error(f"Accessibility spec not found at {spec}")

--- a/cli/slopstopper/checks/broken_links.py
+++ b/cli/slopstopper/checks/broken_links.py
@@ -92,6 +92,19 @@ def _build_env(url: str, ci_mode: bool) -> dict[str, str]:
     return env
 
 
+def _ensure_playwright_assets_ejected() -> None:
+    """Auto-eject the playwright config and the spec we're about to run.
+
+    The bundled assets live inside the pipx venv where node_modules
+    can't be resolved by Playwright. Ejecting into `.ss/` puts them in
+    the adopter's CWD where node_modules IS reachable. Idempotent.
+    """
+    for name in (templates.PLAYWRIGHT_CONFIG_NAME, f"tests/{SPEC_NAME}.spec.ts"):
+        dest, was_new = templates.ensure_ejected(name)
+        if was_new:
+            output.info(f"ejected {dest} (Playwright must run from a path with node_modules reachable)")
+
+
 def _build_cmd(ci_mode: bool) -> list[str]:
     reporter = "list,html" if ci_mode else "list"
     return [
@@ -116,6 +129,7 @@ def run(args: list[str] | None = None) -> int:
         output._emit("  BROKEN_LINKS_TEST_URL=https://your-site slopstopper run reliability:broken-links")
         return 1
 
+    _ensure_playwright_assets_ejected()
     spec = templates.playwright_spec(SPEC_NAME)
     if not spec.exists():
         output.error(f"Broken-links spec not found at {spec}")

--- a/cli/slopstopper/checks/smoke.py
+++ b/cli/slopstopper/checks/smoke.py
@@ -70,6 +70,20 @@ def _build_env(url: str, ci_mode: bool) -> dict[str, str]:
     return env
 
 
+def _ensure_playwright_assets_ejected() -> None:
+    """Auto-eject the playwright config and the spec we're about to run.
+
+    The bundled assets live inside the pipx venv where node_modules
+    can't be resolved by Playwright. Ejecting into `.ss/` (in the
+    adopter's CWD) puts them next to node_modules. Idempotent: silent
+    on re-runs.
+    """
+    for name in (templates.PLAYWRIGHT_CONFIG_NAME, f"tests/{SPEC_NAME}.spec.ts"):
+        dest, was_new = templates.ensure_ejected(name)
+        if was_new:
+            output.info(f"ejected {dest} (Playwright must run from a path with node_modules reachable)")
+
+
 def _build_cmd(ci_mode: bool) -> list[str]:
     reporter = "list,html" if ci_mode else "list"
     return [
@@ -95,6 +109,7 @@ def run(args: list[str] | None = None) -> int:
         return 1
 
     output.running(f"Running smoke tests against: {url}")
+    _ensure_playwright_assets_ejected()
     env = _build_env(url, parsed.ci)
     cmd = _build_cmd(parsed.ci)
     result = subprocess.run(cmd, env=env, check=False)

--- a/cli/slopstopper/cli.py
+++ b/cli/slopstopper/cli.py
@@ -589,10 +589,17 @@ def _dispatch_checks_list(category: str | None, as_json: bool) -> int:
 # Each entry: tool name → (check-name-that-needs-it, install hint).
 # A "check-name-that-needs-it" of None means the tool is needed by the
 # CLI itself (gh for emit, node for several reliability checks).
+#
+# Note on lizard: it used to appear here as an external binary, which
+# was misleading — `brew install lizard` ships lz4's lizard (different
+# tool), and the real Python lizard had to be `pipx inject`ed into
+# the slopstopper-cli venv before hygiene:complexity worked. lizard
+# is now a runtime dependency of slopstopper-cli (see pyproject.toml),
+# so it's always in the venv that `python -m lizard` resolves against.
+# Doctor no longer needs to check for it.
 _DOCTOR_TOOLS: list[tuple[str, str | None, str]] = [
     ("node", None, "Install Node.js (https://nodejs.org/) — required by Playwright, Lighthouse, server"),
     ("gh", None, "Install GitHub CLI (https://cli.github.com/) — required by `slopstopper emit`"),
-    ("lizard", "hygiene:complexity", "pip install --user lizard  (don't use brew install lizard — that's lz4)"),
     ("semgrep", "security:sast", "pip install --user semgrep  or  brew install semgrep"),
     ("gitleaks", "security:secrets", "brew install gitleaks  or  apt-get install gitleaks"),
     ("trivy", "security:dependencies", "brew install aquasecurity/trivy/trivy  or  see https://trivy.dev"),

--- a/cli/slopstopper/data/server.js
+++ b/cli/slopstopper/data/server.js
@@ -115,6 +115,42 @@ function parseJsonRules(headersPath) {
 }
 
 
+function _headerBlockLines(block) {
+	return block
+		.split('\n')
+		.map(l => l.replace(/\r$/, ''))
+		.filter(l => l.trim() && !l.trim().startsWith('#'));
+}
+
+
+function _parseHeaderEntries(lines) {
+	// Lines after the path pattern are `Name: value` pairs. Skip
+	// entries without a colon or with an empty name.
+	const values = {};
+	for (let i = 1; i < lines.length; i++) {
+		const colon = lines[i].indexOf(':');
+		if (colon === -1) continue;
+		const name = lines[i].slice(0, colon).trim();
+		if (!name) continue;
+		values[name] = lines[i].slice(colon + 1).trim();
+	}
+	return values;
+}
+
+
+function _parseHeaderBlock(block) {
+	// Returns one {for, values} rule, or null if the block doesn't
+	// open with a path pattern or has no header entries.
+	const lines = _headerBlockLines(block);
+	if (lines.length === 0) return null;
+	const pattern = lines[0].trim();
+	if (!pattern.startsWith('/')) return null;
+	const values = _parseHeaderEntries(lines);
+	if (Object.keys(values).length === 0) return null;
+	return { for: pattern, values };
+}
+
+
 function parseCloudflareHeaders(headersPath) {
 	// Cloudflare/Netlify _headers grammar:
 	//   * Blank lines separate rule blocks.
@@ -122,8 +158,8 @@ function parseCloudflareHeaders(headersPath) {
 	//   * First non-comment line of a block is the path pattern
 	//     (e.g. `/*`, `/foo`, `/blog/*`).
 	//   * Subsequent indented lines are `Name: value` headers.
-	// We tolerate trailing-comment lines inside a block by stripping
-	// pure-comment lines before parsing the block.
+	// Per-block parsing is delegated so this function stays under
+	// the CCN-10 cap enforced by `ss:hygiene:complexity`.
 	let text;
 	try {
 		text = fs.readFileSync(headersPath, 'utf8');
@@ -132,29 +168,9 @@ function parseCloudflareHeaders(headersPath) {
 		return [];
 	}
 	const rules = [];
-	const blocks = text.split(/\n\s*\n/);
-	for (const block of blocks) {
-		const lines = block
-			.split('\n')
-			.map(l => l.replace(/\r$/, ''))
-			.filter(l => l.trim() && !l.trim().startsWith('#'));
-		if (lines.length === 0) continue;
-		const pattern = lines[0].trim();
-		// First line must look like a path pattern. Otherwise this is
-		// a stray indented block (probably commented-out content) and
-		// we skip it rather than emit a junk rule.
-		if (!pattern.startsWith('/')) continue;
-		const values = {};
-		for (let i = 1; i < lines.length; i++) {
-			const colon = lines[i].indexOf(':');
-			if (colon === -1) continue;
-			const name = lines[i].slice(0, colon).trim();
-			const value = lines[i].slice(colon + 1).trim();
-			if (name) values[name] = value;
-		}
-		if (Object.keys(values).length > 0) {
-			rules.push({ for: pattern, values });
-		}
+	for (const block of text.split(/\n\s*\n/)) {
+		const rule = _parseHeaderBlock(block);
+		if (rule) rules.push(rule);
 	}
 	return rules;
 }

--- a/cli/slopstopper/data/server.js
+++ b/cli/slopstopper/data/server.js
@@ -8,21 +8,26 @@
  * prefers the override.
  *
  * Usage:
- *   slopstopper serve                                # auto-detect SERVE_ROOT, no headers
+ *   slopstopper serve                                # auto-detect SERVE_ROOT + headers
  *   SERVE_ROOT=dist/client slopstopper serve         # explicit root
  *   PORT=8000 slopstopper serve                      # alternative port
- *   SS_SERVER_HEADERS=worker/headers.json slopstopper serve   # apply headers
+ *   SS_SERVER_HEADERS=public/_headers slopstopper serve   # explicit headers file
  *
  * Auto-detect probes ./dist/client, ./dist, ./build, ./out, ./public,
  * ./app in that order and picks the first one containing index.html.
  * Pretty URLs: /foo → /foo.html or /foo/index.html (whichever exists).
  *
- * Headers (optional): if SS_SERVER_HEADERS is set (or ./worker/headers.json
- * exists), the file is read as a JSON array of {for: <path-pattern>,
- * values: {Header-Name: value}} rules and applied per-path. Pattern
- * syntax matches Cloudflare's headers rules: exact paths, or `/prefix/*`
- * / `/*` globs. Used by DAST scans that assert specific security
- * headers locally.
+ * Headers (optional). Both Cloudflare/Netlify native `_headers` text
+ * format and slopstopper.dev's `worker/headers.json` JSON shape are
+ * supported, picked by extension or file content. Auto-detect probes
+ * (in order): `worker/headers.json`, `public/_headers`. Set
+ * SS_SERVER_HEADERS to point at a specific file. Pattern syntax
+ * matches Cloudflare's headers rules: exact paths, `/prefix/*`, `/*`.
+ *
+ * Known gap vs Cloudflare's edge: this server doesn't strip headers
+ * Cloudflare strips automatically (e.g. `Server`). For DAST purposes
+ * the parity is close enough — the security headers we care about
+ * (CSP, X-Frame-Options, COOP/CORP, etc.) are what the scanner checks.
  */
 
 'use strict';
@@ -64,15 +69,38 @@ function findHeadersFile() {
 		}
 		return abs;
 	}
-	// Auto-detect slopstopper.dev-shape header file. Adopters who use
-	// a different format can convert to JSON and point SS_SERVER_HEADERS at it.
-	const defaultPath = path.resolve(CWD, 'worker/headers.json');
-	return fs.existsSync(defaultPath) ? defaultPath : null;
+	// Auto-detect in priority order. worker/headers.json first because
+	// it's slopstopper.dev's own shape; public/_headers second because
+	// it's the Cloudflare/Netlify native format every adopter on those
+	// platforms already has.
+	for (const candidate of ['worker/headers.json', 'public/_headers']) {
+		const abs = path.resolve(CWD, candidate);
+		if (fs.existsSync(abs)) return abs;
+	}
+	return null;
 }
 
 
-function loadHeaderRules(headersPath) {
-	if (!headersPath) return [];
+function pickParser(headersPath) {
+	// Sniff by extension first (cheap, unambiguous for the two formats
+	// we ship). Fall back to inspecting first non-comment line: JSON
+	// arrays start with `[`; Cloudflare _headers starts with a path
+	// pattern (`/`).
+	if (headersPath.endsWith('.json')) return parseJsonRules;
+	const lower = headersPath.toLowerCase();
+	if (lower.endsWith('_headers') || lower.includes('/_headers')) return parseCloudflareHeaders;
+	try {
+		const text = fs.readFileSync(headersPath, 'utf8');
+		const firstSignificant = text.split('\n').map(l => l.trim()).find(l => l && !l.startsWith('#'));
+		if (firstSignificant && firstSignificant.startsWith('[')) return parseJsonRules;
+	} catch (_) {
+		/* fall through to cloudflare default */
+	}
+	return parseCloudflareHeaders;
+}
+
+
+function parseJsonRules(headersPath) {
 	try {
 		const parsed = JSON.parse(fs.readFileSync(headersPath, 'utf8'));
 		if (!Array.isArray(parsed)) {
@@ -84,6 +112,58 @@ function loadHeaderRules(headersPath) {
 		console.warn(`Warning: could not read ${headersPath} (${e.message}) — no headers will be applied`);
 		return [];
 	}
+}
+
+
+function parseCloudflareHeaders(headersPath) {
+	// Cloudflare/Netlify _headers grammar:
+	//   * Blank lines separate rule blocks.
+	//   * Lines starting with `#` are comments (whole-line only).
+	//   * First non-comment line of a block is the path pattern
+	//     (e.g. `/*`, `/foo`, `/blog/*`).
+	//   * Subsequent indented lines are `Name: value` headers.
+	// We tolerate trailing-comment lines inside a block by stripping
+	// pure-comment lines before parsing the block.
+	let text;
+	try {
+		text = fs.readFileSync(headersPath, 'utf8');
+	} catch (e) {
+		console.warn(`Warning: could not read ${headersPath} (${e.message}) — no headers will be applied`);
+		return [];
+	}
+	const rules = [];
+	const blocks = text.split(/\n\s*\n/);
+	for (const block of blocks) {
+		const lines = block
+			.split('\n')
+			.map(l => l.replace(/\r$/, ''))
+			.filter(l => l.trim() && !l.trim().startsWith('#'));
+		if (lines.length === 0) continue;
+		const pattern = lines[0].trim();
+		// First line must look like a path pattern. Otherwise this is
+		// a stray indented block (probably commented-out content) and
+		// we skip it rather than emit a junk rule.
+		if (!pattern.startsWith('/')) continue;
+		const values = {};
+		for (let i = 1; i < lines.length; i++) {
+			const colon = lines[i].indexOf(':');
+			if (colon === -1) continue;
+			const name = lines[i].slice(0, colon).trim();
+			const value = lines[i].slice(colon + 1).trim();
+			if (name) values[name] = value;
+		}
+		if (Object.keys(values).length > 0) {
+			rules.push({ for: pattern, values });
+		}
+	}
+	return rules;
+}
+
+
+function loadHeaderRules(headersPath) {
+	if (!headersPath) return [];
+	const parser = pickParser(headersPath);
+	return parser(headersPath);
 }
 
 
@@ -106,9 +186,12 @@ function headersForPath(rules, urlPath) {
 }
 
 
-const SERVE_ROOT = findServeRoot();
-const HEADERS_PATH = findHeadersFile();
-const HEADER_RULES = loadHeaderRules(HEADERS_PATH);
+// Module-level constants the request handler closes over. Initialised
+// inside the require.main guard so `require('./server.js')` from a test
+// harness doesn't trigger SERVE_ROOT detection (which exits 1 when
+// CWD has no build output — fine for `slopstopper serve`, fatal for
+// unit tests of just the parsers).
+let SERVE_ROOT, HEADERS_PATH, HEADER_RULES;
 
 
 const MIME = {
@@ -199,10 +282,27 @@ const server = http.createServer((req, res) => {
 });
 
 
-server.listen(PORT, () => {
-	console.log(`Slopstopper server: http://localhost:${PORT}`);
-	console.log(`Serving from: ${path.relative(CWD, SERVE_ROOT) || '.'}`);
-	if (HEADERS_PATH) {
-		console.log(`Applying headers from: ${path.relative(CWD, HEADERS_PATH)} (${HEADER_RULES.length} rule${HEADER_RULES.length === 1 ? '' : 's'})`);
-	}
-});
+// Only listen when invoked directly via `node server.js`. When the file
+// is `require`d by a test harness, the parser functions are reachable
+// via module.exports below without spawning a real listener.
+if (require.main === module) {
+	SERVE_ROOT = findServeRoot();
+	HEADERS_PATH = findHeadersFile();
+	HEADER_RULES = loadHeaderRules(HEADERS_PATH);
+	server.listen(PORT, () => {
+		console.log(`Slopstopper server: http://localhost:${PORT}`);
+		console.log(`Serving from: ${path.relative(CWD, SERVE_ROOT) || '.'}`);
+		if (HEADERS_PATH) {
+			console.log(`Applying headers from: ${path.relative(CWD, HEADERS_PATH)} (${HEADER_RULES.length} rule${HEADER_RULES.length === 1 ? '' : 's'})`);
+		}
+	});
+}
+
+module.exports = {
+	parseCloudflareHeaders,
+	parseJsonRules,
+	pickParser,
+	loadHeaderRules,
+	matchesPattern,
+	headersForPath,
+};

--- a/cli/slopstopper/templates.py
+++ b/cli/slopstopper/templates.py
@@ -105,6 +105,25 @@ def eject(name: str) -> tuple[Path, bool]:
     return override, True
 
 
+def ensure_ejected(name: str) -> tuple[Path, bool]:
+    """Auto-eject `<name>` if no override exists.
+
+    Returns (destination_path, was_new) — same shape as `eject()`.
+
+    Used by the reliability checks before they invoke `npx playwright`:
+    Playwright resolves `@playwright/test` from the directory of its
+    own config, and the bundled config lives inside the pipx venv where
+    no `node_modules` is reachable. Ejecting the config (and the spec
+    Playwright is about to run) into `.ss/` puts them in the adopter's
+    CWD where node_modules IS reachable.
+
+    Silent when the override already exists; the caller is responsible
+    for emitting a one-line info message on first eject so the new
+    `.ss/<name>` file isn't surprising to the adopter.
+    """
+    return eject(name)
+
+
 # ── back-compat thin wrappers used by the check modules ──────────
 
 

--- a/cli/tests/test_server_js.py
+++ b/cli/tests/test_server_js.py
@@ -1,0 +1,185 @@
+"""Tests for the bundled `server.js` header parsers.
+
+The server is JavaScript, not Python — these tests invoke `node` in a
+subprocess to load `server.js` as a module, then exercise its exported
+parsers against fixtures. Skipped (rather than failed) when `node` is
+not on PATH, since slopstopper-cli's Python tests must run cleanly in
+node-less environments too (e.g. lint-only CI matrices).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from slopstopper import templates
+
+
+SERVER_JS = templates.PACKAGE_DATA_DIR / "server.js"
+
+
+def _run_node_assert(fixture_path: Path, parser_name: str) -> list[dict]:
+    """Invoke `node -e '...'` to require server.js and run a parser.
+
+    Returns the parsed rules as a Python list of dicts. Raises
+    AssertionError (via the subprocess result) on failure.
+    """
+    script = (
+        f"const s = require({json.dumps(str(SERVER_JS))});\n"
+        f"const result = s.{parser_name}({json.dumps(str(fixture_path))});\n"
+        f"process.stdout.write(JSON.stringify(result));\n"
+    )
+    proc = subprocess.run(
+        ["node", "-e", script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(proc.stdout)
+
+
+if shutil.which("node") is None:
+    pytest.skip("node not on PATH — server.js parser tests require node", allow_module_level=True)
+
+
+# ── parseCloudflareHeaders ───────────────────────────────────────
+
+
+def test_parses_simple_cloudflare_headers(tmp_path):
+    fixture = tmp_path / "_headers"
+    fixture.write_text(
+        "/*\n"
+        "  X-Frame-Options: DENY\n"
+        "  Referrer-Policy: strict-origin-when-cross-origin\n"
+        "\n"
+        "/og-image.png\n"
+        "  Cross-Origin-Resource-Policy: cross-origin\n"
+    )
+    rules = _run_node_assert(fixture, "parseCloudflareHeaders")
+    assert rules == [
+        {
+            "for": "/*",
+            "values": {
+                "X-Frame-Options": "DENY",
+                "Referrer-Policy": "strict-origin-when-cross-origin",
+            },
+        },
+        {
+            "for": "/og-image.png",
+            "values": {"Cross-Origin-Resource-Policy": "cross-origin"},
+        },
+    ]
+
+
+def test_skips_pure_comment_lines(tmp_path):
+    fixture = tmp_path / "_headers"
+    fixture.write_text(
+        "# top-of-file comment\n"
+        "/*\n"
+        "  # this comment doesn't belong inside a values block but we tolerate it\n"
+        "  X-Content-Type-Options: nosniff\n"
+    )
+    rules = _run_node_assert(fixture, "parseCloudflareHeaders")
+    assert rules == [{"for": "/*", "values": {"X-Content-Type-Options": "nosniff"}}]
+
+
+def test_skips_blocks_without_path_pattern(tmp_path):
+    """A block whose first non-comment line isn't a path pattern is skipped."""
+    fixture = tmp_path / "_headers"
+    fixture.write_text(
+        "# slopstopper security headers begin\n"
+        "# (intentionally commented-out block — install ships it disabled by default)\n"
+        "\n"
+        "/*\n"
+        "  X-Frame-Options: DENY\n"
+    )
+    rules = _run_node_assert(fixture, "parseCloudflareHeaders")
+    # The "# slopstopper..." block has no path pattern; only the active /* block produces a rule.
+    assert rules == [{"for": "/*", "values": {"X-Frame-Options": "DENY"}}]
+
+
+def test_handles_multiple_blocks(tmp_path):
+    fixture = tmp_path / "_headers"
+    fixture.write_text(
+        "/blog/*\n"
+        "  Cache-Control: public, max-age=60\n"
+        "\n"
+        "/assets/*\n"
+        "  Cache-Control: public, max-age=31536000, immutable\n"
+        "\n"
+        "/api/*\n"
+        "  Cache-Control: no-store\n"
+        "  X-Robots-Tag: noindex\n"
+    )
+    rules = _run_node_assert(fixture, "parseCloudflareHeaders")
+    assert len(rules) == 3
+    assert rules[0]["for"] == "/blog/*"
+    assert rules[2]["values"]["X-Robots-Tag"] == "noindex"
+
+
+# ── pickParser auto-detection via loadHeaderRules ────────────────
+
+
+def test_pick_parser_uses_cloudflare_for_underscore_headers(tmp_path):
+    fixture = tmp_path / "_headers"
+    fixture.write_text("/*\n  X-Frame-Options: DENY\n")
+    # pickParser returns a function reference, but JSON-serialising a fn
+    # gives null. Instead call loadHeaderRules which threads pickParser
+    # internally and returns the parsed result.
+    script = (
+        f"const s = require({json.dumps(str(SERVER_JS))});\n"
+        f"process.stdout.write(JSON.stringify(s.loadHeaderRules({json.dumps(str(fixture))})));\n"
+    )
+    proc = subprocess.run(["node", "-e", script], capture_output=True, text=True, check=True)
+    rules = json.loads(proc.stdout)
+    assert rules == [{"for": "/*", "values": {"X-Frame-Options": "DENY"}}]
+
+
+def test_pick_parser_uses_json_for_dot_json_extension(tmp_path):
+    fixture = tmp_path / "headers.json"
+    payload = [{"for": "/*", "values": {"X-Frame-Options": "DENY"}}]
+    fixture.write_text(json.dumps(payload))
+    script = (
+        f"const s = require({json.dumps(str(SERVER_JS))});\n"
+        f"process.stdout.write(JSON.stringify(s.loadHeaderRules({json.dumps(str(fixture))})));\n"
+    )
+    proc = subprocess.run(["node", "-e", script], capture_output=True, text=True, check=True)
+    rules = json.loads(proc.stdout)
+    assert rules == payload
+
+
+# ── headersForPath integration ───────────────────────────────────
+
+
+def test_headers_for_path_matches_glob_and_exact(tmp_path):
+    """End-to-end: load _headers, then ask which headers apply to a path."""
+    fixture = tmp_path / "_headers"
+    fixture.write_text(
+        "/*\n"
+        "  X-Frame-Options: DENY\n"
+        "\n"
+        "/og-image.png\n"
+        "  Cross-Origin-Resource-Policy: cross-origin\n"
+    )
+    script = (
+        f"const s = require({json.dumps(str(SERVER_JS))});\n"
+        f"const rules = s.loadHeaderRules({json.dumps(str(fixture))});\n"
+        f"const result = {{\n"
+        f"  root: s.headersForPath(rules, '/'),\n"
+        f"  blog: s.headersForPath(rules, '/blog/post'),\n"
+        f"  og: s.headersForPath(rules, '/og-image.png'),\n"
+        f"}};\n"
+        f"process.stdout.write(JSON.stringify(result));\n"
+    )
+    proc = subprocess.run(["node", "-e", script], capture_output=True, text=True, check=True)
+    result = json.loads(proc.stdout)
+    # /* matches everything → X-Frame-Options applies to every path
+    assert result["root"] == {"X-Frame-Options": "DENY"}
+    assert result["blog"] == {"X-Frame-Options": "DENY"}
+    # The OG image gets both /* and its exact-match rule; later rules win for overlapping keys.
+    assert result["og"]["X-Frame-Options"] == "DENY"
+    assert result["og"]["Cross-Origin-Resource-Policy"] == "cross-origin"

--- a/cli/tests/test_templates.py
+++ b/cli/tests/test_templates.py
@@ -197,3 +197,26 @@ def test_playwright_spec_override_only_for_named_check(isolated_cwd):
     assert a11y_resolved == (
         templates.PACKAGE_DATA_DIR / "tests" / "accessibility.spec.ts"
     )
+
+
+# ── ensure_ejected (auto-eject helper used by reliability checks) ─
+
+
+def test_ensure_ejected_copies_when_missing(isolated_cwd):
+    dest, was_new = templates.ensure_ejected("playwright.config.js")
+    assert was_new is True
+    assert dest == Path(".ss/playwright.config.js")
+    assert dest.exists()
+    # Content matches the bundled file (sanity that we copied not symlinked).
+    bundled = (templates.PACKAGE_DATA_DIR / "playwright.config.js").read_text()
+    assert dest.read_text() == bundled
+
+
+def test_ensure_ejected_is_silent_when_already_present(isolated_cwd):
+    override = isolated_cwd / ".ss" / "playwright.config.js"
+    override.parent.mkdir(parents=True, exist_ok=True)
+    override.write_text("// customised")
+    dest, was_new = templates.ensure_ejected("playwright.config.js")
+    assert was_new is False
+    assert dest == Path(".ss/playwright.config.js")
+    assert override.read_text() == "// customised"


### PR DESCRIPTION
## Summary

Three first-real-adopter findings, all rooted in the same gap: the packaged distribution doesn't currently ship everything an adopter needs to run a clean local-first loop without manual workarounds.

| # | Issue | Fix |
|---|---|---|
| #103 | `hygiene:complexity` failed because `python -m lizard` couldn't find lizard inside the pipx venv. Doctor cheerfully reported `lizard found at /opt/homebrew/bin/lizard` — but that's lz4's lizard, a different tool. | Promote `lizard>=1.17` from `[project.optional-dependencies].test` to `[project].dependencies`. Drop lizard from `_DOCTOR_TOOLS` external list — it's now always in-venv. |
| #104 | Bundled `playwright.config.js` lives inside the pipx venv. When Playwright tries to resolve `@playwright/test`, the lookup starts from the venv path which has no `node_modules` → `MODULE_NOT_FOUND`. | New `templates.ensure_ejected()` helper. smoke/accessibility/broken-links checks call it before invoking `npx playwright`, so the config + spec land in `.ss/` where `node_modules` is reachable. Idempotent; one info line on first eject. |
| #105 | `slopstopper serve` only parsed `worker/headers.json` (slopstopper.dev's shape). Adopters on Cloudflare Workers / Netlify (the most common case) had to maintain a parallel JSON file mirroring their `public/_headers` just for local DAST. | New `parseCloudflareHeaders` parser alongside the JSON one. Auto-detect order: `worker/headers.json` → `public/_headers`. `pickParser` sniffs by extension and content. `server.js` now exports parsers so they're testable from node-via-subprocess without spinning up the listener. |

## Test plan

- [x] `task -t cli/Taskfile.yml test` — **495 passing** (2 new in `test_templates.py` for `ensure_ejected`, 7 new in `test_server_js.py` covering both parsers).
- [x] Local sanity: `slopstopper doctor` reports green without listing lizard; `slopstopper run hygiene:complexity` runs to completion via in-venv lizard.
- [ ] CI green on this PR.
- [ ] End-to-end re-validation on hungovercoders/site once 0.6.0 publishes (Stage 8).

## Notes

- `server.js` was refactored to wrap `server.listen()` in `if (require.main === module)` so the module can be `require`d from tests without binding a port. Module-level `findServeRoot()` (which `process.exit(1)`s on no build dir) was moved inside the same guard.
- Each finding corresponds to one task in the hungovercoders tracker (#103, #104, #105).

🤖 Generated with [Claude Code](https://claude.com/claude-code)