### PR TITLE
feat(workflows): unify issue lifecycle through slopstopper emit

### DIFF
--- a/.claude/skills/slopstopper-update/SKILL.md
+++ b/.claude/skills/slopstopper-update/SKILL.md
@@ -33,7 +33,7 @@ What this refreshes (always, on every run):
 - `slopstopper-cli` — `pipx upgrade slopstopper-cli` (preferred) or `pip install --user --upgrade slopstopper-cli` fallback. Pulled from PyPI, so always lands the latest release. Confirm with `slopstopper --version`.
 - `Taskfile.ss.yml` — thin `task ss:*` shims that all call `slopstopper run …` under the hood.
 - `.ss/server.js` — the only file the installer seeds into `.ss/`. Wholesale replacement.
-- Each workflow in `install.sh`'s `GENERIC_WORKFLOWS` array — provided it's still present in the target's `.github/workflows/`. The workflow body itself is short now (~8 lines: install CLI, `slopstopper run …`, `slopstopper emit …`), so most updates are CLI-version bumps invisible to the workflow YAML.
+- Each workflow in `install.sh`'s `GENERIC_WORKFLOWS` array — provided it's still present in the target's `.github/workflows/`. The workflow body itself is short now (~8 lines: install CLI, `slopstopper run …`, `slopstopper emit …`, optionally `slopstopper emit … --on-pass=close`), so most updates are CLI-version bumps invisible to the workflow YAML. Issue lifecycle (open + close + body marker + `slopstopper` label) is fully owned by `slopstopper emit` as of the issue-emission unification — adopters who customised the legacy inline `gh issue create` blocks will see them replaced on update; re-apply any bespoke wording via the check's META (`issue_title` / `issue_close_comment` / etc.) rather than back in the workflow YAML.
 
 What it scrubs:
 - `.ss/scripts/` — pre-CLI installs leave this directory behind. Every Python/bash script that used to live there is now bundled in `slopstopper-cli`. The installer detects the directory and removes it; commit the deletion as part of the upgrade PR.

--- a/.github/workflows/ss-hygiene-complexity-check.yml
+++ b/.github/workflows/ss-hygiene-complexity-check.yml
@@ -94,6 +94,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: slopstopper emit hygiene:complexity --target issue
 
+      - name: Close issue on main when clean
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.gate.outputs.high_complexity_found != '1'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: slopstopper emit hygiene:complexity --target issue --on-pass=close
+
       - name: Fail job if high complexity found
         if: steps.gate.outputs.high_complexity_found == '1'
         run: |

--- a/.github/workflows/ss-hygiene-docs-accuracy-check.yml
+++ b/.github/workflows/ss-hygiene-docs-accuracy-check.yml
@@ -110,15 +110,7 @@ jobs:
           && steps.check.outcome == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Auto-close any open tracking issue when docs are clean.
-          # emit.py models only create/update, so the close path lives
-          # here as a small inline gh loop.
-          numbers=$(gh issue list --state open --label documentation-accuracy --json number --jq '.[].number')
-          for n in $numbers; do
-            gh issue comment "$n" --body "✅ Documentation accuracy checks now pass. Closing automatically."
-            gh issue close "$n"
-          done
+        run: slopstopper emit hygiene:docs-accuracy --target issue --on-pass=close
 
       - name: Upload accuracy report
         if: always()

--- a/.github/workflows/ss-hygiene-docs-size-check.yml
+++ b/.github/workflows/ss-hygiene-docs-size-check.yml
@@ -81,6 +81,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: slopstopper emit hygiene:docs-size --target issue
 
+      - name: Close issue on main when within thresholds
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.check.outputs.has_alerts != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: slopstopper emit hygiene:docs-size --target issue --on-pass=close
+
       - name: Warn if thresholds exceeded on main
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.check.outputs.has_alerts == 'true'
         run: |

--- a/.github/workflows/ss-hygiene-docs-structure-check.yml
+++ b/.github/workflows/ss-hygiene-docs-structure-check.yml
@@ -74,6 +74,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: slopstopper emit hygiene:docs-structure --target issue
 
