### PR TITLE
fix(app): bump checkout@v4 → @v6 in workflow excerpts

### DIFF
--- a/app/features.html
+++ b/app/features.html
@@ -83,7 +83,7 @@ jobs:
     name: Static Application Security Testing with Semgrep
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: jdx/mise-action@v2
       - run: pip install semgrep
       - run: task ss:security:sast
@@ -104,7 +104,7 @@ jobs:
   dast:
     name: Dynamic Application Security Testing with OWASP ZAP
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: jdx/mise-action@v2
       - run: npm ci &amp;&amp; npm run build &amp;&amp; slopstopper serve &amp;
       - run: task ss:security:dast -- http://localhost:8080
@@ -125,7 +125,7 @@ jobs:
   secrets:
     name: Detect Secrets with Gitleaks
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
       - uses: jdx/mise-action@v2
       - run: curl -sL gitleaks/install.sh | bash
@@ -147,7 +147,7 @@ jobs:
   dependencies:
     name: Scan Dependencies with Trivy
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: jdx/mise-action@v2
       - run: brew install aquasecurity/trivy/trivy
       - run: task ss:security:vulnerability:all
@@ -185,7 +185,7 @@ jobs:
   complexity-check:
     name: Check Code Complexity with Lizard
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: jdx/mise-action@v2
       - run: pip install lizard
       - run: task ss:hygiene:complexity
@@ -226,7 +226,7 @@ on:
 jobs:
   check-csp-exceptions:
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: jdx/mise-action@v2
       - run: task ss:hygiene:csp-exceptions
       - if: github.event_name == 'pull_request'
@@ -281,7 +281,7 @@ on:
 jobs:
   smoke-test:
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: jdx/mise-action@v2
       - run: npm ci
       - run: npm run build &amp;&amp; slopstopper serve &amp;
@@ -306,7 +306,7 @@ jobs:
   broken-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: jdx/mise-action@v2
       - run: npm ci
       - run: npm run build &amp;&amp; slopstopper serve &amp;
@@ -330,7 +330,7 @@ jobs:
   a11y:
     name: Accessibility Audit (axe-core / WCAG 2.1 AA)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: jdx/mise-action@v2
       - run: npm ci
       - run: npm run build &amp;&amp; slopstopper serve &amp;
@@ -354,7 +354,7 @@ jobs:
   cwv:
     name: Core Web Vitals (Lighthouse CI)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: jdx/mise-action@v2
       - run: npm ci &amp;&amp; npm run build
       - run: slopstopper serve &amp;
@@ -378,7 +378,7 @@ jobs:
   seo:
     name: SEO Metatag Audit (OpenGraph + Twitter Card + canonical)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: jdx/mise-action@v2
       - run: npm ci
       - run: npm run build &amp;&amp; slopstopper serve &amp;

--- a/app/tools.html
+++ b/app/tools.html
@@ -198,7 +198,7 @@ slopstopper serve                              # bundled static server</code></p
   sast:
     name: Static Application Security Testing with Semgrep
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: pip install semgrep &amp;&amp; semgrep ci</code></pre></div>
                         <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/ss-security-sast-check.yml" rel="noopener noreferrer">View source →</a>
                     </div>
@@ -234,7 +234,7 @@ slopstopper serve                              # bundled static server</code></p
   dependencies:
     name: Scan Dependencies with Trivy
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: trivy fs --severity HIGH,CRITICAL .</code></pre></div>
                         <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/ss-security-vulnerability-all-check.yml" rel="noopener noreferrer">View source →</a>
                     </div>
@@ -252,7 +252,7 @@ slopstopper serve                              # bundled static server</code></p
   secrets:
     name: Detect Secrets with Gitleaks
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
       - uses: gitleaks/gitleaks-action@v2</code></pre></div>
                         <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/ss-security-secrets-check.yml" rel="noopener noreferrer">View source →</a>
@@ -361,7 +361,7 @@ on:
                         <div class="codeblock codeblock--yaml"><pre><code>jobs:
   check-docs-structure:
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: npx markdownlint-cli 'docs/**/*.md'</code></pre></div>
                         <a class="details__source" href="https://github.com/hungovercoders/slopstopper/blob/main/.github/workflows/ss-hygiene-docs-structure-check.yml" rel="noopener noreferrer">View source →</a>
                     </div>


### PR DESCRIPTION
The features/tools workflow excerpts pinned `actions/checkout@v4` while the shipped `ss-*.yml` workflows use `@v6` — stale version drift on the marketing page for a suite that exists to catch exactly this.

15 occurrences (11 in `app/features.html`, 4 in `app/tools.html`). The `task ss:*` commands themselves were already accurate; this is purely the surrounding action version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)