### PR TITLE
feat(emit): add --on-pass=close to slopstopper emit

### DIFF
--- a/.claude/skills/slopstopper-install/SKILL.md
+++ b/.claude/skills/slopstopper-install/SKILL.md
@@ -9,7 +9,7 @@ You're being asked to install slopstopper into an existing repo. Slopstopper is 
 
 The install ships ~21 GitHub Actions workflows in one shot, pip-installs `slopstopper-cli` (via pipx), merges devDeps into `package.json`, and creates a `Taskfile.yml` if the target doesn't have one. That's a lot of moving parts. Don't run it blind — work through the pre-flight first, then drive every check to green locally before opening a PR.
 
-**The CLI is the single source of truth for every check.** Every workflow boils down to two CLI commands: `slopstopper run <category>:<check>` (executes the check, writes reports under `.ss/reports/`) and `slopstopper emit <category>:<check> --target {pr-comment,issue}` (posts the report to GitHub). Reliability checks also use `slopstopper discover <check> --event=<event>` (resolves which pages to audit) and the installer itself uses `slopstopper config get <key>` to read `.slopstopper.yml`. No bash scripts under `.ss/scripts/` any more — pure Python, one package, one upgrade path.
+**The CLI is the single source of truth for every check.** Every workflow boils down to two CLI commands: `slopstopper run <category>:<check>` (executes the check, writes reports under `.ss/reports/`) and `slopstopper emit <category>:<check> --target {pr-comment,issue} [--on-pass=close]` (posts the report to GitHub on failure, or closes any prior issue when the check now passes on `main`). Reliability checks also use `slopstopper discover <check> --event=<event>` (resolves which pages to audit) and the installer itself uses `slopstopper config get <key>` to read `.slopstopper.yml`. No bash scripts under `.ss/scripts/` any more — pure Python, one package, one upgrade path.
 
 ## Step 1 — Pre-flight: read the target repo before installing
 

--- a/cli/slopstopper/cli.py
+++ b/cli/slopstopper/cli.py
@@ -179,6 +179,7 @@ def _add_emit(sub) -> None:
             "Examples:\n"
             "  slopstopper emit hygiene:docs-size --target pr-comment\n"
             "  slopstopper emit security:dast --target issue\n"
+            "  slopstopper emit security:dast --target issue --on-pass=close\n"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -191,6 +192,15 @@ def _add_emit(sub) -> None:
         required=True,
         choices=["pr-comment", "issue"],
         help="Where to send the report: pr-comment | issue",
+    )
+    p.add_argument(
+        "--on-pass",
+        choices=["close"],
+        default=None,
+        help=(
+            "Post-pass behaviour (only with --target issue): "
+            "'close' comments + closes any open issue matching the check's labels"
+        ),
     )
 
 
@@ -385,7 +395,7 @@ def _add_doctor(sub) -> None:
 # gains subcommands.
 _DISPATCHERS = {
     "run":       lambda a: _dispatch_run(a.check, a.check_args),
-    "emit":      lambda a: _dispatch_emit(a.check, a.target),
+    "emit":      lambda a: _dispatch_emit(a.check, a.target, on_pass=a.on_pass),
     "discover":  lambda a: _dispatch_discover(a.check, a.event),
     "config":    lambda a: _dispatch_config_get(a.key, a.default),
     "templates": lambda a: _dispatch_templates(a.templates_action, getattr(a, "name", None)),
@@ -522,10 +532,16 @@ def _dispatch_templates(action: str, name: str | None) -> int:
     return 2
 
 
-def _dispatch_emit(check_name: str, target: str) -> int:
+def _dispatch_emit(check_name: str, target: str, *, on_pass: str | None = None) -> int:
     """Look up the check's META dict (from its module) and emit."""
     if check_name not in REGISTRY:
         print(f"❌ unknown check: {check_name}", file=sys.stderr)
+        return 2
+    if on_pass is not None and target != "issue":
+        print(
+            f"❌ --on-pass is only valid with --target issue (got --target {target})",
+            file=sys.stderr,
+        )
         return 2
     # Drop the category, join remaining segments with underscores so multi-
     # segment names like `security:vulnerability:all` resolve to the
@@ -544,7 +560,7 @@ def _dispatch_emit(check_name: str, target: str) -> int:
             file=sys.stderr,
         )
         return 2
-    return emit_mod.emit(target, meta)
+    return emit_mod.emit(target, meta, on_pass=on_pass)
 
 
 # ── checks list ──────────────────────────────────────────────────

--- a/cli/slopstopper/emit.py
+++ b/cli/slopstopper/emit.py
@@ -25,11 +25,12 @@ Each check that wants to emit declares a META dict beside its `run()`:
         "issue_title": "📚 ... Exceeds Thresholds",
         "issue_labels": ["...", "maintenance"],
         "issue_followup": "🔔 Thresholds exceeded again in commit",
+        "issue_close_comment": "✅ ... now within thresholds. Closing automatically.",  # optional; used by `emit --on-pass=close`
     }
 
 PR-comment update path: `gh api PATCH .../issues/comments/{id}` —
 `gh` doesn't have a direct edit-comment command.
