### PR TITLE
feat(install): bundle Claude Code skill trio into install.sh

### DIFF
--- a/.claude/skills/slopstopper-install/SKILL.md
+++ b/.claude/skills/slopstopper-install/SKILL.md
@@ -68,6 +68,8 @@ curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/ins
 
 The installer is idempotent. Re-running it pulls newer checks but respects deletions (tracked via `.ss/.workflows-installed`), and refreshes `slopstopper-cli` via `pipx upgrade` (or re-runs `pip install --user --upgrade` when pipx isn't available). All slopstopper files live under the `ss` namespace — your repo's existing files are not touched. If a pre-CLI install left a `.ss/scripts/` directory behind, the installer scrubs it on first run.
 
+**`install.sh` also installs the SlopStopper Claude Code skill trio** at `~/.claude/skills/slopstopper-{install,update,triage}/` when `~/.claude` exists on the machine (user-profile level, not repo-level). Skipped silently if Claude Code isn't set up. Pass `--no-skills` or set `SLOPSTOPPER_NO_SKILLS=1` to disable. Adopters who set up Claude Code later can run `install-skill.sh` separately to backfill.
+
 By default the installer ships **Task-driven workflows** — every check runs via `task ss:<category>:<check>` so the suite shares one invocation surface with `task build`, `task deploy`, etc. The workflows install Task themselves via `arduino/setup-task@v2`, so adopters don't need it in their CI runners by hand. If the adopter explicitly doesn't want Task in their CI, install with `--no-task`:
 
 ```bash

--- a/.claude/skills/slopstopper-update/SKILL.md
+++ b/.claude/skills/slopstopper-update/SKILL.md
@@ -24,15 +24,17 @@ git checkout -b chore/slopstopper-refresh
 
 If `git status` shows uncommitted changes: stop. Commit or stash them first — the installer's wipe-and-replace behaviour will clobber anything sitting in the tracked files it rewrites.
 
-## Step 1 — Refresh this skill first
+## Step 1 — Note: skill trio auto-refreshes as part of Step 2
 
-The update playbook itself evolves. Before doing anything else, re-run the skill installer so you're working from the latest version:
+Re-running `install.sh` in Step 2 also refreshes the SlopStopper skill trio at `~/.claude/skills/slopstopper-*` (unless you pass `--no-skills`). So an old SKILL.md on disk gets replaced with the latest before the next agent session picks it up.
+
+**This invocation is already running off the in-memory SKILL.md** — the refresh helps the next session, not this one. If you suspect this skill is significantly out of date and want the latest BEFORE continuing, abort here and re-invoke after manually running:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install-skill.sh | bash
 ```
 
-The script is idempotent: it compares each fetched `SKILL.md` against what's on disk and only overwrites if the content differs. Safe to run any time. It refreshes the whole trio (`slopstopper-install`, `slopstopper-update`, `slopstopper-triage`), not just this one.
+Otherwise carry on to Step 2 — the refresh happens automatically there.
 
 ## Step 2 — Re-run the installer in-place
 

--- a/README.md
+++ b/README.md
@@ -158,11 +158,13 @@ Contributions are welcome. The full contributor guide lives in [`docs/contributi
 
 If an AI agent (Claude, Copilot, Cursor, etc.) is working on this repo, the canonical conventions live in [`AGENTS.md`](./AGENTS.md). [`CLAUDE.md`](./CLAUDE.md) imports `AGENTS.md` so Claude Code picks up the same instructions automatically.
 
-**Using Claude Code?** Install the [`slopstopper-install`](./.claude/skills/slopstopper-install/SKILL.md) / [`slopstopper-update`](./.claude/skills/slopstopper-update/SKILL.md) / [`slopstopper-triage`](./.claude/skills/slopstopper-triage/SKILL.md) skill trio once per machine — Claude Code auto-picks the right one per prompt. Runbook: [`docs/runbooks/INSTALL_SKILLS.md`](./docs/runbooks/INSTALL_SKILLS.md).
+**Using Claude Code?** The skill trio ([`install`](./.claude/skills/slopstopper-install/SKILL.md) / [`update`](./.claude/skills/slopstopper-update/SKILL.md) / [`triage`](./.claude/skills/slopstopper-triage/SKILL.md)) auto-installs with `install.sh` when `~/.claude/` exists; re-runs refresh. `--no-skills` opts out, or run:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install-skill.sh | bash
 ```
+
+Runbook: [`docs/runbooks/INSTALL_SKILLS.md`](./docs/runbooks/INSTALL_SKILLS.md).
 
 ---
 

--- a/docs/runbooks/INSTALL_SKILLS.md
+++ b/docs/runbooks/INSTALL_SKILLS.md
@@ -73,7 +73,9 @@ Claude Code stops invoking the skills immediately on next prompt. No other state
 
 The skills are *for* installing/updating/triaging SlopStopper in target repos. Committing them into target repos is circular (by the time the skills are there, the install they describe is already done). User-global is the right shape — install once, every project benefits.
 
-Bundling the skills into `install.sh` was considered and rejected for the same reason: `install.sh` runs *inside* a target repo, but the skills need to be available *before* you're inside a target repo (you need them to know how to install). Two scripts, two scopes — `install.sh` for the suite-in-the-repo, `install-skill.sh` for the skills-on-the-machine.
+Two scripts, two scopes — `install.sh` for the suite-in-the-repo, `install-skill.sh` for the skills-on-the-machine. The scripts stay separate (they target different filesystems) but they're no longer disconnected: as of the bundling change, **`install.sh` calls `install-skill.sh` as a post-install convenience** when `~/.claude` exists on the machine. So an adopter re-running `install.sh` to refresh their suite also gets their skill trio refreshed in the same command. Pass `--no-skills` (or set `SLOPSTOPPER_NO_SKILLS=1`) to disable.
+
+This doesn't solve the chicken-and-egg of FIRST-time install (the human still has to know about `install.sh` from the README) — but every subsequent re-run keeps skills current without a second command. Adopters who set up Claude Code AFTER their first slopstopper install just need to re-run `install.sh` once to backfill the trio, or run `install-skill.sh` directly.
 
 ## When this runbook needs updating
 

--- a/install.sh
+++ b/install.sh
@@ -63,11 +63,20 @@ if [ -n "${SLOPSTOPPER_NO_TASK:-}" ]; then
   USE_TASK=false
 fi
 
+INSTALL_SKILLS=true
+if [ -n "${SLOPSTOPPER_NO_SKILLS:-}" ]; then
+  INSTALL_SKILLS=false
+fi
+
 POSITIONAL=()
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --no-task)
       USE_TASK=false
+      shift
+      ;;
+    --no-skills)
+      INSTALL_SKILLS=false
       shift
       ;;
     --help|-h)