+      - name: Close issue on main when clean
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.check.outcome == 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: slopstopper emit hygiene:docs-structure --target issue --on-pass=close
+
       - name: Upload structure report
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ss-reliability-accessibility-check.yml
+++ b/.github/workflows/ss-reliability-accessibility-check.yml
@@ -187,92 +187,16 @@ jobs:
         if: github.event_name == 'pull_request' && always()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JOB_STATUS: ${{ job.status }}
-          INPUT_IMPACT: ${{ github.event.inputs.impact || 'serious' }}
-          INPUT_THRESHOLD: ${{ github.event.inputs.threshold || '0' }}
-        run: |
-          status_marker=$([ "$JOB_STATUS" = "success" ] && echo "✅ PASSED" || echo "❌ FAILED")
-          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          failure_note=""
-          if [ "$JOB_STATUS" != "success" ]; then
-            failure_note=$'\n> ⚠️ Violations were detected. See workflow logs for details.\n'
-          fi
-          body=$(cat <<EOF
-          ## ♿ Accessibility Audit ${status_marker}
+        run: slopstopper emit reliability:accessibility --target pr-comment
 
-          **Standard:** WCAG 2.1 AA  **Min impact:** \`${INPUT_IMPACT}\`  **Max violations allowed:** ${INPUT_THRESHOLD}
-          ${failure_note}
-          ### 🔍 How to Check Locally
-
-          \`\`\`bash
-          task ss:reliability:accessibility -- https://your-site.example.com
-          \`\`\`
-
-          [Full report in workflow artifacts](${run_url})
-          EOF
-          )
-          marker='♿ Accessibility Audit'
-          pr_number=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
-          existing=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" \
-            --jq ".[] | select(.user.type==\"Bot\" and (.body | contains(\"$marker\"))) | .id" | head -n1)
-          if [ -n "$existing" ]; then
-            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" -f body="$body"
-          else
-            gh pr comment "$pr_number" --body "$body"
-          fi
-
-      - name: Open / update issue on accessibility failure (main)
+      - name: Emit issue on accessibility failure (main)
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          title='♿ Accessibility Violations Detected on Main Branch'
-          label='accessibility'
-          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          sha_short="${GITHUB_SHA:0:7}"
-          body=$(cat <<EOF
-          ## Accessibility Audit Failure
+        run: slopstopper emit reliability:accessibility --target issue
 
-          **Commit:** [\`${sha_short}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})
-          **Run:** [#${GITHUB_RUN_ID}](${run_url})
-
-          Accessibility violations above the configured impact threshold were found on the main branch.
-
-          ## How to Reproduce Locally
-
-          \`\`\`bash
-          # Start the local server
-          npm run build && slopstopper serve &
-
-          # Run accessibility audit
-          task ss:reliability:accessibility -- http://localhost:8080
-          \`\`\`
-
-          [View the failed workflow run](${run_url})
-
-          ---
-          *This issue was automatically created by the Accessibility Check workflow.*
-          EOF
-          )
-          existing=$(gh issue list --state open --label "$label" --search "in:title $title" --json number,title --jq ".[] | select(.title==\"$title\") | .number" | head -n1)
-          if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body "## New Failure
-
-          **Time:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
-          **Run:** [#${GITHUB_RUN_ID}](${run_url})"
-          else
-            gh issue create --title "$title" --body "$body" --label "$label" --label reliability
-          fi
-
-      - name: Close accessibility issue on success (main)
+      - name: Close accessibility issue on recovery (main)
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          title='♿ Accessibility Violations Detected on Main Branch'
-          label='accessibility'
-          numbers=$(gh issue list --state open --label "$label" --search "in:title $title" --json number,title --jq ".[] | select(.title==\"$title\") | .number")
-          for n in $numbers; do
-            gh issue comment "$n" --body "✅ Accessibility audit is now passing. Closing this issue automatically."
-            gh issue close "$n"
-          done
+        run: slopstopper emit reliability:accessibility --target issue --on-pass=close

--- a/.github/workflows/ss-reliability-broken-links-check.yml
+++ b/.github/workflows/ss-reliability-broken-links-check.yml
@@ -34,6 +34,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   broken-links:
@@ -174,34 +175,16 @@ jobs:
         if: github.event_name == 'pull_request' && always()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JOB_STATUS: ${{ job.status }}
-          CHECK_URL: ${{ steps.url.outputs.url }}
-        run: |
-          status_marker=$([ "$JOB_STATUS" = "success" ] && echo "✅ PASSED" || echo "❌ FAILED")
-          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          body=$(cat <<EOF
-          ## 🔗 Broken Links Check ${status_marker}
+        run: slopstopper emit reliability:broken-links --target pr-comment
 
-          **Checked URL:** ${CHECK_URL}
+      - name: Emit issue on broken-links failure (main)
+        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: slopstopper emit reliability:broken-links --target issue
 
-          ### 🔍 How to Check Locally
-
-          \`\`\`bash
-          task ss:reliability:broken-links -- https://your-site.example.com
-          \`\`\`
-
-          [Full report in workflow artifacts](${run_url})
-          EOF
-          )
-          # Match the existing bot comment by the H2 marker and update
-          # in place, else create. Keeps one rolling comment per PR
-          # rather than appending on every push.
-          marker='🔗 Broken Links Check'
-          pr_number=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
-          existing=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" \
-            --jq ".[] | select(.user.type==\"Bot\" and (.body | contains(\"$marker\"))) | .id" | head -n1)
-          if [ -n "$existing" ]; then
-            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" -f body="$body"
-          else
-            gh pr comment "$pr_number" --body "$body"
-          fi
+      - name: Close broken-links issue on recovery (main)
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: slopstopper emit reliability:broken-links --target issue --on-pass=close

--- a/.github/workflows/ss-reliability-core-web-vitals.yml
+++ b/.github/workflows/ss-reliability-core-web-vitals.yml
@@ -181,7 +181,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: slopstopper emit reliability:cwv --target issue
 
-      - name: Close CWV failure issue on success
+      - name: Close CWV failure issue on recovery
         if: |
           steps.cwv.outcome == 'success' && (
             (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
@@ -190,14 +190,7 @@ jobs:
           )
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          title='❌ Core Web Vitals Below Threshold'
-          label='cwv-failure'
-          numbers=$(gh issue list --state open --label "$label" --search "in:title $title" --json number,title --jq ".[] | select(.title==\"$title\") | .number")
-          for n in $numbers; do
-            gh issue comment "$n" --body "✅ Core Web Vitals are now passing all thresholds. Closing this issue automatically."
-            gh issue close "$n"
-          done
+        run: slopstopper emit reliability:cwv --target issue --on-pass=close
 
       - name: Fail the job if CWV thresholds were not met
         if: steps.cwv.outcome == 'failure'

--- a/.github/workflows/ss-reliability-smoke-tests.yml
+++ b/.github/workflows/ss-reliability-smoke-tests.yml
@@ -158,55 +158,14 @@ jobs:
 
           [View detailed results](${run_url})"
 
-      - name: Open / update issue on smoke failure
-        if: failure()
+      - name: Emit issue on smoke failure
+        if: failure() && github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          URL: ${{ steps.url.outputs.url }}
-        run: |
-          title='❌ Smoke Tests Failing'
-          label='smoke-test-failure'
-          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          body=$(cat <<EOF
-          ## Smoke Test Failure Detected
+        run: slopstopper emit reliability:smoke --target issue
 
-          **URL Tested:** ${URL}
-          **Run:** [#${GITHUB_RUN_ID}](${run_url})
-
-          The smoke tests are failing on the deployed site.
-
-          ## How to Investigate
-
-          \`\`\`bash
-          task ss:reliability:smoke -- "${URL}"
-          \`\`\`
-
-          [View the failed workflow run](${run_url})
-
-          ---
-          *This issue was automatically created by the Reliability Smoke Tests workflow.*
-          EOF
-          )
-          existing=$(gh issue list --state open --label "$label" --search "in:title $title" --json number,title --jq ".[] | select(.title==\"$title\") | .number" | head -n1)
-          if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body "## New Failure
-
-          **Time:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
-          **URL Tested:** ${URL}
-          **Run:** [#${GITHUB_RUN_ID}](${run_url})"
-          else
-            gh issue create --title "$title" --body "$body" --label "$label" --label reliability
-          fi
-
-      - name: Close smoke failure issue on success
-        if: success()
+      - name: Close smoke failure issue on recovery
+        if: success() && github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          title='❌ Smoke Tests Failing'
-          label='smoke-test-failure'
-          numbers=$(gh issue list --state open --label "$label" --search "in:title $title" --json number,title --jq ".[] | select(.title==\"$title\") | .number")
-          for n in $numbers; do
-            gh issue comment "$n" --body "✅ Smoke tests are now passing. Closing this issue automatically."
-            gh issue close "$n"
-          done
+        run: slopstopper emit reliability:smoke --target issue --on-pass=close

--- a/.github/workflows/ss-security-dast-check.yml
+++ b/.github/workflows/ss-security-dast-check.yml
@@ -103,6 +103,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: slopstopper emit security:dast --target issue
 
+      - name: Close issue on main when clean
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.dast.outcome == 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: slopstopper emit security:dast --target issue --on-pass=close
+
       - name: Fail job if gate found blocking alerts
         if: steps.dast.outcome == 'failure'
         run: |

--- a/.github/workflows/ss-security-sast-check.yml
+++ b/.github/workflows/ss-security-sast-check.yml
@@ -100,6 +100,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: slopstopper emit security:sast --target issue
 
+      - name: Close issue on main when clean
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.gate.outputs.errors_found != '1'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: slopstopper emit security:sast --target issue --on-pass=close
+
       - name: Fail job if error-severity findings
         if: steps.gate.outputs.errors_found == '1'
         run: |

--- a/.github/workflows/ss-security-secrets-check.yml
+++ b/.github/workflows/ss-security-secrets-check.yml
@@ -120,6 +120,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: slopstopper emit security:secrets --target issue
 
+      - name: Close issue on main when clean
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.gate.outputs.secrets_found != '1'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: slopstopper emit security:secrets --target issue --on-pass=close
+
       - name: Fail job if secrets detected
         if: steps.gate.outputs.secrets_found == '1'
         run: |

--- a/.github/workflows/ss-security-vulnerability-all-check.yml
+++ b/.github/workflows/ss-security-vulnerability-all-check.yml
@@ -87,3 +87,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: slopstopper emit security:vulnerability:all --target issue
+
+      - name: Close issue on main when clean
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.dependencies.outcome == 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: slopstopper emit security:vulnerability:all --target issue --on-pass=close

--- a/cli/slopstopper/checks/cwv.py
+++ b/cli/slopstopper/checks/cwv.py
@@ -66,6 +66,7 @@ META = {
     "issue_title": "❌ Core Web Vitals Below Threshold",
     "issue_labels": ["cwv-failure", "reliability"],
     "issue_followup": "🔔 Core Web Vitals failure recurred in commit",
+    "issue_close_comment": "✅ Core Web Vitals are now passing all thresholds. Closing automatically.",
 }
 
 

--- a/cli/slopstopper/checks/docs_accuracy.py
+++ b/cli/slopstopper/checks/docs_accuracy.py
@@ -33,14 +33,16 @@ REPORT_MD = REPORT_DIR / "docs-accuracy-report.md"
 # Discriminator matches the H1 of the report ("# 🔎 Documentation Accuracy Report")
 # so the same bot comment is reused after the workflow flip. Issue title,
 # labels, and follow-up string are byte-identical to the legacy block. The
-# pre-flip workflow's "close issue when clean" behaviour stays in YAML (see
-# the workflow's final step) — emit.py only handles create/update, not close.
+# close behaviour is also driven by emit (`--on-pass=close`) since PR 1 of
+# the issue-emission unification — close_comment matches the legacy YAML
+# message so adopters see the same friendly recovery line.
 META = {
     "report_path": str(REPORT_MD),
     "comment_discriminator": "🔎 Documentation Accuracy",
     "issue_title": "🔎 Documentation Accuracy Issues",
     "issue_labels": ["documentation-accuracy", "documentation"],
     "issue_followup": "🔔 Documentation accuracy issues detected again",
+    "issue_close_comment": "✅ Documentation accuracy checks now pass. Closing automatically.",
 }
 
 DOCS_DIR = Path("docs")


### PR DESCRIPTION
## Summary

11 workflows now read identically. `slopstopper emit <check> --target {pr-comment,issue} [--on-pass=close]` is the single verb for issue lifecycle. Net deletion of 104 lines: inline `gh issue create` blocks, hand-rolled `gh issue list/close` loops, and `cat <<EOF` PR-comment construction are all gone.

## Three categories of change

### 1. Three bypass workflows migrated to emit

| Workflow | Replaced |
|---|---|
| `ss-reliability-smoke-tests.yml` | Raw `gh issue create` (open) + raw close loop → `--target issue` + `--on-pass=close` |
| `ss-reliability-accessibility-check.yml` | Inline PR-comment construction + raw open + raw close → three emit calls |
| `ss-reliability-broken-links-check.yml` | Inline PR-comment construction → `--target pr-comment`; **new** issue open + close paths (was previously issue-less); gains `issues: write` permission |

Title + label strings preserved verbatim from the legacy YAML so existing open issues continue to dedup. Broken-links is net-new to the issue surface.

### 2. Asymmetric workflows symmetrised

- `ss-reliability-core-web-vitals.yml` — close path was hand-rolled `gh` loop while open used emit. Now both use emit.
- `ss-hygiene-docs-accuracy-check.yml` — same pattern.

Bespoke close-comment text preserved via new `issue_close_comment` keys in cwv + docs-accuracy META.

### 3. Seven missing close-on-pass paths added

- `ss-security-sast-check.yml`
- `ss-security-secrets-check.yml`
- `ss-security-dast-check.yml`
- `ss-security-vulnerability-all-check.yml`
- `ss-hygiene-complexity-check.yml`
- `ss-hygiene-docs-size-check.yml`
- `ss-hygiene-docs-structure-check.yml`

Each gains a "Close issue when clean" step paired with its existing emit-issue step. Stale issues no longer accumulate on these checks.

## Pre-PR-2 issue migration

Issues created before PR 263 (brand label + body marker) lack the `slopstopper` label, so emit's label-intersection dedup won't auto-match them post-merge. Two recovery paths:

- Trigger a re-failure on `main` → `_update_issue_body` regenerates the body and migrates the marker. Subsequent close-on-pass picks it up.
- Close stale issues manually if the underlying finding is already resolved.

The triage skill's pre-marker gotcha row (added in PR 263) is the documented migration playbook.

## PR shape

PR 4 of 5 from the issue-emission unification plan. PR 5 will switch `ss-workflow-failure-issue.yml`'s dedup heuristic from the broken run-URL heuristic to the body marker.

## Files

- 11 workflow YAML files (the migration, summarised above).
- `cli/slopstopper/checks/cwv.py` + `cli/slopstopper/checks/docs_accuracy.py` — new `issue_close_comment` keys in META preserve bespoke close-comment wording.
- `.claude/skills/slopstopper-update/SKILL.md` — Step 2 'what this refreshes' note that issue lifecycle is now fully owned by emit; bespoke wording belongs in META, not workflow YAML.

## Test plan

- [x] `task -t cli/Taskfile.yml test` — 525 passed
- [x] `task ss:hygiene:test` — all green
- [ ] CI suite green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)