### PR TITLE
fix(install): detect and remediate silently-stale CLI on refresh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -297,6 +297,11 @@ install_cli() {
   local latest_version
   latest_version="$(latest_pypi_version)"
 
+  # Pre-install version (empty if not yet installed). Lets us tell the
+  # adopter what an upgrade actually changed — old → new plus release notes.
+  local pre_version
+  pre_version="$(installed_cli_version)"
+
   if command -v pipx &>/dev/null; then
     if pipx list 2>/dev/null | grep -q "slopstopper-cli"; then
       info "Refreshing slopstopper-cli via pipx…"
@@ -344,6 +349,7 @@ install_cli() {
   # scrolls past.
   SLOPSTOPPER_CLI_VERSION="$post_version"
   SLOPSTOPPER_CLI_LATEST="$latest_version"
+  SLOPSTOPPER_CLI_PREVIOUS="$pre_version"
 
   # Still behind even after a forced reinstall → something is wrong with the
   # network or a PyPI mirror; tell the adopter how to retry by hand.
@@ -848,6 +854,7 @@ echo ""
 # silently-stale CLI can't masquerade as a clean install.
 ss_installed="${SLOPSTOPPER_CLI_VERSION:-}"
 ss_latest="${SLOPSTOPPER_CLI_LATEST:-}"
+ss_previous="${SLOPSTOPPER_CLI_PREVIOUS:-}"
 if [ -n "$ss_installed" ]; then
   if [ -n "$ss_latest" ] && version_lt "$ss_installed" "$ss_latest"; then
     warn "slopstopper-cli $ss_installed installed — but PyPI latest is $ss_latest. You are BEHIND."
@@ -856,6 +863,12 @@ if [ -n "$ss_installed" ]; then
     echo "  📦 slopstopper-cli $ss_installed (latest on PyPI)"
   else
     echo "  📦 slopstopper-cli $ss_installed"
+  fi
+  # On an actual upgrade, surface old → new and where to read what changed,
+  # so an adopter (or agent) isn't left guessing the new feature set.
+  if [ -n "$ss_previous" ] && [ "$ss_previous" != "$ss_installed" ]; then
+    echo "  ⬆  Upgraded $ss_previous → $ss_installed"
+    echo "     What's new: ${REPO_URL%.git}/releases/tag/v${ss_installed}"
   fi
   echo ""
 fi

--- a/install.sh
+++ b/install.sh
@@ -123,6 +123,26 @@ error()   { echo "  ❌ $*" >&2; exit 1; }
 
 sep() { echo "────────────────────────────────────────────────────────────"; }
 
+# Latest slopstopper-cli version published on PyPI. Empty string on any
+# failure (offline, no curl, malformed JSON) — callers treat empty as
+# "unknown" and fall back to best-effort behaviour rather than blocking.
+latest_pypi_version() {
+  curl -fsSL "https://pypi.org/pypi/slopstopper-cli/json" 2>/dev/null \
+    | python3 -c 'import sys,json; print(json.load(sys.stdin)["info"]["version"])' 2>/dev/null \
+    || true
+}
+
+# Installed CLI version as a bare semver (e.g. "0.8.0"), or empty if the
+# binary is absent. `slopstopper --version` prints "slopstopper <ver>".
+installed_cli_version() {
+  slopstopper --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true
+}
+
+# version_lt A B → exit 0 if A is strictly older than B (semver ordering).
+version_lt() {
+  [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" = "$1" ]
+}
+
 # ── prerequisite check ────────────────────────────────────────────────────────
 #
 # Surface missing tools up front rather than letting the install fail mid-flight
@@ -269,14 +289,13 @@ install_cli() {
     return 0
   fi
 
-  # Capture the pre-install version (empty if not installed). After
-  # installing/upgrading, compare against the post-install version and
-  # warn if pipx silently kept a stale build. Catches the "0.1.0 reported
-  # as just-installed" failure mode that swallowing stderr used to mask.
-  local pre_version=""
-  if command -v slopstopper &>/dev/null; then
-    pre_version="$(slopstopper --version 2>&1 || true)"
-  fi
+  # The real latest published on PyPI. Knowing this lets us detect the
+  # "pipx upgrade exited 0 but upgraded nothing" failure mode that a
+  # pre-vs-post string compare cannot — that compare can't tell "already
+  # current" from "silently stale". Empty if PyPI is unreachable, in which
+  # case we degrade to the old best-effort path.
+  local latest_version
+  latest_version="$(latest_pypi_version)"
 
   if command -v pipx &>/dev/null; then
     if pipx list 2>/dev/null | grep -q "slopstopper-cli"; then
@@ -302,17 +321,34 @@ install_cli() {
   fi
 
   local post_version
-  post_version="$(slopstopper --version 2>&1 || true)"
+  post_version="$(installed_cli_version)"
+
+  # If PyPI has a newer release than what we actually ended up with, the
+  # upgrade silently no-op'd (pipx exits 0 without doing anything). Don't
+  # trust its exit code — force a clean reinstall. Cheap, deterministic,
+  # and the only reliable way to land the published version.
+  if [ -n "$latest_version" ] && [ -n "$post_version" ] && version_lt "$post_version" "$latest_version"; then
+    warn "slopstopper-cli is $post_version but PyPI has $latest_version — forcing a clean reinstall."
+    if command -v pipx &>/dev/null; then
+      pipx install --force slopstopper-cli >/dev/null
+    else
+      python3 -m pip install --user --force-reinstall slopstopper-cli >/dev/null
+    fi
+    post_version="$(installed_cli_version)"
+  fi
+
   success "slopstopper-cli installed ($post_version)"
 
-  # If an upgrade was supposed to happen (pre_version was non-empty) and
-  # the version string didn't change, surface that loudly. pipx sometimes
-  # claims success when the version on PyPI is the same as the local
-  # build; that's fine. But a genuinely stale local install + a silently-
-  # failed upgrade looks identical from the success line — so we warn
-  # rather than error, and tell the adopter how to force a refresh.
-  if [ -n "$pre_version" ] && [ "$pre_version" = "$post_version" ]; then
-    warn "Version unchanged after upgrade attempt ($post_version). If you expected a newer release, run 'pipx install --force slopstopper-cli' to refresh."
+  # Stash the version facts for the completion banner so installed-vs-latest
+  # is surfaced loudly at the end, not buried in a mid-stream warn that
+  # scrolls past.
+  SLOPSTOPPER_CLI_VERSION="$post_version"
+  SLOPSTOPPER_CLI_LATEST="$latest_version"
+
+  # Still behind even after a forced reinstall → something is wrong with the
+  # network or a PyPI mirror; tell the adopter how to retry by hand.
+  if [ -n "$latest_version" ] && [ -n "$post_version" ] && version_lt "$post_version" "$latest_version"; then
+    warn "Still on $post_version after a forced reinstall (PyPI latest: $latest_version). Check your network/PyPI mirror, then run 'pipx install --force slopstopper-cli'."
   fi
 }
 
@@ -808,6 +844,21 @@ sep
 echo ""
 echo "  🎉 Installation complete!"
 echo ""
+# Surface installed-vs-latest right under the banner. "Behind" is loud so a
+# silently-stale CLI can't masquerade as a clean install.
+ss_installed="${SLOPSTOPPER_CLI_VERSION:-}"
+ss_latest="${SLOPSTOPPER_CLI_LATEST:-}"
+if [ -n "$ss_installed" ]; then
+  if [ -n "$ss_latest" ] && version_lt "$ss_installed" "$ss_latest"; then
+    warn "slopstopper-cli $ss_installed installed — but PyPI latest is $ss_latest. You are BEHIND."
+    warn "Run 'pipx install --force slopstopper-cli' to land $ss_latest."
+  elif [ -n "$ss_latest" ]; then
+    echo "  📦 slopstopper-cli $ss_installed (latest on PyPI)"
+  else
+    echo "  📦 slopstopper-cli $ss_installed"
+  fi
+  echo ""
+fi
 echo "  ── SlopStopper status for this repo ──────────────────────────────"
 echo ""
 echo "  ✅ Active now (no config needed — work on any code):"


### PR DESCRIPTION
Addresses the two **High** findings and the **Medium** finding from #277.

## Problem

`pipx upgrade slopstopper-cli` can exit `0` without actually upgrading. `install_cli()` only fell through to `pipx install --force` when that returned non-zero, so the force-fallback never fired — an adopter could finish with the big "Installation complete!" banner while two minor versions behind (observed: stuck on `0.6.0` while PyPI had `0.8.0`). On top of that, nothing told them what changed on an upgrade.

The old guard only compared the pre- vs post-install version *strings*. That can warn, but it can never **act**, because it never learns PyPI's real latest — it can't tell "already current" from "silently stale".

## Fix

1. **PyPI-aware remediation** (High, finding 1): new `latest_pypi_version()` fetches `info.version` from `https://pypi.org/pypi/slopstopper-cli/json`. After the upgrade/install, if the installed version is strictly older than PyPI latest (`version_lt`, semver-ordered via `sort -V`), force a clean reinstall instead of trusting `pipx upgrade`'s exit code.
2. **Loud banner** (High, finding 2): the completion banner now prints installed-vs-latest. When behind, it's a `⚠️ … You are BEHIND` notice with the exact `pipx install --force` remediation — not a mid-stream warn that scrolls past.
3. **What's-new on upgrade** (Medium, finding 3): capture the pre-install version and, when an upgrade actually happened, print `⬆ Upgraded X → Y` plus a link to that release's notes (`…/releases/tag/vY`) so an adopter or agent isn't left guessing the new feature set.

New helpers: `latest_pypi_version`, `installed_cli_version`, `version_lt`.

## Behaviour change worth noting

The old pre-vs-post string-compare warn (`"Version unchanged after upgrade attempt…"`) is **removed**, replaced by the PyPI comparison. When PyPI is unreachable, `latest_version` is empty, the remediation and banner-behind notice are both skipped, and there is no staleness warning at all (vs. the old warn, which fired offline but couldn't distinguish current from stale and never remediated). Net: online installs are now self-healing; offline installs lose a low-signal warning.

## Testing

- `cli/tests/test_install.py` — all 5 pass (they set `SKIP_CLI_INSTALL=1`; banner vars stay unset and are `${VAR:-}`-guarded under `set -u`).
- `bash -n install.sh` clean.
- `version_lt` verified across `<`, `=`, `>`, and multi-digit semver (`0.8.0 < 0.10.0`).
- Live `latest_pypi_version()` returns `0.8.0`; banner branches (behind / current / unknown-latest / no-install / upgrade-delta / fresh-install / same-version re-run) render correctly under bash.

## Not included

The two **Low** findings in #277 (refresh-skill drift false-positive on `ss-release.yml`, leading with the two-step install form in agent-facing docs) are handled in a separate skill/docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)