-Issue path: `gh issue list | gh issue {create,edit,comment}`.
+Issue path: `gh issue list | gh issue {create,edit,comment,close}`.
 """
 
 from __future__ import annotations
@@ -236,18 +237,54 @@ def emit_issue(
     return _create_issue(title, body_path, labels)
 
 
+# ── issue close ──────────────────────────────────────────────────
+
+
+_DEFAULT_CLOSE_COMMENT = "✅ Check is now passing on `main`. Closing automatically."
+
+
+def _close_issue(labels: list[str], close_comment: str) -> int:
+    """Comment + close any open issue matching `labels`. No-op if none exists.
+
+    Used by `emit --on-pass=close` as the post-success twin of
+    `emit_issue`'s post-failure open path. Same label-intersection dedup
+    via `_find_existing_issue`, so a check only ever closes the issue it
+    would have re-opened.
+    """
+    if not _gh_available():
+        print("❌ gh CLI is not available — needed for --on-pass=close", file=sys.stderr)
+        return 1
+    existing = _find_existing_issue(labels)
+    if existing is None:
+        print("· No open issue to close")
+        return 0
+    print(f"× Closing issue #{existing}")
+    rc = _comment_issue(existing, close_comment)
+    if rc != 0:
+        return rc
+    return _gh("issue", "close", str(existing)).returncode
+
+
 # ── public dispatcher ────────────────────────────────────────────
 
 
-def emit(target: str, meta: dict) -> int:
+def emit(target: str, meta: dict, *, on_pass: str | None = None) -> int:
     """Route --target {pr-comment, issue} to the corresponding emitter.
 
     meta is the check's META dict (see module docstring).
+    on_pass='close' (only valid with target='issue') flips the issue
+    branch from open/update to comment-and-close — the post-success
+    twin of the post-failure open path.
     """
     report_path = Path(meta["report_path"])
     if target == "pr-comment":
         return emit_pr_comment(report_path, meta["comment_discriminator"])
     if target == "issue":
+        if on_pass == "close":
+            return _close_issue(
+                meta["issue_labels"],
+                meta.get("issue_close_comment", _DEFAULT_CLOSE_COMMENT),
+            )
         return emit_issue(
             report_path,
             meta["issue_title"],

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -53,19 +53,40 @@ def test_emit_no_meta_returns_2(monkeypatch, capsys):
 
 def test_emit_routes_to_emit_module(monkeypatch):
     """When the check has META, the dispatcher hands off to emit.emit
-    with the target and the META dict."""
+    with the target, META dict, and on_pass kwarg."""
     called: dict = {}
 
-    def fake_emit(target, meta):
+    def fake_emit(target, meta, *, on_pass=None):
         called["target"] = target
         called["meta"] = meta
+        called["on_pass"] = on_pass
         return 0
 
     monkeypatch.setattr(cli.emit_mod, "emit", fake_emit)
     rc = cli.main(["emit", "hygiene:docs-size", "--target", "issue"])
     assert rc == 0
     assert called["target"] == "issue"
+    assert called["on_pass"] is None
     assert "comment_discriminator" in called["meta"]
+
+
+def test_emit_threads_on_pass_close_through(monkeypatch):
+    called: dict = {}
+
+    def fake_emit(target, meta, *, on_pass=None):
+        called["on_pass"] = on_pass
+        return 0
+
+    monkeypatch.setattr(cli.emit_mod, "emit", fake_emit)
+    rc = cli.main(["emit", "hygiene:docs-size", "--target", "issue", "--on-pass=close"])
+    assert rc == 0
+    assert called["on_pass"] == "close"
+
+
+def test_emit_rejects_on_pass_with_pr_comment_target(capsys):
+    rc = cli.main(["emit", "hygiene:docs-size", "--target", "pr-comment", "--on-pass=close"])
+    assert rc == 2
+    assert "--on-pass is only valid with --target issue" in capsys.readouterr().err
 
 
 def test_emit_requires_target_flag(capsys):

--- a/cli/tests/test_emit.py
+++ b/cli/tests/test_emit.py
@@ -246,6 +246,50 @@ def test_emit_issue_fails_when_gh_missing(monkeypatch, isolated_cwd, capsys):
     assert "gh CLI is not available" in capsys.readouterr().err
 
 
