### PR TITLE
fix(reliability): read scheduled-run URL from .slopstopper.yml urls.production

### DIFF
--- a/.github/workflows/ss-reliability-accessibility-check.yml
+++ b/.github/workflows/ss-reliability-accessibility-check.yml
@@ -116,7 +116,13 @@ jobs:
             echo "url=$SAFE_URL" >> "$GITHUB_OUTPUT"
             echo "use_local=false" >> "$GITHUB_OUTPUT"
           elif [ "$EVENT_NAME" == "schedule" ]; then
-            echo "url=https://slopstopper.dev" >> "$GITHUB_OUTPUT"
+            CONFIG_URL="$(slopstopper config get urls.production)"
+            if [ -z "$CONFIG_URL" ]; then
+              echo "::error::Scheduled run requires urls.production in .slopstopper.yml" >&2
+              exit 1
+            fi
+            SAFE_URL="$(validate_url "$CONFIG_URL")"
+            echo "url=$SAFE_URL" >> "$GITHUB_OUTPUT"
             echo "use_local=false" >> "$GITHUB_OUTPUT"
           else
             echo "url=http://localhost:8080" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ss-reliability-broken-links-check.yml
+++ b/.github/workflows/ss-reliability-broken-links-check.yml
@@ -110,7 +110,13 @@ jobs:
             echo "url=$SAFE_URL" >> "$GITHUB_OUTPUT"
             echo "use_local=false" >> "$GITHUB_OUTPUT"
           elif [ "$EVENT_NAME" == "schedule" ]; then
-            echo "url=https://slopstopper.dev" >> "$GITHUB_OUTPUT"
+            CONFIG_URL="$(slopstopper config get urls.production)"
+            if [ -z "$CONFIG_URL" ]; then
+              echo "::error::Scheduled run requires urls.production in .slopstopper.yml" >&2
+              exit 1
+            fi
+            SAFE_URL="$(validate_url "$CONFIG_URL")"
+            echo "url=$SAFE_URL" >> "$GITHUB_OUTPUT"
             echo "use_local=false" >> "$GITHUB_OUTPUT"
           else
             echo "url=http://localhost:8080" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ss-reliability-core-web-vitals.yml
+++ b/.github/workflows/ss-reliability-core-web-vitals.yml
@@ -15,9 +15,9 @@ on:
   workflow_dispatch:
     inputs:
       url:
-        description: 'URL to audit'
-        required: true
-        default: 'https://slopstopper.dev/'
+        description: 'URL to audit (leave blank to use urls.production from .slopstopper.yml)'
+        required: false
+        default: ''
         type: string
   pull_request:
     branches:
@@ -124,7 +124,15 @@ jobs:
             echo "url=http://localhost:8080" >> "$GITHUB_OUTPUT"
             echo "prod=false" >> "$GITHUB_OUTPUT"
           elif [ "$EVENT_NAME" == "workflow_dispatch" ]; then
-            SAFE_URL="$(validate_url "$INPUT_URL")"
+            DISPATCH_URL="$INPUT_URL"
+            if [ -z "$DISPATCH_URL" ]; then
+              DISPATCH_URL="$(slopstopper config get urls.production)"
+              if [ -z "$DISPATCH_URL" ]; then
+                echo "::error::No url input given and urls.production is unset in .slopstopper.yml" >&2
+                exit 1
+              fi
+            fi
+            SAFE_URL="$(validate_url "$DISPATCH_URL")"
             echo "url=$SAFE_URL" >> "$GITHUB_OUTPUT"
             echo "prod=false" >> "$GITHUB_OUTPUT"
           elif [ "$EVENT_NAME" == "deployment_status" ]; then
@@ -132,7 +140,13 @@ jobs:
             echo "url=$SAFE_URL" >> "$GITHUB_OUTPUT"
             echo "prod=true" >> "$GITHUB_OUTPUT"
           else
-            echo "url=https://slopstopper.dev" >> "$GITHUB_OUTPUT"
+            CONFIG_URL="$(slopstopper config get urls.production)"
+            if [ -z "$CONFIG_URL" ]; then
+              echo "::error::Scheduled run requires urls.production in .slopstopper.yml" >&2
+              exit 1
+            fi
+            SAFE_URL="$(validate_url "$CONFIG_URL")"
+            echo "url=$SAFE_URL" >> "$GITHUB_OUTPUT"
             echo "prod=true" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/ss-reliability-seo-check.yml
+++ b/.github/workflows/ss-reliability-seo-check.yml
@@ -100,7 +100,13 @@ jobs:
             echo "url=$SAFE_URL" >> "$GITHUB_OUTPUT"
             echo "use_local=false" >> "$GITHUB_OUTPUT"
           elif [ "$EVENT_NAME" == "schedule" ]; then
-            echo "url=https://slopstopper.dev" >> "$GITHUB_OUTPUT"
+            CONFIG_URL="$(slopstopper config get urls.production)"
+            if [ -z "$CONFIG_URL" ]; then
+              echo "::error::Scheduled run requires urls.production in .slopstopper.yml" >&2
+              exit 1
+            fi
+            SAFE_URL="$(validate_url "$CONFIG_URL")"
+            echo "url=$SAFE_URL" >> "$GITHUB_OUTPUT"
             echo "use_local=false" >> "$GITHUB_OUTPUT"
           else
             echo "url=http://localhost:8080" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ss-reliability-smoke-tests.yml
+++ b/.github/workflows/ss-reliability-smoke-tests.yml
@@ -96,7 +96,13 @@ jobs:
             echo "url=$SAFE_URL" >> "$GITHUB_OUTPUT"
             echo "use_local=false" >> "$GITHUB_OUTPUT"
           elif [ "$EVENT_NAME" == "schedule" ]; then
-            echo "url=https://slopstopper.dev" >> "$GITHUB_OUTPUT"
+            CONFIG_URL="$(slopstopper config get urls.production)"
+            if [ -z "$CONFIG_URL" ]; then
+              echo "::error::Scheduled run requires urls.production in .slopstopper.yml" >&2
+              exit 1
+            fi
+            SAFE_URL="$(validate_url "$CONFIG_URL")"
+            echo "url=$SAFE_URL" >> "$GITHUB_OUTPUT"
             echo "use_local=false" >> "$GITHUB_OUTPUT"
           else
             echo "url=http://localhost:8080" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The smoke, accessibility, SEO, broken-links and Core Web Vitals workflows
hardcoded https://slopstopper.dev as the target for scheduled runs, so an
adopter repo's scheduled audits hit slopstopper.dev instead of their own
site. The Playwright specs and config already resolved URLs correctly via
env vars; only the workflows' "Determine URL" step was wrong.

Replace the hardcoded schedule branch with `slopstopper config get
urls.production` (the reader the example config already documents) and
fail the step with a clear error when urls.production is unset — scheduled
runs start no local server, so there is no safe fallback. For Core Web
Vitals also drop the slopstopper.dev workflow_dispatch input default,
falling back to urls.production when the manual URL is left blank.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SR7QMk1zuwf8puftxQ42Z3