### PR TITLE
docs(install-skill): document install.sh's blast radius explicitly

### DIFF
--- a/.claude/skills/slopstopper-install/SKILL.md
+++ b/.claude/skills/slopstopper-install/SKILL.md
@@ -70,6 +70,34 @@ The installer is idempotent. Re-running it pulls newer checks but respects delet
 
 **`install.sh` also installs the SlopStopper Claude Code skill trio** at `~/.claude/skills/slopstopper-{install,update,triage}/` when `~/.claude` exists on the machine (user-profile level, not repo-level). Skipped silently if Claude Code isn't set up. Pass `--no-skills` or set `SLOPSTOPPER_NO_SKILLS=1` to disable. Adopters who set up Claude Code later can run `install-skill.sh` separately to backfill.
 
+### What `install.sh` writes (and leaves alone)
+
+Three categories of write, in order of "how much trust to extend on re-run":
+
+**Always overwritten — slopstopper-owned, safe to clobber:**
+
+- `Taskfile.ss.yml`, `.ss/server.js`, `.ss/.workflows-installed`
+- Workflows under `.github/workflows/ss-*.yml` that are in `GENERIC_WORKFLOWS` and not listed in `.slopstopper.yml` `workflows.disabled`
+- `slopstopper-cli` itself (via `pipx upgrade`, user-profile level)
+- `~/.claude/skills/slopstopper-*/SKILL.md` (only if `~/.claude/` exists; opt out with `--no-skills`)
+
+**Seeded only if missing — adopter-owned, NEVER overwritten on re-run:**
+
+- `.slopstopper.yml` (config; once it exists `install.sh` never touches it)
+- `.github/labeler.yml`, `.zap/rules.tsv`, `.markdownlint.json`
+- Root `Taskfile.yml` — only if absent; otherwise install.sh prints the `includes:` block to paste in
+- `package.json` — only if absent (otherwise see below)
+
+**Conservatively additive on shared files — adopter content preserved:**
+
+- `package.json` devDeps merge: adds missing keys; existing keys are kept on version conflict (warning printed, not error).
+- `.gitignore`: appends a `# slopstopper begin` / `# slopstopper end` marker-bracketed block exactly once. Re-runs detect the marker and skip; adopter's existing lines are never edited.
+- `public/_headers` (only if `public/` exists): appends a commented-out security-headers baseline inside `# slopstopper security headers begin/end` markers. Same idempotent skip on re-run.
+
+**Everything else is left alone** — source code, build outputs, custom workflows under `.github/workflows/` outside the `ss-*` namespace, generic configs (`.eslintrc`, `tsconfig.json`, etc.), and anything under `app/`, `src/`, `worker/`, etc.
+
+**One risk worth flagging:** inline customisations to `ss-*.yml` workflow body content (bespoke `gh issue create` blocks, extra steps, custom env vars beyond what `.slopstopper.yml` covers) get wiped on the next `install.sh` re-run because workflow files are wholesale-replaced. Push bespoke wording into the check's META in `slopstopper-cli` upstream rather than hand-editing the YAML locally. See `slopstopper-update` Step 4 for how to diff and re-apply on refresh.
+
 By default the installer ships **Task-driven workflows** — every check runs via `task ss:<category>:<check>` so the suite shares one invocation surface with `task build`, `task deploy`, etc. The workflows install Task themselves via `arduino/setup-task@v2`, so adopters don't need it in their CI runners by hand. If the adopter explicitly doesn't want Task in their CI, install with `--no-task`:
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a "What install.sh writes (and leaves alone)" subsection inside Step 2 of `slopstopper-install`. Mirrors the level of detail `slopstopper-update` Step 2 already has, but framed for first-install context: the question "is anything dangerous?" rather than "what will be overwritten on refresh?"

Three buckets:

1. **Always overwritten** (slopstopper-owned, safe): Taskfile.ss.yml, .ss/server.js, ss-*.yml workflows, slopstopper-cli, ~/.claude/skills/slopstopper-*/.
2. **Seeded only if missing** (adopter-owned, never re-overwritten): .slopstopper.yml, labeler.yml, .zap/rules.tsv, .markdownlint.json, root Taskfile.yml, package.json.
3. **Conservatively additive** (adopter content preserved): package.json devDeps merge, .gitignore append, public/_headers append — all marker-bracketed and idempotent.

Plus a callout for the one real risk: inline `ss-*.yml` workflow body customisations get wiped on re-run because workflows are wholesale-replaced. Adopters who want bespoke wording should push it into the check's META in slopstopper-cli upstream rather than hand-editing YAML.

## Why

Surfaced by an adopter asking "if a fresh install is done, will it just override settings etc that are local to the repo already there, or just update slopstopper specifics?" The honest answer is "mostly slopstopper specifics, with three small additive operations and one risk" — and the skill should say that explicitly so adopters don't have to read install.sh to find out.

## Files

- `.claude/skills/slopstopper-install/SKILL.md` — one new subsection inside Step 2, ~28 added lines.

## Test plan

- [x] `task ss:hygiene:test` — all green
- [ ] CI suite green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)