+# ── issue close ──────────────────────────────────────────────────
+
+
+def test_close_issue_comments_and_closes_when_match(monkeypatch, capsys):
+    monkeypatch.setattr(emit, "_gh_available", lambda: True)
+    monkeypatch.setattr(emit, "_find_existing_issue", lambda labels: 77)
+
+    captured: dict = {}
+
+    def fake_gh(*args, capture=False):
+        captured.setdefault("calls", []).append(args)
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(emit, "_gh", fake_gh)
+    rc = emit._close_issue(["test-label"], "✅ now passing")
+    assert rc == 0
+    comment_call = captured["calls"][0]
+    assert "comment" in comment_call and "77" in comment_call
+    assert "✅ now passing" in comment_call
+    close_call = captured["calls"][1]
+    assert "close" in close_call and "77" in close_call
+    assert "Closing issue #77" in capsys.readouterr().out
+
+
+def test_close_issue_noops_when_no_match(monkeypatch, capsys):
+    monkeypatch.setattr(emit, "_gh_available", lambda: True)
+    monkeypatch.setattr(emit, "_find_existing_issue", lambda labels: None)
+
+    def fake_gh(*args, capture=False):
+        raise AssertionError(f"_gh should not be called when no open issue, got {args}")
+
+    monkeypatch.setattr(emit, "_gh", fake_gh)
+    rc = emit._close_issue(["test-label"], "✅ now passing")
+    assert rc == 0
+    assert "No open issue to close" in capsys.readouterr().out
+
+
+def test_close_issue_fails_when_gh_missing(monkeypatch, capsys):
+    monkeypatch.setattr(emit, "_gh_available", lambda: False)
+    rc = emit._close_issue(["test-label"], "✅ now passing")
+    assert rc == 1
+    assert "gh CLI is not available" in capsys.readouterr().err
+
+
 # ── public dispatcher ────────────────────────────────────────────
 
 
@@ -280,3 +324,46 @@ def test_emit_rejects_unknown_target(capsys):
     rc = emit.emit("slack", SAMPLE_META)
     assert rc == 2
     assert "Unknown emit target" in capsys.readouterr().err
+
+
+def test_emit_routes_on_pass_close_to_close_issue(monkeypatch):
+    called: dict = {}
+
+    def fake_close(labels, close_comment):
+        called["close"] = (labels, close_comment)
+        return 0
+
+    monkeypatch.setattr(emit, "_close_issue", fake_close)
+    rc = emit.emit("issue", SAMPLE_META, on_pass="close")
+    assert rc == 0
+    assert called["close"][0] == ["test-label", "maintenance"]
+    # SAMPLE_META has no issue_close_comment → defaults to the module default.
+    assert called["close"][1] == emit._DEFAULT_CLOSE_COMMENT
+
+
+def test_emit_close_uses_meta_close_comment_when_present(monkeypatch):
+    meta_with_close = {**SAMPLE_META, "issue_close_comment": "✅ custom-close"}
+    called: dict = {}
+
+    def fake_close(labels, close_comment):
+        called["close"] = (labels, close_comment)
+        return 0
+
+    monkeypatch.setattr(emit, "_close_issue", fake_close)
+    rc = emit.emit("issue", meta_with_close, on_pass="close")
+    assert rc == 0
+    assert called["close"][1] == "✅ custom-close"
+
+
+def test_emit_without_on_pass_still_opens_issue(monkeypatch):
+    """on_pass=None must not divert from the normal open-or-update path."""
+    called: dict = {}
+
+    def fake_issue(report_path, title, labels, followup):
+        called["issue"] = True
+        return 0
+
+    monkeypatch.setattr(emit, "emit_issue", fake_issue)
+    rc = emit.emit("issue", SAMPLE_META)
+    assert rc == 0
+    assert called.get("issue") is True


### PR DESCRIPTION
## Summary

Adds `--on-pass=close` to `slopstopper emit <check> --target issue`. When passed, the dispatcher comments + closes any open issue matching the check's META labels (same label-intersection dedup as the open path) and no-ops cleanly when no matching issue is open.

META gains an optional `issue_close_comment` key; checks that don't set it get a generic default (`"✅ Check is now passing on \`main\`. Closing automatically."`).

## Why

Today, 4 workflows hand-roll their close-on-pass logic with 4 slightly-different `gh issue list/close` loops; 7 other workflows that open issues have no close-on-pass at all and stack stale issues forever. This PR ships the CLI surface; subsequent PRs migrate the workflows.

## What this is + isn't

- ✅ Pure CLI addition. Zero workflow changes. Standalone-shippable.
- ✅ Unblocks PR 4 (migrate 3 bypass workflows + add close-on-pass to 7) and PR 5 (switch global failure-issue dedup to body marker).
- ❌ No workflow changes — those land in PR 4 of the 5-PR plan.

## Files

- ` cli/slopstopper/emit.py` — `_close_issue(labels, close_comment)` helper; `emit(target, meta, *, on_pass=None)` dispatches close when `target=='issue' && on_pass=='close'`.
- `cli/slopstopper/cli.py` — `--on-pass` arg on the emit subparser; threaded through `_dispatch_emit`. CLI-layer validation: `--on-pass` only valid with `--target issue`.
- `cli/tests/test_emit.py` — six new tests covering `_close_issue` (match / no-match / gh-missing) and `emit(..., on_pass="close")` routing (default + META-override close comments).
- `cli/tests/test_cli.py` — updated dispatcher signature in fake; new tests for flag threading + cross-target validation error.
- `.claude/skills/slopstopper-install/SKILL.md` — mention `--on-pass=close` in the CLI-surface paragraph at line 12.

## Test plan

- [x] `task -t cli/Taskfile.yml test` — 508 passed
- [x] `task ss:hygiene:test` — all hygiene aggregates green
- [x] `task ss:security:scan` — SAST clean (no errors), trivy clean
- [ ] CI suite green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)