### PR TITLE
feat(checks): META + markdown reports for smoke/accessibility/broken-links

### DIFF
--- a/.claude/skills/slopstopper-triage/SKILL.md
+++ b/.claude/skills/slopstopper-triage/SKILL.md
@@ -202,7 +202,7 @@ Update this skill when:
 
 - A new workflow is added under `slopstopper/.github/workflows/ss-*.yml` → add a row to Step 2's workflow→CLI table and a row to Step 5's gotcha table (with a forward-looking diagnostic step and fix location, not citing the install that surfaced it).
 - A workflow is renamed or removed → update both tables.
-- A check is added or renamed in `cli/slopstopper/checks/__init__.py`'s `REGISTRY` → update Step 2's table (CLI column AND Taskfile-shim column, since the shim mirrors the CLI name).
+- A check is added or renamed in `cli/slopstopper/checks/__init__.py`'s `REGISTRY` → update Step 2's table (CLI column AND Taskfile-shim column, since the shim mirrors the CLI name). The new check must also define a `META` dict in its module — the `test_every_check_has_meta` pytest enforces this. PR-comment-only checks need at least `report_path` + `comment_discriminator`; checks that open main-branch issues also need `issue_title` / `issue_labels` / `issue_followup` / `issue_close_comment` (see `cli/slopstopper/emit.py` docstring for the schema).
 - A `task ss:*` shim is renamed in `slopstopper/Taskfile.ss.yml` → update Step 2's Taskfile-shim column.
 - A new `slopstopper` subcommand ships (e.g. `init`, `inspect`) → mention in the intro and the relevant Step.
 - A new suppression mechanism becomes available for an existing check (e.g. a new `.zap/rules.tsv`-shaped file for a different tool) → add a row to Step 4's suppression table.

--- a/cli/slopstopper/checks/accessibility.py
+++ b/cli/slopstopper/checks/accessibility.py
@@ -44,10 +44,25 @@ import argparse
 import os
 import shutil
 import subprocess
+from pathlib import Path
 
 from slopstopper import discovery, output, templates
 
 SPEC_NAME = "accessibility"
+REPORT_DIR = Path(".ss/reports/reliability")
+REPORT_MD = REPORT_DIR / "accessibility-report.md"
+
+# Consumed by `slopstopper emit reliability:accessibility --target {pr-comment,issue}`.
+# Issue title + label match the strings the legacy workflow used in raw
+# `gh issue create` so existing open issues continue to dedup post-migration.
+META = {
+    "report_path": str(REPORT_MD),
+    "comment_discriminator": "## ♿ Accessibility Audit Results",
+    "issue_title": "♿ Accessibility Violations Detected on Main Branch",
+    "issue_labels": ["accessibility", "reliability"],
+    "issue_followup": "🔔 Accessibility violations recurred in commit",
+    "issue_close_comment": "✅ Accessibility audit is now passing on `main`. Closing automatically.",
+}
 
 
 def _parse_args(args: list[str] | None) -> argparse.Namespace:
@@ -125,6 +140,38 @@ def _build_cmd(ci_mode: bool) -> list[str]:
     ]
 
 
+def _gha_run_url() -> str | None:
+    server = os.environ.get("GITHUB_SERVER_URL")
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    run_id = os.environ.get("GITHUB_RUN_ID")
+    if not (server and repo and run_id):
+        return None
+    return f"{server}/{repo}/actions/runs/{run_id}"
+
+
+def _write_report(exit_code: int, url: str) -> None:
+    """Write a minimal markdown summary consumable by `slopstopper emit`."""
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    status = "✅ PASSED" if exit_code == 0 else "❌ FAILED"
+    lines = [
+        "## ♿ Accessibility Audit Results",
+        "",
+        f"**Status:** {status}",
+        f"**Target:** `{url}`",
+    ]
+    if exit_code != 0:
+        lines += [
+            "",
+            "Accessibility violations detected. Investigate the failing assertions in the "
+            "[Playwright HTML report](playwright-report/index.html) "
+            "(uploaded as an artifact in CI).",
+        ]
+        run_url = _gha_run_url()
+        if run_url:
+            lines += ["", f"[View the workflow run]({run_url})"]
+    REPORT_MD.write_text("\n".join(lines) + "\n")
+
+
 def run(args: list[str] | None = None) -> int:
     if not _npx_available():
         output.error("npx is not available — install Node.js to run Playwright tests")