@@ -77,13 +86,19 @@ install.sh — install the SlopStopper quality suite into a target repo.
 Usage:
   bash install.sh [TARGET_DIR]              # Task-driven workflows (default)
   bash install.sh --no-task [TARGET_DIR]    # CLI-driven workflows (no Task install)
+  bash install.sh --no-skills [TARGET_DIR]  # Skip installing Claude Code skills
 
 Env var equivalents:
   SLOPSTOPPER_NO_TASK=1 bash install.sh
+  SLOPSTOPPER_NO_SKILLS=1 bash install.sh
 
 Default mode installs workflows that invoke `task ss:<check>` so the suite
 shares a single invocation surface with the rest of your codebase. `--no-task`
 installs workflows that invoke `slopstopper run <check>` directly.
+
+If ~/.claude/ exists (Claude Code is set up on this machine), the installer
+also refreshes the SlopStopper skill trio at ~/.claude/skills/slopstopper-*
+by curl-piping install-skill.sh. Pass --no-skills to skip this step.
 USAGE
       exit 0
       ;;
@@ -662,6 +677,38 @@ if [ -f "$TARGET_DIR/.slopstopper.yml" ] && command -v slopstopper &>/dev/null; 
     fi
   fi
 fi
+
+# ── install Claude Code skill trio (best-effort, user-profile level) ─────────
+
+# install-skill.sh writes to ~/.claude/skills/slopstopper-*/ — i.e. the
+# user profile, not the target repo. Done as part of install.sh so adopters
+# get the trio without a separate command. Skipped silently if Claude Code
+# isn't set up on this machine (no ~/.claude directory) or if --no-skills
+# / SLOPSTOPPER_NO_SKILLS was passed.
+
+install_claude_skills() {
+  if [ "$INSTALL_SKILLS" = "false" ]; then
+    info "Skipping Claude Code skill install (--no-skills / SLOPSTOPPER_NO_SKILLS)."
+    return 0
+  fi
+  if [ ! -d "${HOME}/.claude" ]; then
+    info "No ~/.claude directory found — skipping Claude Code skill install."
+    info "If you set up Claude Code later, run:"
+    info "  curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install-skill.sh | bash"
+    return 0
+  fi
+  echo ""
+  sep
+  echo "  🧠  Installing the SlopStopper Claude Code skill trio…"
+  sep
+  if ! curl -fsSL "https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install-skill.sh" | bash; then
+    warn "Skill install failed (non-fatal). You can re-run it later:"
+    info "  curl -fsSL https://raw.githubusercontent.com/hungovercoders/slopstopper/main/install-skill.sh | bash"
+    return 0
+  fi
+}
+
+install_claude_skills
 
 # ── post-install guidance ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes the "how do skills get new info?" gap surfaced after the issue-emission unification.

