### PR TITLE
fix(cli): exit non-zero on HIGH+ vulnerabilities to match CI gate behaviour

### DIFF
--- a/.github/workflows/ss-security-vulnerability-all-check.yml
+++ b/.github/workflows/ss-security-vulnerability-all-check.yml
@@ -52,32 +52,13 @@ jobs:
             pip install slopstopper-cli
           fi
 
+      # The CLI exits non-zero (2) on CRITICAL/HIGH vulnerabilities, so this
+      # step's outcome IS the gate — no separate "fail job if HIGH+" step
+      # needed any more, and local `task ss:security:vulnerability:all`
+      # agrees with the CI workflow without divergent post-processing.
       - name: Run dependency scan
         id: dependencies
         run: slopstopper run security:dependencies
-
-      - name: Detect critical/high vulnerabilities
-        id: gate
-        run: |
-          if [ -f .ss/reports/dependencies/dependencies-report.json ]; then
-            VULN_COUNT=$(python3 -c "
-          import json
-          with open('.ss/reports/dependencies/dependencies-report.json') as f:
-              data = json.load(f)
-          count = 0
-          for r in data.get('Results', []):
-              for v in r.get('Vulnerabilities', []):
-                  if v.get('Severity', '').upper() in ('CRITICAL', 'HIGH'):
-                      count += 1
-          print(count)
-          ")
-          else
-            VULN_COUNT=0
-          fi
-          echo "vulns_found=$([ "$VULN_COUNT" -gt 0 ] && echo 1 || echo 0)" >> "$GITHUB_OUTPUT"
-          if [ "$VULN_COUNT" -gt 0 ]; then
-            echo "⚠️  Found $VULN_COUNT CRITICAL/HIGH vulnerability(ies)"
-          fi
 
       - name: Upload dependency reports
         if: always()
@@ -91,19 +72,13 @@ jobs:
           if-no-files-found: warn
 
       - name: Emit PR comment
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: slopstopper emit security:dependencies --target pr-comment
 
       - name: Emit issue on main (if critical/high vulns)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.gate.outputs.vulns_found == '1'
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.dependencies.outcome == 'failure'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: slopstopper emit security:dependencies --target issue
-
-      - name: Fail job if critical/high vulnerabilities
-        if: steps.gate.outputs.vulns_found == '1'
-        run: |
-          echo "::error::CRITICAL/HIGH dependency vulnerabilities detected. Update vulnerable packages."
-          exit 1

--- a/cli/slopstopper/checks/dependencies.py
+++ b/cli/slopstopper/checks/dependencies.py
@@ -14,8 +14,13 @@ trivy code. Trivy itself is Apache-2.0 so the boundary is gentler
 than semgrep's, but the discipline is identical.
 
 Exit codes:
-  0 — analysis completed (gating happens at the workflow level)
+  0 — analysis completed with no CRITICAL/HIGH vulnerabilities
   1 — trivy is not installed
+  2 — CRITICAL/HIGH vulnerabilities detected (local/CI gate parity:
+      the CI workflow used to add a separate "fail job if HIGH+" step
+      after this check; having the check itself exit non-zero means
+      the local `task ss:security:vulnerability:all` and the CI run
+      agree without divergent post-processing)
 """
 
 from __future__ import annotations
@@ -192,4 +197,8 @@ def run(_args: list[str] | None = None) -> int:
     else:
         output.success("No vulnerabilities detected")
     output.footer(REPORT_DIR, [REPORT_MD.name])
-    return 0
+    # Exit non-zero on CRITICAL/HIGH so local `task ss:security:vulnerability:all`
+    # and the CI workflow gate the same way. Anything below HIGH is reported
+    # but doesn't block — same threshold the CI workflow previously enforced
+    # in a separate post-processing step.
+    return 2 if blocking > 0 else 0

--- a/cli/tests/checks/test_dependencies.py
+++ b/cli/tests/checks/test_dependencies.py
@@ -168,7 +168,11 @@ def test_run_clean_when_no_vulns(monkeypatch, isolated_cwd, capsys):
     assert "No vulnerabilities detected" in dependencies.REPORT_MD.read_text()
 
 
-def test_run_with_blocking_vulns_returns_zero(monkeypatch, isolated_cwd, capsys):
+def test_run_exits_two_on_critical_or_high(monkeypatch, isolated_cwd, capsys):
+    """Local/CI gate parity: HIGH+ findings make this check exit non-zero
+    so adopters' local `task ss:security:vulnerability:all` agrees with
+    the CI workflow without a separate post-processing gate step."""
+
     def fake_trivy():
         dependencies.REPORT_DIR.mkdir(parents=True, exist_ok=True)
         dependencies.REPORT_JSON.write_text(
@@ -178,8 +182,7 @@ def test_run_with_blocking_vulns_returns_zero(monkeypatch, isolated_cwd, capsys)
     monkeypatch.setattr(dependencies, "_trivy_available", lambda: True)
     monkeypatch.setattr(dependencies, "_run_trivy", fake_trivy)
     rc = dependencies.run()
-    # Bash flow doesn't gate at this layer; gating happens in CI.
-    assert rc == 0
+    assert rc == 2, "CRITICAL+HIGH findings must produce a non-zero exit code"
     out = capsys.readouterr().out
     assert "Found 2 CRITICAL/HIGH" in out
     md = dependencies.REPORT_MD.read_text()
@@ -188,6 +191,8 @@ def test_run_with_blocking_vulns_returns_zero(monkeypatch, isolated_cwd, capsys)
 
 
 def test_run_with_only_medium_or_low(monkeypatch, isolated_cwd, capsys):
+    """MEDIUM/LOW only → exit 0 (still reported, but doesn't block)."""
+
     def fake_trivy():
         dependencies.REPORT_DIR.mkdir(parents=True, exist_ok=True)
         dependencies.REPORT_JSON.write_text(


### PR DESCRIPTION
## Summary

Local `task ss:security:vulnerability:all` used to exit 0 even when Trivy found CRITICAL/HIGH CVEs — the CI workflow then ran a separate "fail job if HIGH+" step that re-parsed the JSON and exited 1. Adopters got **green locally and red in CI for the same scan**, which is the worst-of-both: they were told everything was fine by their own machine, then the build proved them wrong forty seconds after push.

## Fix

Move the gate into the check itself. `cli/slopstopper/checks/dependencies.py` now:

- Returns exit code **2** when `CRITICAL + HIGH > 0`.
- Returns exit code **0** otherwise (MEDIUM/LOW still reported in the markdown but don't block).
- Threshold is unchanged from the CI workflow's previous behaviour — only the *location* moves.

`.github/workflows/ss-security-vulnerability-all-check.yml`:

- Drops the now-redundant "Detect critical/high vulnerabilities" + "Fail job if critical/high vulnerabilities" steps.
- "Emit issue on main" now keys off `steps.dependencies.outcome == 'failure'`.
- "Emit PR comment" and the report upload gain `if: always()` so they still run when the scan exits non-zero.

## Test plan

- [x] `task -t cli/Taskfile.yml test` — **486 passing**. `test_run_with_blocking_vulns_returns_zero` renamed to `test_run_exits_two_on_critical_or_high` with updated expectation.
- [ ] CI green on this PR.
- [ ] End-to-end re-validation on hungovercoders/site after 0.6.0 publishes (Stage 8).

## Notes

- Exit code 2 (not 1) for HIGH+ to leave room for distinguishing "scan failed" (exit 1, e.g. trivy not installed) from "scan ran, found blocking issues" (exit 2). The CI workflow treats both as failure either way; local users see `task ss:security:vulnerability:all && echo OK` correctly skip the OK branch on HIGH+.
- Finding #106 in the hungovercoders tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)