@@ -150,4 +197,5 @@ def run(args: list[str] | None = None) -> int:
     env = _build_env(url, parsed.ci)
     cmd = _build_cmd(parsed.ci)
     result = subprocess.run(cmd, env=env, check=False)
+    _write_report(result.returncode, url)
     return result.returncode

--- a/cli/slopstopper/checks/broken_links.py
+++ b/cli/slopstopper/checks/broken_links.py
@@ -43,10 +43,25 @@ import argparse
 import os
 import shutil
 import subprocess
+from pathlib import Path
 
 from slopstopper import discovery, output, templates
 
 SPEC_NAME = "broken-links"
+REPORT_DIR = Path(".ss/reports/reliability")
+REPORT_MD = REPORT_DIR / "broken-links-report.md"
+
+# Consumed by `slopstopper emit reliability:broken-links --target {pr-comment,issue}`.
+# New issue surface — previously this check never opened main-branch issues
+# (the workflow built a PR comment manually but never escalated to an issue).
+META = {
+    "report_path": str(REPORT_MD),
+    "comment_discriminator": "## 🔗 Broken Links Report",
+    "issue_title": "🔗 Broken Links on Main Branch",
+    "issue_labels": ["broken-links", "reliability"],
+    "issue_followup": "🔔 Broken links detected again in commit",
+    "issue_close_comment": "✅ Broken-link check is now passing on `main`. Closing automatically.",
+}
 
 
 def _parse_args(args: list[str] | None) -> argparse.Namespace:
@@ -121,6 +136,37 @@ def _build_cmd(ci_mode: bool) -> list[str]:
     ]
 
 
+def _gha_run_url() -> str | None:
+    server = os.environ.get("GITHUB_SERVER_URL")
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    run_id = os.environ.get("GITHUB_RUN_ID")
+    if not (server and repo and run_id):
+        return None
+    return f"{server}/{repo}/actions/runs/{run_id}"
+
+
+def _write_report(exit_code: int, url: str) -> None:
+    """Write a minimal markdown summary consumable by `slopstopper emit`."""
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    status = "✅ PASSED" if exit_code == 0 else "❌ FAILED"
+    lines = [
+        "## 🔗 Broken Links Report",
+        "",
+        f"**Status:** {status}",
+        f"**Target:** `{url}`",
+    ]
+    if exit_code != 0:
+        lines += [
+            "",
+            "Broken links detected. The [Playwright HTML report](playwright-report/index.html) "
+            "(uploaded as an artifact in CI) lists each failing link and its source page.",
+        ]
+        run_url = _gha_run_url()
+        if run_url:
+            lines += ["", f"[View the workflow run]({run_url})"]
+    REPORT_MD.write_text("\n".join(lines) + "\n")
+
+
 def run(args: list[str] | None = None) -> int:
     if not _npx_available():
         output.error("npx is not available — install Node.js to run Playwright tests")
@@ -145,4 +191,5 @@ def run(args: list[str] | None = None) -> int:
     env = _build_env(url, parsed.ci)
     cmd = _build_cmd(parsed.ci)
     result = subprocess.run(cmd, env=env, check=False)
+    _write_report(result.returncode, url)
     return result.returncode

--- a/cli/slopstopper/checks/smoke.py
+++ b/cli/slopstopper/checks/smoke.py
@@ -38,10 +38,25 @@ import argparse
 import os
 import shutil
 import subprocess
+from pathlib import Path
 
 from slopstopper import config, output, templates
 
 SPEC_NAME = "smoke"
+REPORT_DIR = Path(".ss/reports/reliability")
+REPORT_MD = REPORT_DIR / "smoke-report.md"
+
+# Consumed by `slopstopper emit reliability:smoke --target {pr-comment,issue}`.
+# Issue title + label match the strings the legacy workflow used in raw
+# `gh issue create` so existing open issues continue to dedup post-migration.
+META = {
+    "report_path": str(REPORT_MD),
+    "comment_discriminator": "## Smoke Test Results",
+    "issue_title": "❌ Smoke Tests Failing",
+    "issue_labels": ["smoke-test-failure", "reliability"],
+    "issue_followup": "🔔 Smoke tests failing again in commit",
+    "issue_close_comment": "✅ Smoke tests are now passing on `main`. Closing automatically.",
+}
 
 
 def _parse_args(args: list[str] | None) -> argparse.Namespace:
@@ -100,6 +115,43 @@ def _build_cmd(ci_mode: bool) -> list[str]:
     ]
 
 
+def _gha_run_url() -> str | None:
+    server = os.environ.get("GITHUB_SERVER_URL")
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    run_id = os.environ.get("GITHUB_RUN_ID")
+    if not (server and repo and run_id):
+        return None
+    return f"{server}/{repo}/actions/runs/{run_id}"
+
+
+def _write_report(exit_code: int, url: str) -> None:
+    """Write a minimal markdown summary consumable by `slopstopper emit`.
+
+    Playwright's own HTML report at `playwright-report/` is the source of
+    truth for failure detail; this report just summarises pass/fail and
+    points at it.
+    """
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    status = "✅ PASSED" if exit_code == 0 else "❌ FAILED"
+    lines = [
+        "## Smoke Test Results",
+        "",
+        f"**Status:** {status}",
+        f"**Target:** `{url}`",
+    ]
+    if exit_code != 0:
+        lines += [
+            "",
+            "The smoke tests are failing. Investigate the failing assertion in the "
+            "[Playwright HTML report](playwright-report/index.html) "
+            "(uploaded as an artifact in CI).",
+        ]
+        run_url = _gha_run_url()
+        if run_url:
+            lines += ["", f"[View the workflow run]({run_url})"]
+    REPORT_MD.write_text("\n".join(lines) + "\n")
+
+
 def run(args: list[str] | None = None) -> int:
     if not _npx_available():
         output.error("npx is not available — install Node.js to run Playwright tests")
@@ -119,4 +171,5 @@ def run(args: list[str] | None = None) -> int:
     env = _build_env(url, parsed.ci)
     cmd = _build_cmd(parsed.ci)
     result = subprocess.run(cmd, env=env, check=False)
+    _write_report(result.returncode, url)
     return result.returncode

--- a/cli/tests/checks/test_accessibility.py
+++ b/cli/tests/checks/test_accessibility.py
@@ -185,3 +185,42 @@ def test_run_propagates_playwright_failure(monkeypatch, isolated_cwd):
 
     rc = accessibility.run(["--url", "https://example.com"])
     assert rc == 1
+
+
+# ── report writing ────────────────────────────────────────────────
+
+
+def test_run_writes_report_on_pass(monkeypatch, isolated_cwd):
+    monkeypatch.setattr(accessibility, "_npx_available", lambda: True)
+    monkeypatch.setattr(accessibility, "_discover_pages", lambda: None)
+    monkeypatch.setattr(
+        accessibility.subprocess, "run",
+        lambda cmd, env, check: subprocess.CompletedProcess(cmd, 0),
+    )
+    rc = accessibility.run(["--url", "https://example.com"])
+    assert rc == 0
+    body = accessibility.REPORT_MD.read_text()
+    assert "PASSED" in body
+    assert "https://example.com" in body
+
+
+def test_run_writes_report_on_failure(monkeypatch, isolated_cwd):
+    monkeypatch.setattr(accessibility, "_npx_available", lambda: True)
+    monkeypatch.setattr(accessibility, "_discover_pages", lambda: None)
+    monkeypatch.setattr(
+        accessibility.subprocess, "run",
+        lambda cmd, env, check: subprocess.CompletedProcess(cmd, 1),
+    )
+    rc = accessibility.run(["--url", "https://example.com"])
+    assert rc == 1
+    body = accessibility.REPORT_MD.read_text()
+    assert "FAILED" in body
+    assert "playwright-report" in body
+
+
+def test_meta_matches_legacy_workflow_strings():
+    """Title + label must match the legacy `gh issue create` strings so
+    existing open issues continue to dedup after the workflow migrates."""
+    assert accessibility.META["issue_title"] == "♿ Accessibility Violations Detected on Main Branch"
+    assert "accessibility" in accessibility.META["issue_labels"]
+    assert "reliability" in accessibility.META["issue_labels"]