`install.sh` now runs `install-skill.sh` as a post-install convenience when `~/.claude/` exists on the machine. Every adopter re-running install.sh to refresh the suite also gets the SlopStopper skill trio at `~/.claude/skills/slopstopper-{install,update,triage}/` refreshed — without remembering a second command.

Opt-out via `--no-skills` flag or `SLOPSTOPPER_NO_SKILLS=1` env var. Skipped silently if `~/.claude/` doesn't exist (don't force Claude Code structure on non-users).

## Why

Two related coherence problems pre-bundling:

1. **Skills never auto-refreshed.** An adopter who installed the skill trio months ago would keep running stale SKILL.md content. The only way to refresh was running `install-skill.sh` separately — which isn't part of any obvious flow.
2. **`slopstopper-update` Step 1's self-refresh was misleading.** It told the agent to `curl install-skill.sh | bash` first, claiming "you're working from the latest version." But the agent had already loaded the in-memory SKILL.md before Step 1 ran — the refresh only helps the NEXT session.

Folding skill install into `install.sh` fixes both: skills refresh automatically every time the suite does, and the misleading "Step 1 self-refresh" can be honest about being a next-session benefit (or dropped entirely in favour of Step 2's install.sh re-run doing the work).

## What stays the same

- `install-skill.sh` is still a separate script. Different scope (user-profile vs. repo) — they don't collapse into one. But `install.sh` now calls it.
- The chicken-and-egg of first-time install is unchanged: humans still discover `install.sh` via the README; the skill trio is a progressive enhancement, not a prerequisite.
- Adopters who don't use Claude Code see no behavioural change (`~/.claude/` absent → skip silently).
- `--no-skills` for adopters who use Claude Code but want to keep the skills install separate.

## Files

- `install.sh` — new `INSTALL_SKILLS` toggle, `--no-skills` flag, `SLOPSTOPPER_NO_SKILLS` env, `install_claude_skills` function that curl-pipes `install-skill.sh` when `~/.claude/` exists. Called near end of main flow, before post-install guidance. Help text updated.
- `.claude/skills/slopstopper-update/SKILL.md` — Step 1 rewritten from a full curl-install-skill step to a one-line note that Step 2's install.sh re-run handles the refresh, with an honest acknowledgement that the refresh applies to the next session.
- `.claude/skills/slopstopper-install/SKILL.md` — one-paragraph mention of the bundling.
- `README.md` — adopter-facing paragraph rewritten around the bundling. Trimmed to stay under the 1500-word entry-file budget.
- `docs/runbooks/INSTALL_SKILLS.md` — "Why the trio is shipped as a separate one-liner" rewritten to explain that the two scripts now cooperate.

## Test plan

- [x] `task -t cli/Taskfile.yml test` — 525 passed (install.sh changes don't break the CLI's install-related tests)
- [x] `task ss:hygiene:test` — all green (README trimmed to 1497/1500 words after the new paragraph)
- [ ] CI suite green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)