--- a/cli/tests/checks/test_broken_links.py
+++ b/cli/tests/checks/test_broken_links.py
@@ -178,3 +178,39 @@ def test_run_propagates_playwright_failure(monkeypatch, isolated_cwd):
 
     rc = broken_links.run(["--url", "https://example.com"])
     assert rc == 1
+
+
+# ── report writing ────────────────────────────────────────────────
+
+
+def test_run_writes_report_on_pass(monkeypatch, isolated_cwd):
+    monkeypatch.setattr(broken_links, "_npx_available", lambda: True)
+    monkeypatch.setattr(broken_links, "_discover_pages", lambda: None)
+    monkeypatch.setattr(
+        broken_links.subprocess, "run",
+        lambda cmd, env, check: subprocess.CompletedProcess(cmd, 0),
+    )
+    rc = broken_links.run(["--url", "https://example.com"])
+    assert rc == 0
+    body = broken_links.REPORT_MD.read_text()
+    assert "PASSED" in body
+    assert "https://example.com" in body
+
+
+def test_run_writes_report_on_failure(monkeypatch, isolated_cwd):
+    monkeypatch.setattr(broken_links, "_npx_available", lambda: True)
+    monkeypatch.setattr(broken_links, "_discover_pages", lambda: None)
+    monkeypatch.setattr(
+        broken_links.subprocess, "run",
+        lambda cmd, env, check: subprocess.CompletedProcess(cmd, 1),
+    )
+    rc = broken_links.run(["--url", "https://example.com"])
+    assert rc == 1
+    body = broken_links.REPORT_MD.read_text()
+    assert "FAILED" in body
+    assert "playwright-report" in body
+
+
+def test_meta_includes_reliability_and_broken_links_labels():
+    assert "broken-links" in broken_links.META["issue_labels"]
+    assert "reliability" in broken_links.META["issue_labels"]

--- a/cli/tests/checks/test_smoke.py
+++ b/cli/tests/checks/test_smoke.py
@@ -164,3 +164,41 @@ def test_run_propagates_playwright_failure(monkeypatch, isolated_cwd):
 
     rc = smoke.run(["--url", "https://example.com"])
     assert rc == 1
+
+
+# ── report writing ────────────────────────────────────────────────
+
+
+def test_run_writes_report_on_pass(monkeypatch, isolated_cwd):
+    monkeypatch.setattr(smoke, "_npx_available", lambda: True)
+    monkeypatch.setattr(
+        smoke.subprocess, "run",
+        lambda cmd, env, check: subprocess.CompletedProcess(cmd, 0),
+    )
+    rc = smoke.run(["--url", "https://example.com"])
+    assert rc == 0
+    assert smoke.REPORT_MD.exists()
+    body = smoke.REPORT_MD.read_text()
+    assert "PASSED" in body
+    assert "https://example.com" in body
+
+
+def test_run_writes_report_on_failure_with_playwright_link(monkeypatch, isolated_cwd):
+    monkeypatch.setattr(smoke, "_npx_available", lambda: True)
+    monkeypatch.setattr(
+        smoke.subprocess, "run",
+        lambda cmd, env, check: subprocess.CompletedProcess(cmd, 1),
+    )
+    rc = smoke.run(["--url", "https://example.com"])
+    assert rc == 1
+    body = smoke.REPORT_MD.read_text()
+    assert "FAILED" in body
+    assert "playwright-report" in body
+
+
+def test_meta_matches_legacy_workflow_strings():
+    """Title + label must match the legacy `gh issue create` strings so
+    existing open issues continue to dedup after the workflow migrates."""
+    assert smoke.META["issue_title"] == "❌ Smoke Tests Failing"
+    assert "smoke-test-failure" in smoke.META["issue_labels"]
+    assert "reliability" in smoke.META["issue_labels"]

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -45,7 +45,14 @@ def test_emit_unknown_check_returns_2(capsys):
 
 
 def test_emit_no_meta_returns_2(monkeypatch, capsys):
-    # Pick a check that has no META yet — accessibility currently doesn't.
+    """When a check module is loaded but lacks META, dispatcher returns 2.
+
+    Every shipped check has META as of PR 3, so this test patches one
+    away to exercise the dispatcher's missing-META branch.
+    """
+    from slopstopper.checks import accessibility
+
+    monkeypatch.setattr(accessibility, "META", None)
     rc = cli.main(["emit", "reliability:accessibility", "--target", "pr-comment"])
     assert rc == 2
     assert "has no META" in capsys.readouterr().err

--- a/cli/tests/test_emit.py
+++ b/cli/tests/test_emit.py
@@ -508,3 +508,39 @@ def test_emit_threads_check_name_to_emit_issue(monkeypatch):
     rc = emit.emit("issue", SAMPLE_META, check_name="hygiene:docs-size")
     assert rc == 0
     assert called["check_name"] == "hygiene:docs-size"
+
+
+# ── META completeness ────────────────────────────────────────────
+
+
+def test_every_check_has_meta():
+    """Every check in REGISTRY must define a META dict, or be explicitly exempt.
+
+    Prevents silent regressions where a new check lands without emit support
+    and is only discovered when an adopter runs `slopstopper emit <check>`.
+    """
+    import importlib
+
+    from slopstopper.checks import REGISTRY
+
+    # Checks with no emit support by design. Empty as of PR 3 (every shipped
+    # check has at least PR-comment-only META). Add a check name here only
+    # if there's a documented architectural reason it cannot emit.
+    EMIT_EXEMPT: set[str] = set()
+
+    missing: list[str] = []
+    for check_name in REGISTRY:
+        if check_name in EMIT_EXEMPT:
+            continue
+        parts = check_name.split(":")[1:]
+        module_name = "slopstopper.checks." + "_".join(parts).replace("-", "_")
+        module = importlib.import_module(module_name)
+        if getattr(module, "META", None) is None:
+            missing.append(check_name)
+
+    assert missing == [], (
+        f"Checks without META: {missing}. Add a META dict to each check "
+        "module (see the slopstopper.emit module docstring for the schema), "
+        "or add the check name to EMIT_EXEMPT in this test with a documented "
+        "reason."
+    )


### PR DESCRIPTION
## Summary

Brings the three Playwright-wrapper reliability checks into the central `slopstopper emit` machinery so PR 4 can replace their inline `gh issue create` workflow blocks with `slopstopper emit <check> --target ...`. Each check now defines:

- A `META` dict (issue title + labels + follow-up + close-comment, plus PR-comment discriminator).
- A `_write_report()` helper that writes a minimal markdown summary to `.ss/reports/reliability/<check>-report.md` after every run. The Playwright HTML report stays the source of truth for detailed failure traces; this report just summarises pass/fail and links to it.

Plus: a new `test_every_check_has_meta` that walks `REGISTRY` and fails the build if any check lacks META — prevents future silent regressions.

## Issue-title preservation for migration safety

For checks that already have open issues on `main` (smoke, accessibility), META preserves the exact title + label strings the legacy `gh issue create` workflow blocks used. After PR 4 lands, `emit_issue`'s label-intersection dedup will find and update those existing issues rather than orphaning them and opening duplicates.

`broken-links` is new to the issue-emission surface — it never opened main-branch issues before. New title (`🔗 Broken Links on Main Branch`) + labels (`[broken-links, reliability]`).

## Files

- `cli/slopstopper/checks/smoke.py` — META + REPORT_MD + `_write_report()` + call from `run()`.
- `cli/slopstopper/checks/accessibility.py` — same shape.
- `cli/slopstopper/checks/broken_links.py` — same shape.
- `cli/tests/checks/test_{smoke,accessibility,broken_links}.py` — pass-path + failure-path report-writing tests; META label/title assertions to keep migration safety honest.
- `cli/tests/test_emit.py` — new `test_every_check_has_meta` that walks `REGISTRY` and asserts META exists for every shipped check (empty `EMIT_EXEMPT` set today).
- `cli/tests/test_cli.py` — `test_emit_no_meta_returns_2` now monkeypatches `accessibility.META = None` to exercise the dispatcher's missing-META branch (since every check has META now).
- `.claude/skills/slopstopper-triage/SKILL.md` — one-line maintainer note in 'Maintaining this skill' that adding a new check requires META.

## Test plan

- [x] `task -t cli/Taskfile.yml test` — 525 passed
- [x] `task ss:hygiene:test` — all green
- [ ] CI suite green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)